### PR TITLE
Add PHP 5.6

### DIFF
--- a/bucket/php56.json
+++ b/bucket/php56.json
@@ -1,0 +1,9 @@
+{
+	"homepage": "http://windows.php.net",
+	"version": "5.6.0",
+	"license": "http://www.php.net/license/",
+	"url": "http://windows.php.net/downloads/releases/php-5.6.0-Win32-VC11-x86.zip",
+	"hash": "sha1:ff7ad8ae2211b0e2e9a6d45f6132e8899fb48790",
+	"bin": "php.exe",
+	"post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\""
+}


### PR DESCRIPTION
PHP 5.6 was just released this week. I did not overwrite php.json with 5.6's configuration because others might not want to move to 5.6. I know that goes against your convention, so feel free to overwrite php.json with this configuration. If you do so, please make a php55.json so we can still install PHP 5.5.

Thanks for a cool tool!
