### PR TITLE
Add support for cookies

### DIFF
--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -62,6 +62,7 @@ function arch_specific($prop, $manifest, $architecture) {
 }
 
 function url($manifest, $arch) { arch_specific 'url' $manifest $arch }
+function cookie($manifest, $arch) { arch_specific 'cookie' $manifest $arch }
 function installer($manifest, $arch) { arch_specific 'installer' $manifest $arch }
 function uninstaller($manifest, $arch) { arch_specific 'uninstaller' $manifest $arch }
 function msi($manifest, $arch) { arch_specific 'msi' $manifest $arch }


### PR DESCRIPTION
The support is there and has been tested fairly well, in most situations.  Unfortunately the implementation is a bit of a hack at the moment, but at least it is working.  A new `$cookie` has to be passed through the `dl` functions, because of the lack of a `$manifest` and `$arch` object being passed through therefore the `$cookie` object has to be initialised earlier.

The syntax can be used like so, here are a few examples.  Changes may need to be made.

As seen below it is fairly robust and should be able to handle almost all situations.
- Multiple cookies for one url
- Multiple urls with different cookies
- Multiple urls (differnce in `architecture` url, 32bit or 64bit)
- And hopefully all combinations of above

``` json
{
    "url": "https://download.com/file.zp",
    "cookie": {
        "license": "accept"
    }
}
```

``` json
{
    "url": "https://download.com/file.zip",
    "cookie": {
        "license": "accept",
        "allow-download": "sure"
    }
}
```

``` json
{
    "url": [
        "https://download.com/file.zip",
        "https://download.com/file2.zip"
    ],
    "cookie": [
        { "license": "accept" },
        { "allow-download": "sure" }
    ]
}
```

``` json
{
    "architecture": {
        "64bit": {
            "url": "https://download.com/file.zip",
            "cookie": {
                "license": "accept",
            }
        }
    }
}
```
