### PR TITLE
Add creation of '$dir\$extract_to' directory in install.ps1

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -151,6 +151,9 @@ function dl_urls($app, $version, $manifest, $architecture, $dir) {
 			write-host "extracting..." -nonewline
 			$null = mkdir "$dir\_scoop_extract"
 			& $extract_fn "$dir\$fname" "$dir\_scoop_extract"
+			if ($extract_to) {
+				$null = mkdir "$dir\$extract_to" -force
+			}
 			cp "$dir\_scoop_extract\$extract_dir\*" "$dir\$extract_to" -r -force
 			rm -r -force "$dir\_scoop_extract"
 			rm "$dir\$fname"


### PR DESCRIPTION
When the source is a file, Copy-Item expects the destination
to be a file or directory that already exists. So create dir
if needed.

Fixes failure of devkit installation for ruby and ruby19.
