### PR TITLE
Add haxe and neko VM (dependency)

### DIFF
--- a/bucket/haxe.json
+++ b/bucket/haxe.json
@@ -1,0 +1,10 @@
+{
+    "homepage": "http://haxe.org/",
+    "version": "3.1.3",
+    "license": "GPL2",
+    "url": "http://haxe.org/website-content/downloads/3,1,3/downloads/haxe-3.1.3-win.zip",
+    "hash": "4cf84cdbf7960a61ae70b0d9166c6f9bde16388c3b81e54af91446f4c9e44ae4",
+    "extract_dir": "haxe-3.1.3",
+    "env_add_path": "./",
+    "depends": "neko"
+}

--- a/bucket/neko.json
+++ b/bucket/neko.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "http://nekovm.org/",
+    "version": "2.0.0",
+    "license": "LGPL2",
+    "url": "http://nekovm.org/_media/neko-2.0.0-win.zip",
+    "hash": "66d3a332b670e5890a451c85eb104db4049aa1ea80fc838be493dd13f4869212",
+    "extract_dir": "neko-2.0.0-win",
+    "env_add_path": "./"
+}


### PR DESCRIPTION
Can the haxe language be included in scoop, it is a powerful language used to target used to target _other languages_ as compile targets.  Neko is a VM that haxe requires as a dependency, but is left as a separate dependency so that it may be installed without haxe.
