### PR TITLE
mariadb 10.0.14

### DIFF
--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -1,17 +1,17 @@
 {
 	"homepage": "http://mariadb.org",
-	"version": "5.5.36",
+	"version": "10.0.14",
 	"license": "GPL2",
 	"architecture": {
 		"64bit": {
-			"url": "https://downloads.mariadb.org/f/mariadb-5.5.36/winx64-packages/mariadb-5.5.36-winx64.zip?serve#/dl.zip",
-			"hash": "md5:2d920564a6f44d7b767e066c71ec7fa7",
-			"extract_dir": "mariadb-5.5.36-winx64"
+			"url": "https://downloads.mariadb.org/f/mariadb-10.0.14/winx64-packages/mariadb-10.0.14-winx64.zip",
+			"hash": "md5:6880f94badb9a0198549d61d243af1e3",
+			"extract_dir": "mariadb-10.0.14-winx64"
 		},
 		"32bit": {
-			"url": "https://downloads.mariadb.org/f/mariadb-5.5.36/win32-packages/mariadb-5.5.36-win32.zip?serve#/dl.zip",
-			"hash": "md5:82f4502f1e262799e59c968a67eee2b2",
-			"extract_dir": "mariadb-5.5.36-win32"
+			"url": "https://downloads.mariadb.org/f/mariadb-10.0.14/win32-packages/mariadb-10.0.14-win32.zip",
+			"hash": "md5:daff6549e7a924d550f369ce665e72bc",
+			"extract_dir": "mariadb-10.0.14-win32"
 		}
 	},
 	"bin": [


### PR DESCRIPTION
Url for 5.5.36 wasn't working so I updated it to the latest version instead of just fixing the url.
