### PR TITLE
Fix #376 Robocopy is not always in PATH

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -32,6 +32,7 @@ rm $zipfile
 echo 'creating shim...'
 shim "$dir\bin\scoop.ps1" $false
 
+ensure_robocopy_in_path
 ensure_scoop_in_path
 success 'scoop was installed successfully!'
 echo "type 'scoop help' for instructions"

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -179,6 +179,12 @@ function ensure_scoop_in_path($global) {
 	ensure_in_path $abs_shimdir $global
 }
 
+function ensure_robocopy_in_path {
+	if(!(gcm robocopy -ea ignore)) {
+		shim "C:\Windows\System32\Robocopy.exe" $false
+	}
+}
+
 function wraptext($text, $width) {
 	if(!$width) { $width = $host.ui.rawui.windowsize.width };
 	$width -= 1 # be conservative: doesn't seem to print the last char

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -136,6 +136,11 @@ describe "rm_shim" {
 
 describe "ensure_robocopy_in_path" {
     $shimdir = shimdir $false
+    mock versiondir { ".\" }
+
+    beforeall {
+        reset_aliases
+    }
 
     context "robocopy is not in path" {
         it "shims robocopy when not on path" {

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -133,3 +133,32 @@ describe "rm_shim" {
         { shim-test } | should throw
     }
 }
+
+describe "ensure_robocopy_in_path" {
+    $shimdir = shimdir $false
+
+    context "robocopy is not in path" {
+        it "shims robocopy when not on path" {
+            mock gcm { $false }
+            gcm robocopy | should be $false
+
+            ensure_robocopy_in_path
+
+            "$shimdir/robocopy.ps1" | should exist
+            "$shimdir/robocopy.exe" | should exist
+
+            # clean up
+            rm_shim robocopy $(shimdir $false) | out-null
+        }
+    }
+
+    context "robocopy is in path" {
+        it "does not shim robocopy when it is in path" {
+            mock gcm { $true }
+            ensure_robocopy_in_path
+
+            "$shimdir/robocopy.ps1" | should not exist
+            "$shimdir/robocopy.exe" | should not exist
+        }
+    }
+}


### PR DESCRIPTION
Add ensure_robocopy_in_path method to core.ps1 which checks if
robocopy is available, then shims it if not.