### PR TITLE
Bucket: PHP: 64bit download added.

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -2,8 +2,16 @@
 	"homepage": "http://windows.php.net",
 	"version": "5.5.10",
 	"license": "http://www.php.net/license/",
-	"url": "http://windows.php.net/downloads/releases/php-5.5.10-Win32-VC11-x86.zip",
-	"hash": "sha1:b891871d4aba8e0a88e8847fce05655783b5cd92",
+	"architecture": {
+		"32bit": {
+			"url": "http://windows.php.net/downloads/releases/php-5.5.10-Win32-VC11-x86.zip",
+			"hash": "sha1:b891871d4aba8e0a88e8847fce05655783b5cd92"
+		},
+		"64bit": {
+			"url": "http://windows.php.net/downloads/releases/php-5.5.10-Win32-VC11-x64.zip",
+			"hash": "sha1:3ebcfec5a3502ba98bcc6f4f224a032764a6b570"
+		}
+	},
 	"bin": "php.exe",
 	"post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\""
 }


### PR DESCRIPTION
Since 64 bit Apache download was added, a 64 bit version of PHP is now required (64-Apache won't work with 32-PHP, the php5apache2_4.dll file will fail).

So, I've added a 64bit download for the latest PHP version.

Older versions (5.4 and 5.3) do not seem to have those "experimental" 64 bit builds, so I'm just submitting the 5.5 manifest now.

Tested with `scoop install php.json` and `httpd`, works just fine.

Thanks!
