### PR TITLE
Renames function in lib\install.ps1 to not collide with other packages.

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -5,7 +5,7 @@ function nightly_version($date) {
 }
 
 function install_app($app, $architecture, $global) {
-	$app, $manifest, $bucket, $url = locate $app
+	$app, $manifest, $bucket, $url = find $app
 	$use_cache = $true
 	$check_hash = $true
 
@@ -65,7 +65,7 @@ function appname_from_url($url) {
 	(split-path $url -leaf) -replace '.json$', ''
 }
 
-function locate($app) {
+function find($app) {
 	$manifest, $bucket, $url = $null, $null, $null
 
 	# check if app is a url


### PR DESCRIPTION
If you have another package installed, for example this well known package https://gallery.technet.microsoft.com/scriptcenter/Invoke-Locate-PowerShell-0aa2673a it wont work to install packages via scoop. 

The reason why it is not working is because the command locate seems to be reserved for that package and therefore collides with the function.

A fix for this is to rename a function called locate. What do you think?