### PR TITLE
Mercurial 3.2.3 (Security Release)

### DIFF
--- a/bucket/mercurial.json
+++ b/bucket/mercurial.json
@@ -1,15 +1,15 @@
 {
 	"homepage": "mercurial.selenic.com",
-	"version": "3.1.1",
+	"version": "3.2.3",
 	"license": "GPL2",
 	"architecture": {
 		"64bit": {
-			"url": "http://mercurial.selenic.com/release/windows/Mercurial-3.1.1-x64.exe",
-			"hash": "a9d5e613540aa2934f34b763e6ceed783605eb80822992501f44e8be6667a495"
+			"url": "http://mercurial.selenic.com/release/windows/Mercurial-3.2.3-x64.exe",
+			"hash": "9A494D5DED2FD6E2F8689A07E55E6D8A6DE903C7AAEC466732D538A52608330E"
 		},
 		"32bit": {
-			"url": "http://mercurial.selenic.com/release/windows/Mercurial-3.1.1.exe",
-			"hash": "0a4fee43a25decae7e1c8cec1eb76a34a16e43284cabff3931daf2ad873409a5"
+			"url": "http://mercurial.selenic.com/release/windows/Mercurial-3.2.3.exe",
+			"hash": "CB9AE8FD9A78C886E6E4B2EEA554B3E67EE380B39C657956CFE8C1E71DD49313"
 		}
 	},
 	"innosetup": true,
@@ -19,4 +19,3 @@
 		"re": "Mercurial ([0-9\\.]+) Inno Setup installer - x86 Windows - does not require admin rights"
 	}
 }
-


### PR DESCRIPTION
This is an unscheduled bugfix release containing two security fixes for issues we uncovered in both Git and Mercurial for CVE-2014-9390. Users on Mac and Windows are encouraged to upgrade.
