### PR TITLE
Change apps (ant, maven) to depend on openjdk

### DIFF
--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -9,9 +9,5 @@
     "env_set": {
         "ANT_HOME": "$dir"
     },
-    "notes": "Apache Ant requires,
-
->   JDK (either openJDK or Oracle JDK)
->   JAVA_HOME environment variable pointing to JDK
-"
+    "depends": "openjdk"
 }

--- a/bucket/mvn.json
+++ b/bucket/mvn.json
@@ -10,5 +10,6 @@
 	],
 	"env_set": {
 		"M2_HOME": "$dir"
-	}
+	},
+	"depends": "openjdk"
 }


### PR DESCRIPTION
Both these apps require some JDK to run, so they have now been changed to depend on `openjdk` Perhaps in the near future `oraclejdk` will appear in the `scoop-extras` bucket which could alternatively be used.

As a side note, should `mvn` be renamed to `maven`? [Maven](http://maven.apache.org/) is what the app is called, but perhaps some people prefer the shorthand `mvn'? Personally I would prefer`maven`and it also makes it easier to find for people using`scoop search`.
