### PR TITLE
Update haxe to use bin and env_set

### DIFF
--- a/bucket/haxe.json
+++ b/bucket/haxe.json
@@ -5,6 +5,12 @@
     "url": "http://haxe.org/website-content/downloads/3,1,3/downloads/haxe-3.1.3-win.zip",
     "hash": "4cf84cdbf7960a61ae70b0d9166c6f9bde16388c3b81e54af91446f4c9e44ae4",
     "extract_dir": "haxe-3.1.3",
-    "env_add_path": "./",
+    "bin": [
+        "haxe.exe",
+        "haxelib.exe"
+    ],
+    "env_set": {
+        "HAXEPATH": "$dir"
+    },
     "depends": "neko"
 }


### PR DESCRIPTION
Haxe used to just env_add_path, but is perfectly cabable of using a shim instead. Also the executable haxe installation usually configures an environment variable named `HAXEPATH` which is now configured in scoop as well.
