### PR TITLE
added setuptools in favor of distribute

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -25,7 +25,7 @@
 	"bin": [ "python.exe", "py.exe" ],
 	"env_add_path": [ "scripts" ],
 	"post_install": "pushd $env:temp
-	$s = 'http://python-distribute.org/distribute_setup.py'
+	$s = 'https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
 	echo \"running $s...\";(new-object net.webclient).downloadstring($s) | python 2>&1 > $null
 	popd",
 	"notes": "To use PIP to manage Python packages, run 'easy_install pip'"

--- a/bucket/python27.json
+++ b/bucket/python27.json
@@ -25,7 +25,7 @@
 	"bin": [ "python.exe" ],
 	"env_add_path": [ "scripts" ],
 	"post_install": "pushd $env:temp
-	$s = 'http://python-distribute.org/distribute_setup.py'
+	$s = 'https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py'
 	echo \"running $s...\";(new-object net.webclient).downloadstring($s) | python 2>&1 > $null
 	popd",
 	"notes": "To use PIP to manage Python packages, run 'easy_install pip'"


### PR DESCRIPTION
> ~ $ scoop install python
> installing python (3.3.2)
> loading http://www.python.org/ftp/python/3.3.2/python-3.3.2.amd64.msi from cache...
> checking hash...ok
> running installer...done
> creating shim for python.exe
> creating shim for py.exe
> running post-install script...
> running https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py...
> python (3.3.2) was installed successfully!
> Notes
> .....
> To use PIP to manage Python packages, run 'easy_install pip'
> ~ $ easy_install pip
> Searching for pip
> Reading https://pypi.python.org/simple/pip/
> Best match: pip 1.4.1
> Downloading https://pypi.python.org/packages/source/p/pip/pip-1.4.1.tar.gz#md5=6afbb46aeb48abac658d4df742bff714
> Processing pip-1.4.1.tar.gz
> ...
