### PR TITLE
NodeJS - Add post install `npm update -g`

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -15,6 +15,7 @@
 	"env_add_path": "nodejs",
 	"post_install": "
 # Remove npmrc that makes global modules get installed in AppData\\Roaming\\npm
-rm $dir\\nodejs\\node_modules\\npm\\npmrc",
+rm $dir\\nodejs\\node_modules\\npm\\npmrc
+npm update -g",
 	"checkver": "<p class=\"version\">Current Version: v([0-9\\.]+)</p>"
 }


### PR DESCRIPTION
NodeJS is no longer bundling an up to date NPM package, currently shipping with v1.4.28, now post install running `npm update -g` will update to NPM v2.1.10 at time of writing.

Note: After "Travelling Directories" are implemented this would also then update all NPM "Global" packages, not sure this is a bad thing but worth noting.
