### PR TITLE
Add manifest validation tests

### DIFF
--- a/test/Scoop-Manifest.Tests.ps1
+++ b/test/Scoop-Manifest.Tests.ps1
@@ -21,3 +21,15 @@ describe "manifest-validation" {
         }
     }
 }
+
+describe "parse_json" {
+    beforeall {
+        $working_dir = setup_working "parse_json"
+    }
+
+    context "json is invalid" {
+        it "fails with invalid json" {
+            { parse_json "$working_dir\wget.json" } | should throw
+        }
+    }
+}

--- a/test/Scoop-Manifest.Tests.ps1
+++ b/test/Scoop-Manifest.Tests.ps1
@@ -1,0 +1,23 @@
+. "$psscriptroot\Scoop-TestLib.ps1"
+. "$psscriptroot\..\lib\core.ps1"
+. "$psscriptroot\..\lib\manifest.ps1"
+
+describe "manifest-validation" {
+    $bucketdir = "$psscriptroot\..\bucket\"
+    $manifest_files = gci $bucketdir *.json
+
+    $manifest_files | % { 
+        it "test validity of $_" {
+            $manifest = parse_json $_.fullname
+
+            $url = arch_specific "url" $manifest "32bit"
+            if(!$url) {
+                $url = arch_specific "url" $manifest "64bit"
+            }
+
+            $url | should not benullorempty
+            $manifest | should not benullorempty
+            $manifest.version | should not benullorempty
+        }
+    }
+}

--- a/test/fixtures/parse_json/wget.json
+++ b/test/fixtures/parse_json/wget.json
@@ -1,0 +1,29 @@
+{
+	"homepage": "https://eternallybored.org/misc/wget/",
+	"license": "GPL3",
+	"version": "1.16.3"
+	"architecture": {
+		"64bit": {
+			"url": [ 
+				"https://eternallybored.org/misc/wget/wget-1.16.3-win64.zip",
+				"http://curl.haxx.se/ca/cacert.pem"
+			],
+			"hash": [
+				"85e5393ffd473f7bec40b57637fd09b6808df86c06f846b6885b261a8acac8c5",
+				""
+			]
+		},
+		"32bit": {
+			"url": [ 
+				"https://eternallybored.org/misc/wget/wget-1.16.3-win32.zip",
+				"http://curl.haxx.se/ca/cacert.pem"
+			],
+			"hash": [
+				"2ef82af3070abfdaf3862baff0bffdcb3c91c8d75e2f02c8720d90adb9d7a8f7",
+				""
+			]
+		}
+	},
+	"bin": "wget.exe",
+	"post_install": "\"ca_certificate=$dir\\cacert.pem\" | out-file $dir\\wget.ini -encoding default"
+}


### PR DESCRIPTION
The manifest-validation test iterates through each json in the main
bucket to ensure that required fields (url, version) are not empty