### PR TITLE
Add Apache Ant (build tool)

### DIFF
--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -8,5 +8,10 @@
     "env_add_path": "bin",
     "env_set": {
         "ANT_HOME": "$dir"
-    }
+    },
+    "notes": "Apache Ant requires,
+
+>   JDK (either openJDK or Oracle JDK)
+>   JAVA_HOME environment variable pointing to JDK
+"
 }


### PR DESCRIPTION
The app ant requires a JDK, however scoop only has the option of openJDK not the alternative Oracle JDK due to its policy.  The closed source commercial alternative is prefered by many developers due to its commercial testing, widespread installation and closed source librarys and tools included.  Developers should not be forced to install openJDK for use of ant within scoop.
