### PR TITLE
Remove openjdk dependancy for ant

### DIFF
--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -8,6 +8,5 @@
     "env_add_path": "bin",
     "env_set": {
         "ANT_HOME": "$dir"
-    },
-    "depends": "openjdk"
+    }
 }


### PR DESCRIPTION
In fact, when installing oraclejdk, openjdk conflicts with oraclejdk