### PR TITLE
Updated PHP 5.3 location on php.net

### DIFF
--- a/bucket/php53.json
+++ b/bucket/php53.json
@@ -2,7 +2,7 @@
 	"homepage": "http://windows.php.net",
 	"version": "5.3.29",
 	"license": "http://www.php.net/license/",
-	"url": "http://windows.php.net/downloads/releases/php-5.3.29-Win32-VC9-x86.zip",
+	"url": "http://windows.php.net/downloads/releases/archives/php-5.3.29-Win32-VC9-x86.zip",
 	"hash": "sha1:61615fe9db85c3ab630fe35673a1b6f45782e5d4",
 	"bin": "php.exe",
 	"post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",


### PR DESCRIPTION
Currently, version 5.3 is in archives directory