### PR TITLE
Include 7zFM.exe & 7zG.exe to 'bin' shims

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -20,9 +20,6 @@
 			}
 		}
 	},
-	"bin": [
-		"7z.exe",
-		"7zFM.exe",
-		"7zG.exe"
-	]
+	"env_add_path": "\\",
+	"bin": "7z.exe"
 }


### PR DESCRIPTION
I wanted to add 7zFM.exe to my path, instead I added both 7zFM.exe & 7zG.exe to the 'bin' section so that when 7zip is installed shims are directly created for these.
