### PR TITLE
Add premake build tools

### DIFF
--- a/bucket/premake4.json
+++ b/bucket/premake4.json
@@ -1,0 +1,10 @@
+{
+    "homepage": "http://premake.github.io/download.html",
+    "version": "4.4-b5",
+    "license": "BSD 3-Clause",
+    "url": "http://sourceforge.net/projects/premake/files/Premake/4.4/premake-4.4-beta5-windows.zip",
+    "hash": "09614c122156617a2b7973cc9f686daa32e64e3e7335d38db887cfb8f6a8574d",
+    "bin": [
+        "premake4.exe"
+    ]
+}

--- a/bucket/premake5.json
+++ b/bucket/premake5.json
@@ -1,0 +1,10 @@
+{
+    "homepage": "http://premake.github.io/download.html",
+    "version": "5.0-a1",
+    "license": "BSD 3-Clause",
+    "url": "http://sourceforge.net/projects/premake/files/5.0/premake-5.0-alpha1-windows.zip",
+    "hash": "1fe4e32fe8d0662ebd00e8333c33eca28a14fd773a351fb4eb702e246d7b7110",
+    "bin": [
+        "premake5.exe"
+    ]
+}


### PR DESCRIPTION
The premake build tools are similar to cmake, except they use lua to describe projects.