### PR TITLE
Invoke-Build 2.12.1 and replaced "bin" with "env_add_path" (explained)

### DIFF
--- a/bucket/invoke-build.json
+++ b/bucket/invoke-build.json
@@ -1,12 +1,9 @@
 ﻿{
-    "version":  "2.12.0",
+    "version":  "2.12.1",
     "license":  "Apache 2.0",
     "extract_dir":  "tools",
-    "url":  "http://nuget.org/api/v2/package/Invoke-Build/2.12.0#.zip",
+    "url":  "http://nuget.org/api/v2/package/Invoke-Build/2.12.1#.zip",
     "homepage":  "https://github.com/nightroman/Invoke-Build",
-    "hash":  "573e12ba650d7a7e9c3b9545a62d28804843bfc3b1d6a9930069a4fd7c647c91",
-    "bin":  [
-        "Invoke-Build.ps1",
-        "Invoke-Builds.ps1"
-    ]
+    "hash":  "a5ef7af480b7c3bd16abd65fe17b3428fdfe562305cee9beb1c475737dea42ba",
+    "env_add_path": "."
 }


### PR DESCRIPTION
Minor change - updated version to the latest stable 2.12.1

Major change - replaced installation of "bin" shims with "env_add_path".
Invoke-Build is designed to be installed either together with a project
(NuGet does this) or in the path (scoop may do this as proposed).

Here is the analysis of why the approach with shims does not work well for
Invoke-Build:

- *invoke-build.ps1*
    - PowerShell help is not available, the help file *Invoke-Build-Help.xml*
      is not together with the shim. And even if it were help would not work
      because the shim parameters do not match.
    - The original script *Invoke-Build.ps1* provides the special dot-sourced
      mode. The shim invokes the original script as `& $path`. Thus, this mode
      is not available. And even if it were Invoke-Build would not set the
      correct start location because its immediate caller is the shim, so the
      location is the shim directory.
- *invoke-build.cmd*
    - Redundant because Invoke-Build package comes with its own helper
      *ib.cmd*, specifically crafted.
    - *Potential* issue [339](https://github.com/lukesampson/scoop/issues/339).
- *invoke-builds.ps1*
    - Presumably should work fine but PowerShell help is also not available.
- *invoke-builds.cmd*
    - Very difficult to use, if possible. *Invoke-Builds.ps1* is designed for
      calls from PowerShell because it accepts a rather complex hashtable of
      parameters, fine to compose in a PowerShell script, difficult in CMD.

With the proposed change scoop installs Invoke-Build ideally. It is immediately
ready to use in the path and easy to uninstall with its path removed (tested).
