### PR TITLE
Apache: New version, 64 bit package, hash updated.

### DIFF
--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -1,10 +1,19 @@
 {
 	"homepage": "http://www.apachelounge.com",
-	"version": "2.4.6",
+	"version": "2.4.7",
 	"license": "Apache 2.0",
-	"url": "http://www.apachelounge.com/download/VC11/binaries/httpd-2.4.6-win32-VC11.zip",
-	"hash": "E112445A222916FF6C60F4258373CF9B427B0E9EBCEB01E67DDB7C3CECEF892B",
-	"extract_dir": "Apache24",
+	"architecture": {
+		"64bit": {
+			"url": "http://www.apachelounge.com/download/VC11/binaries/httpd-2.4.7-win64-VC11.zip",
+			"hash": "sha1:88A586D2794BF46952259E2C76D781246D70C057",
+			"extract_dir": "Apache24-winx64"
+		},
+		"32bit": {
+			"url": "http://www.apachelounge.com/download/VC11/binaries/httpd-2.4.7-win32-VC11.zip",
+			"hash": "sha1:B155FC75A540385E18F59E391DB035318D9B21F4",
+			"extract_dir": "Apache24-win32"
+		}
+	},
 	"bin": [
 		"bin\\ab.exe",
 		"bin\\abs.exe",


### PR DESCRIPTION
Hi,

Apache installation would fail due to hash check fail:

```
~ $ scoop install apache
installing apache (2.4.6)
downloading http://www.apachelounge.com/download/VC11/binaries/httpd-2.4.6-win32-VC11.zip...done
checking hash...hash check failed for http://www.apachelounge.com/download/VC11/binaries/httpd-2.4.6-win32-VC11.zip. 
expected: E112445A222916FF6C60F4258373CF9B427B0E9EBCEB01E67DDB7C3CECEF892B, actual: 864d04fdb5a03f0dda2af0cd26a67fa6f2d8cd5edde3eb40e3e95bb2c05b4899!
```

Apparently, Apache uses SHA1, not MD5.

Instead of just updating the hash, I've also updated the version, and added 64 bit download.

Thanks!
