### PR TITLE
Update Node.js to the latest version

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,29 +1,20 @@
 {
 	"homepage": "http://nodejs.org",
-	"version": "0.10.29",
+	"version": "0.10.31",
 	"license": "MIT",
 	"architecture": {
 		"64bit": {
-			"url": [
-				"http://nodejs.org/dist/v0.10.29/x64/node.exe",
-				"http://nodejs.org/dist/npm/npm-1.4.10.zip"
-			],
-			"hash": [
-				"8ca647c61cadd0bc91e1a43ceb021d89afc580a95e708b52fc283bcb2634a15d",
-				"17cbe14f6d3d9e4149f32b8df7ebf67f300783e6e51fbc1b0987c0582466e1b6"
-			]
+			"url": "http://nodejs.org/dist/v0.10.31/x64/node-v0.10.31-x64.msi",
+			"hash": "85178339767794c06ce7f035a25f10542375049b8c1b8a8521b8c131b571adc6"
 		},
 		"32bit": {
-			"url": [
-				"http://nodejs.org/dist/v0.10.29/node.exe",
-				"http://nodejs.org/dist/npm/npm-1.4.10.zip"
-			],
-			"hash": [
-				"fbd516aa3752da8bfb14d557d4ae16315f500376c3688ed0cfb087c95c95ea20",
-				"17cbe14f6d3d9e4149f32b8df7ebf67f300783e6e51fbc1b0987c0582466e1b6"
-			]
+			"url": "http://nodejs.org/dist/v0.10.31/node-v0.10.31-x86.msi",
+			"hash": "6d07347395f30e70af7ad2a7cb333e497655dd6489fc8a7b4e0d903c4abf6b0b"
 		}
 	},
-	"env_add_path": ".",
+	"env_add_path": "nodejs",
+	"post_install": "
+# Remove npmrc that makes global modules get installed in AppData\\Roaming\\npm
+rm $dir\\nodejs\\node_modules\\npm\\npmrc",
 	"checkver": "<p class=\"version\">Current Version: v([0-9\\.]+)</p>"
 }


### PR DESCRIPTION
`npm 1.4.23` that [goes with](https://raw.githubusercontent.com/joyent/node/v0.10.31/ChangeLog) `node 0.10.31` is not available to download separately, but does come bundled with the MSI version.

While testing that, I found that global modules are not available for use because they're installed in  `%appdata%\Roaming\npm` by default, due to the bundled `npmrc` file. The `postinstall` script removes that file, so global modules get installed inside scoop's nodejs directory, thus making them usable.

I tested on my Windows 8.1 x64 machine. I don't have a 32-bit machine to test on, but I imagine (hope?) it's the same.
