### PR TITLE
Scoop update git

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -29,8 +29,6 @@ cp "$dir\_scoop_extract\scoop-master\*" $dir -r -force
 rm "$dir\_scoop_extract" -r -force
 rm $zipfile
 
-$null > "$dir\last_updated" # save install timestamp
-
 echo 'creating shim...'
 shim "$dir\bin\scoop.ps1" $false
 

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -8,15 +8,6 @@
 . "$psscriptroot\..\lib\depends.ps1"
 . "$psscriptroot\..\lib\config.ps1"
 
-function timeago($when) {
-	$diff = [datetime]::now - $last_update
-
-	if($diff.totaldays -gt 2) { return "$([int]$diff.totaldays) days ago" }
-	if($diff.totalhours -gt 2) { return "$([int]$diff.totalhours) hours ago" }
-	if($diff.totalminutes -gt 2) { return "$([int]$diff.totalminutes) minutes ago" }
-	return "$([int]$diff.totalseconds) seconds ago"
-}
-
 # check if scoop needs updating
 $currentdir = fullpath $(versiondir 'scoop' 'current')
 $needs_update = $false

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -18,11 +18,12 @@ function timeago($when) {
 }
 
 # check when scoop was last updated
-$timestamp = "$(versiondir 'scoop' 'current')\last_updated"
-if(test-path $timestamp) {
-	$last_update = [io.file]::getlastwritetime((resolve-path $timestamp))
-	"scoop was last updated $(timeago($last_update))"
+git fetch origin
+$commits = $(git log HEAD..origin/master --oneline)
+if($commits) {
+	"scoop is out of date. run scoop update to get the latest changes."
 }
+else { "scoop is up-to-date."}
 
 $failed = @()
 $old = @()

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -17,10 +17,22 @@ function timeago($when) {
 	return "$([int]$diff.totalseconds) seconds ago"
 }
 
-# check when scoop was last updated
-git fetch origin
-$commits = $(git log HEAD..origin/master --oneline)
-if($commits) {
+# check if scoop needs updating
+$currentdir = fullpath $(versiondir 'scoop' 'current')
+$needs_update = $false
+
+if(test-path "$currentdir\.git") {
+	pushd $currentdir
+	git fetch origin
+	$commits = $(git log "HEAD..origin/$(scoop config SCOOP_BRANCH)" --oneline)
+	if($commits) { $needs_update = $true }
+	popd
+}
+else {
+	$needs_update = $true
+}
+
+if($needs_update) {
 	"scoop is out of date. run scoop update to get the latest changes."
 }
 else { "scoop is up-to-date."}

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -14,7 +14,7 @@ $needs_update = $false
 
 if(test-path "$currentdir\.git") {
 	pushd $currentdir
-	git fetch origin
+	git fetch -q origin
 	$commits = $(git log "HEAD..origin/$(scoop config SCOOP_BRANCH)" --oneline)
 	if($commits) { $needs_update = $true }
 	popd

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -33,12 +33,24 @@ function update_scoop() {
 	"updating scoop..."
 	$currentdir = fullpath $(versiondir 'scoop' 'current')
 	if(!(test-path "$currentdir\.git")) {
+		# load config
+		$repo = $(scoop config SCOOP_REPO)
+		if(!$repo) { 
+			$repo = "http://github.com/lukesampson/scoop" 
+			scoop config SCOOP_REPO "$repo"
+		}
+
+		$branch = $(scoop config SCOOP_BRANCH)
+		if(!$branch) { 
+			$branch = "master" 
+			scoop config SCOOP_BRANCH "$branch"
+		}
+
 		# remove non-git scoop
 		rm -r -force $currentdir -ea stop
 
 		# get git scoop
-		# todo: pull the address out into a variable somewhere
-		git clone "http://github.com/lukesampson/scoop" $currentdir
+		git clone -q $repo --branch $branch --single-branch $currentdir
 	}
 	else {
 		pushd $currentdir

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -26,42 +26,34 @@ $force = $opt.f -or $opt.force
 $use_cache = !($opt.k -or $opt.'no-cache')
 
 function update_scoop() {
-	$tempdir = versiondir 'scoop' 'update'
-	$currentdir = versiondir 'scoop' 'current'
+	# check for git
+	$git = try { gcm git -ea stop } catch { $null }
+	if(!$git) { abort "scoop uses git to update itself. run 'scoop install git'." }
 
-	if(test-path $tempdir) {
-		try { rm -r $tempdir -ea stop -force } catch { abort "couldn't remove $tempdir`: it may be in use" }
+	"updating scoop..."
+	$currentdir = fullpath $(versiondir 'scoop' 'current')
+	if(!(test-path "$currentdir\.git")) {
+		# remove non-git scoop
+		rm -r -force $currentdir -ea stop
+
+		# get git scoop
+		# todo: pull the address out into a variable somewhere
+		git clone "http://github.com/lukesampson/scoop" $currentdir
 	}
-	$tempdir = ensure $tempdir
-	$currentdir = fullpath $currentdir
+	else {
+		pushd $currentdir
+		git pull -q
+		popd
+	}
 
-	$zipurl = 'https://github.com/lukesampson/scoop/archive/master.zip'
-	$zipfile = "$tempdir\scoop.zip"
-	echo 'downloading...'
-	dl $zipurl $zipfile
-
-	echo 'extracting...'
-	unzip $zipfile $tempdir
-	rm $zipfile
-
-	echo 'replacing files...'
-	$null = robocopy "$tempdir\scoop-master" $currentdir /mir /njh /njs /nfl /ndl
-	rm -r -force $tempdir -ea stop
-
-	$null > "$currentdir\last_updated" # save update timestamp
 	ensure_scoop_in_path
-
 	shim "$currentdir\bin\scoop.ps1" $false
 
 	@(buckets) | % {
 		"updating $_ bucket..."
-		$git = try { gcm git -ea stop } catch { $null }
-		if(!$git) { warn "git is required for buckets. run 'scoop install git'." }
-		else {
-			pushd (bucketdir $_)
-			git pull -q
-			popd
-		}
+		pushd (bucketdir $_)
+		git pull -q
+		popd
 	}
 	success 'scoop was updated successfully!'
 }


### PR DESCRIPTION
Uses git to update scoop instead of downloading the zip every time

Issues
---------

* Changing repos/branch is not possible after initial update

Usage
---------

If you want to test this out do the following:

```powershell
# this is a custom install script - check the source out if you're worried
# all i changed is where the zip is downloaded from
iex (new-object net.webclient).downloadstring("https://gist.githubusercontent.com/deevus/864ce870042ae1235fe2/raw/9eae811a59c070a9f384b3cfb6b54f8f329be02c/scoop-install.ps1")

# update/status will check these settings
scoop config SCOOP_REPO "https://github.com/deevus/scoop"
scoop config SCOOP_BRANCH "scoop-update-git"

# will now use git to update
scoop update
```

Let me know if I've missed anything