### PR TITLE
Python post-install of distribute fails with a RemoteException ...

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -25,7 +25,7 @@
 	"bin": [ "python.exe", "py.exe" ],
 	"env_add_path": [ "scripts" ],
 	"post_install": "pushd $env:temp
-	$s = 'http://python-distribute.org/distribute_setup.py'
+	$s = 'https://python-distribute.org/distribute_setup.py'
 	echo \"running $s...\";(new-object net.webclient).downloadstring($s) | python 2>&1 > $null
 	popd",
 	"notes": "To use PIP to manage Python packages, run 'easy_install pip'"

--- a/bucket/python27.json
+++ b/bucket/python27.json
@@ -25,7 +25,7 @@
 	"bin": [ "python.exe" ],
 	"env_add_path": [ "scripts" ],
 	"post_install": "pushd $env:temp
-	$s = 'http://python-distribute.org/distribute_setup.py'
+	$s = 'https://python-distribute.org/distribute_setup.py'
 	echo \"running $s...\";(new-object net.webclient).downloadstring($s) | python 2>&1 > $null
 	popd",
 	"notes": "To use PIP to manage Python packages, run 'easy_install pip'"


### PR DESCRIPTION
...becase the non-ssl pypi.python.org link redirects to the ssl address and DownloadString does not follow the redirect.
