### PR TITLE
New MariaDB version, download links, and hashes.

### DIFF
--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -1,17 +1,17 @@
 {
 	"homepage": "http://mariadb.org",
-	"version": "5.5.33a",
+	"version": "5.5.36",
 	"license": "GPL2",
 	"architecture": {
 		"64bit": {
-			"url": "http://ftp.osuosl.org/pub/mariadb/mariadb-5.5.33a/winx64-packages/mariadb-5.5.33a-winx64.zip",
-			"hash": "md5:ac97429e9288419c1b357c5c84e95fc2",
-			"extract_dir": "mariadb-5.5.33a-winx64"
+			"url": "http://mirror.mephi.ru/mariadb/mariadb-5.5.36/winx64-packages/mariadb-5.5.36-winx64.zip",
+			"hash": "md5:2d920564a6f44d7b767e066c71ec7fa7",
+			"extract_dir": "mariadb-5.5.36-winx64"
 		},
 		"32bit": {
-			"url": "http://ftp.osuosl.org/pub/mariadb/mariadb-5.5.33a/win32-packages/mariadb-5.5.33a-win32.zip",
-			"hash": "md5:7eb1f673dae6489be98334f4b29bee56",
-			"extract_dir": "mariadb-5.5.33a-win32"
+			"url": "http://mirror.mephi.ru/mariadb/mariadb-5.5.36/winx64-packages/mariadb-5.5.36-win32.zip",
+			"hash": "md5:82f4502f1e262799e59c968a67eee2b2",
+			"extract_dir": "mariadb-5.5.36-win32"
 		}
 	},
 	"bin": [


### PR DESCRIPTION
The previous download location is unmaintained and explicitly redirects a user to the official MariaDB download page.

The version was also outdated.
