### PR TITLE
Added mediainfo-cli 0.7.73

### DIFF
--- a/bucket/mediainfo.json
+++ b/bucket/mediainfo.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.7.73",
+    "architecture": {
+      "64bit": {
+        "url": "http://downloads.sourceforge.net/project/mediainfo/binary/mediainfo/0.7.73/MediaInfo_CLI_0.7.73_Windows_x64.zip",
+        "hash": "b1b7ea9915fdbcac4294edec3556109c5cd4d4d9d3c6535cf9602598c31b6699"
+      },
+      "32bit": {
+        "url": "http://downloads.sourceforge.net/project/mediainfo/binary/mediainfo/0.7.73/MediaInfo_CLI_0.7.73_Windows_i386.zip",
+        "hash": "967D88C703B4BC11C940B3F4B0C6698B9B4859F855E4C3E0DBB8781666A24680"
+      }
+    },
+    "extract_dir": "",
+    "bin": "mediainfo.exe"
+}


### PR DESCRIPTION
There are two versions: a GUI and a CLI version. The CLI one seemed more appropriate.

thanks
--oleg