### PR TITLE
A brute force fix for powershell alias problems

### DIFF
--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -6,6 +6,8 @@ set-strictmode -off
 . "$psscriptroot\..\lib\core.ps1"
 . (relpath '..\lib\commands')
 
+reset_aliases
+
 $commands = commands
 
 if (@($null, '-h', '--help', '/?') -contains $cmd) { exec 'help' $args }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -222,12 +222,11 @@ function reset_alias($name, $value) {
 		if($existing.definition -ne $value) {
 			write-host "alias $name is read-only; can't reset it" -f darkyellow
 		}
-		
-		return;
+		return # already set
 	}
 	if($value -is [scriptblock]) {
 		new-item -path function: -name "script:$name" -value $value | out-null
-		$value = "script:$name"
+		return
 	}
 	
 	set-alias $name $value -scope script -option allscope
@@ -235,7 +234,7 @@ function reset_alias($name, $value) {
 
 function reset_aliases() {
 	# for aliases where there's a local function, re-alias so the function takes precedence
-	$aliases = get-alias -scope global |? { $_.options -notmatch 'readonly' } |% { $_.name }
+	$aliases = get-alias |? { $_.options -notmatch 'readonly' } |% { $_.name }
 	get-childitem function: | % {
 		$fn = $_.name
 		if($aliases -contains $fn) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -2,22 +2,6 @@ $scoopdir = $env:SCOOP, "~\appdata\local\scoop" | select -first 1
 $globaldir = $env:SCOOP_GLOBAL, "$($env:programdata.tolower())\scoop" | select -first 1
 $cachedir = "$scoopdir\cache" # always local
 
-# using functions as aliases for powershell commands
-function script:cp() { copy-item @args } 
-function script:echo() { write-output @args } 
-function script:gc() { get-content @args } 
-function script:gci() { get-childitem @args } 
-function script:gcm() { get-command @args } 
-function script:iex() { invoke-expression @args } 
-function script:ls() { get-childitem @args } 
-function script:mkdir() { new-item -type directory @args } 
-function script:mv() { move-item @args } 
-function script:rm() { remove-item @args } 
-function script:rmdir() { remove-item @args } 
-function script:sc() { set-content @args } 
-function script:select() { select-object @args } 
-function script:sls() { select-string @args } 
-
 # helper functions
 function coalesce($a, $b) { if($a) { return $a } $b }
 function format($str, $hash) {
@@ -214,4 +198,51 @@ function wraptext($text, $width) {
 
 function pluralize($count, $singular, $plural) {
 	if($count -eq 1) { $singular } else { $plural }
+}
+
+# for dealing with user aliases
+$default_aliases = @{
+	'cp' = 'copy-item'
+	'echo' = 'write-output'
+	'gc' = 'get-content'
+	'gci' = 'get-childitem'
+	'gcm' = 'get-command'
+	'iex' = 'invoke-expression'
+	'ls' = 'get-childitem'
+	'mkdir' = { new-item -type directory @args }
+	'mv' = 'move-item'
+	'rm' = 'remove-item'
+	'sc' = 'set-content'
+	'select' = 'select-object'
+	'sls' = 'select-string'
+}
+
+function reset_alias($name, $value) {
+	if($existing = get-alias $name -ea ignore |? { $_.options -match 'readonly' }) {
+		if($existing.definition -ne $value) {
+			write-host "alias $name is read-only; can't reset it" -f darkyellow
+		}
+		
+		return;
+	}
+	if($value -is [scriptblock]) {
+		new-item -path function: -name "script:$name" -value $value | out-null
+		$value = "script:$name"
+	}
+	
+	set-alias $name $value -scope script -option allscope
+}
+
+function reset_aliases() {
+	# for aliases where there's a local function, re-alias so the function takes precedence
+	$aliases = get-alias -scope global |? { $_.options -notmatch 'readonly' } |% { $_.name }
+	get-childitem function: | % {
+		$fn = $_.name
+		if($aliases -contains $fn) {
+			set-alias $fn local:$fn -scope script
+		}
+	}
+
+	# set default aliases
+	$default_aliases.keys | % { reset_alias $_ $default_aliases[$_] }
 }

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -20,6 +20,8 @@ param($cmd, $name, $repo)
 . "$psscriptroot\..\lib\buckets.ps1"
 . "$psscriptroot\..\lib\help.ps1"
 
+reset_aliases
+
 $usage_add = "usage: scoop bucket add <name> [<repo>]"
 $usage_rm = "usage: scoop bucket rm <name>"
 

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -11,6 +11,8 @@ param($cmd, $app)
 
 . "$psscriptroot\..\lib\help.ps1"
 
+reset_aliases
+
 function cacheinfo($file) {
 	$app, $version, $url = $file.name -split '#'
 	$size = filesize $file.length

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -31,6 +31,8 @@ param($name, $value)
 . "$psscriptroot\..\lib\config.ps1"
 . "$psscriptroot\..\lib\help.ps1"
 
+reset_aliases
+
 if(!$name) { my_usage; exit 1 }
 
 if($name -like 'rm') {

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -10,6 +10,8 @@
 . "$psscriptroot\..\lib\config.ps1"
 . "$psscriptroot\..\lib\help.ps1"
 
+reset_aliases
+
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]
 

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -7,6 +7,8 @@
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\buckets.ps1"
 
+reset_aliases
+
 $local = installed_apps $false | % { @{ name = $_; global = $false } }
 $global = installed_apps $true | % { @{ name = $_; global = $true } }
 

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -6,6 +6,8 @@ param($cmd)
 . "$psscriptroot\..\lib\commands.ps1"
 . "$psscriptroot\..\lib\help.ps1"
 
+reset_aliases
+
 function print_help($cmd) {
 	$file = gc (command_path $cmd) -raw
 

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -7,6 +7,8 @@ param($app)
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\buckets.ps1"
 
+reset_aliases
+
 if($app) {
     $manifest, $bucket = find_manifest $app
     if($manifest) {

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -26,6 +26,8 @@
 . "$psscriptroot\..\lib\depends.ps1"
 . "$psscriptroot\..\lib\config.ps1"
 
+reset_aliases
+
 function ensure_none_installed($apps, $global) {
 	$app = @(all_installed $apps $global)[0] # might return more than one; just get the first
 	if($app) {

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -8,6 +8,8 @@ param($query)
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\buckets.ps1"
 
+reset_aliases
+
 $local = installed_apps $false | % { @{ name = $_ } }
 $global = installed_apps $true | % { @{ name = $_; global = $true } }
 

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -11,6 +11,8 @@ param($app)
 . "$psscriptroot\..\lib\install.ps1"
 . "$psscriptroot\..\lib\versions.ps1"
 
+reset_aliases
+
 if(!$app) { 'ERROR: <app> missing'; my_usage; exit 1 }
 
 if(!(installed $app)) { abort "$app isn't installed" }

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -10,6 +10,8 @@ param($query)
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\versions.ps1"
 
+reset_aliases
+
 function bin_match($manifest, $query) {
 	if(!$manifest.bin) { return $false }
 	foreach($bin in $manifest.bin) {

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -8,6 +8,8 @@
 . "$psscriptroot\..\lib\depends.ps1"
 . "$psscriptroot\..\lib\config.ps1"
 
+reset_aliases
+
 # check if scoop needs updating
 $currentdir = fullpath $(versiondir 'scoop' 'current')
 $needs_update = $false

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -11,6 +11,8 @@
 . "$psscriptroot\..\lib\versions.ps1"
 . "$psscriptroot\..\lib\getopt.ps1"
 
+reset_aliases
+
 # options
 $opt, $app, $err = getopt $args 'g' 'global'
 if($err) { "scoop uninstall: $err"; exit 1 }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -19,6 +19,8 @@
 . "$psscriptroot\..\lib\depends.ps1"
 . "$psscriptroot\..\lib\config.ps1"
 
+reset_aliases
+
 $opt, $apps, $err = getopt $args 'gfk' 'global','force', 'no-cache'
 if($err) { "scoop update: $err"; exit 1 }
 $global = $opt.g -or $opt.global

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -5,6 +5,8 @@ param($command)
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\help.ps1"
 
+reset_aliases
+
 if(!$command) { 'ERROR: <command> missing'; my_usage; exit 1 }
 
 try { $gcm = gcm $command -ea stop } catch { }


### PR DESCRIPTION
This is a possible fix for #351. What it does:

1. Resets common Powershell aliases to their defaults in Scoop's script scope (e.g. ls, gcm). This was already being done with script-scoped functions, but this change does it with script-scoped aliases instead.
2. Prioritises local functions over user-defined aliases with the same name.
3. Doesn't require renaming functions to make them more obscure in the hope that they won't collide with user's aliases.
4. Gives more protection against invasive aliases.

On my machine this adds about 30ms execution time to each scoop command issued.

I'm going to think about this one before committing. Comments welcome.