### PR TITLE
Bump PHP version to 5.5.14

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,9 +1,9 @@
 {
 	"homepage": "http://windows.php.net",
-	"version": "5.5.13",
+	"version": "5.5.14",
 	"license": "http://www.php.net/license/",
-	"url": "http://windows.php.net/downloads/releases/php-5.5.13-Win32-VC11-x86.zip",
-	"hash": "sha1:67d90888d7ae37029452d9b2e1135d9e3a087bd3",
+	"url": "http://windows.php.net/downloads/releases/php-5.5.14-Win32-VC11-x86.zip",
+	"hash": "sha1:f974747a64fdaa0b50a4a8c4458580e52b55435f",
 	"bin": "php.exe",
 	"post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\""
 }


### PR DESCRIPTION
Version 5.5.13 is no longer available, this is the current one.
