### PR TITLE
Add support for PHP 5.3

### DIFF
--- a/bucket/php53.json
+++ b/bucket/php53.json
@@ -1,6 +1,6 @@
 {
 	"homepage": "http://windows.php.net",
-	"version": "5.4.23",
+	"version": "5.3.28",
 	"license": "http://www.php.net/license/",
 	"url": "http://windows.php.net/downloads/releases/php-5.3.28-Win32-VC9-x86.zip",
 	"hash": "sha1:fa7e8f6e8bff442e0e0b1889f52e0c3b93a84b2b",


### PR DESCRIPTION
Add ability to install PHP 5.3. Most hosts don't support PHP 5.5 yet, so having the ability to install previous versions of PHP is helpful.

This way, when someone installs "php" they'll get the latest version, but have the ability to install an earlier version if they need it.
