### PR TITLE
Git 1.9.5 (Security Release)

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -1,9 +1,9 @@
 {
 	"homepage": "http://msysgit.github.io/",
 	"license": "GPL2",
-	"version": "1.9.4",
-	"url": "https://github.com/msysgit/msysgit/releases/download/Git-1.9.4-preview20140611/PortableGit-1.9.4-preview20140611.7z",
-	"hash": "b68a7852390208d08c7609a34cae2f4bbc629e65341cb5a9b2fe0d161bd9376f",
+	"version": "1.9.5",
+	"url": "https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20141217/PortableGit-1.9.5-preview20141217.7z",
+	"hash": "e0b597f7a27803fb76c27254c9974e946ddfd713d4a37eac22e18c3be2a3e67e",
 	"bin": [ "cmd\\git.exe", "cmd\\gitk.cmd" ],
 	"post_install": [
 		"git config --global credential.helper wincred"


### PR DESCRIPTION
- Safeguards against bogus file names on NTFS (CVE-2014-9390)
- More info https://github.com/blog/1938-vulnerability-announced-update-your-git-clients
