### PR TITLE
Added support for SBT.

### DIFF
--- a/bucket/sbt.json
+++ b/bucket/sbt.json
@@ -1,0 +1,11 @@
+{
+	"homepage": "http://www.scala-sbt.org/",
+	"version": "0.13.0",
+	"license": "BSD",
+	"url": "http://repo.scala-sbt.org/scalasbt/sbt-native-packages/org/scala-sbt/sbt/0.13.0/sbt.zip",
+	"hash": "7e9b413736b9ad841f1588dd3116c848110a2fc37ba663461523a4383bb236ae",
+	"extract_dir": "sbt",
+	"bin": [
+		"bin\\sbt.bat"
+	]
+}


### PR DESCRIPTION
Hi! I have added support for SBT, Scala Build Tool (http://www.scala-sbt.org/). I am not sure whether this would fit better in the main bucket, or in the extras: this pull request is to add it to the main bucket, but let me know if you'd rather add it to the extras bucket (or not at all).
