### PR TITLE
Added support for custom commands

### DIFF
--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -1,5 +1,7 @@
 function command_files {
-	gci (relpath '..\libexec') | where { $_.name -match 'scoop-.*?\.ps1$' }
+	(gci (relpath '..\libexec')) `
+        + (gci "$env:scoop\shims") `
+        | where { $_.name -match 'scoop-.*?\.ps1$' }
 }
 
 function commands {
@@ -10,6 +12,23 @@ function command_name($filename) {
 	$filename.name | sls 'scoop-(.*?)\.ps1$' | % { $_.matches[0].groups[1].value }
 }
 
+function command_path($cmd) {
+    $cmd_path = relpath "..\libexec\scoop-$cmd.ps1"
+
+    # built in commands
+    if (!(Test-Path $cmd_path)) {
+        # get path from shim
+        $shim_path = "$env:scoop\shims\scoop-$cmd.ps1"
+        $line = ((gc $shim_path) | where { $_.startswith('$path') })
+        iex -command "$line"
+        $cmd_path = $path
+    } 
+
+    $cmd_path
+}
+
 function exec($cmd, $arguments) {
-	& (relpath "..\libexec\scoop-$cmd.ps1") @arguments
+    $cmd_path = command_path $cmd
+
+    & $cmd_path @arguments
 }

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -7,7 +7,7 @@ param($cmd)
 . "$psscriptroot\..\lib\help.ps1"
 
 function print_help($cmd) {
-	$file = gc (relpath ".\scoop-$cmd.ps1") -raw
+	$file = gc (command_path $cmd) -raw
 
 	$usage = usage $file
 	$summary = summary $file
@@ -22,7 +22,7 @@ function print_summaries {
 
 	command_files | % {
 		$command = command_name $_
-		$summary = summary (gc (relpath $_) -raw )
+		$summary = summary (gc (command_path $command) -raw)
 		if(!($summary)) { $summary = '' }
 		$commands.add("$command ", $summary) # add padding
 	}


### PR DESCRIPTION
Custom commands `scoop-*` that are in the `$env:scoop\shims` directory
can now be run using scoop as well as the built-in commands