### PR TITLE
Add --quiet opt to update command to suppress extraneous messages

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1,6 +1,8 @@
-function nightly_version($date) {
+function nightly_version($date, $quiet = $false) {
 	$date_str = $date.tostring("yyyyMMdd") 
-	warn "this is a nightly version: downloaded files won't be verified"
+	if (!$quiet) {
+		warn "this is a nightly version: downloaded files won't be verified"
+	}
 	"nightly-$date_str"
 }
 


### PR DESCRIPTION
This:

```
$ scoop update *
the latest version of 7zip (9.20) is already installed.
run 'scoop update' to check for new versions.
the latest version of apache (2.4.12) is already installed.
run 'scoop update' to check for new versions.
the latest version of bfg (1.12.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of busybox (1.24.0-TIG-1778) is already installed.
run 'scoop update' to check for new versions.
the latest version of cmake (3.2.2) is already installed.
run 'scoop update' to check for new versions.
the latest version of concfg (0.2014.03.17.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of conemu (150408) is already installed.
run 'scoop update' to check for new versions.
the latest version of coreutils (5.97.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of cpu-z (1.71) is already installed.
run 'scoop update' to check for new versions.
the latest version of csvtosql (v0.1.1-alpha) is already installed.
run 'scoop update' to check for new versions.
the latest version of curl (7.39.0) is already installed.
run 'scoop update' to check for new versions.
the latest version of docker (1.6.2) is already installed.
run 'scoop update' to check for new versions.
the latest version of docker-machine (0.2.0) is already installed.
run 'scoop update' to check for new versions.
the latest version of dwarf-fortress (0.40.24) is already installed.
run 'scoop update' to check for new versions.
the latest version of emacs (24.4) is already installed.
run 'scoop update' to check for new versions.
the latest version of enso (0.1.5) is already installed.
run 'scoop update' to check for new versions.
the latest version of ffmpeg (2.5.2) is already installed.
run 'scoop update' to check for new versions.
the latest version of gawk (3.1.7) is already installed.
run 'scoop update' to check for new versions.
the latest version of gcc (4.8.1) is already installed.
run 'scoop update' to check for new versions.
the latest version of git (1.9.5-preview20150319) is already installed.
run 'scoop update' to check for new versions.
the latest version of git-flow (latest) is already installed.
run 'scoop update' to check for new versions.
updating git-preview (v2.3.7.windows.1 -> 2.4.0.windows.1)
uninstalling git-preview (v2.3.7.windows.1)
removing shim for git
removing shim for gitk
removing shim for git-gui
installing git-preview (2.4.0.windows.1)
loading https://github.com/git-for-windows/git/releases/download/v2.4.0.windows.1/PortableGit-2.4.0.1-dev-preview-64-bit.7z.exe#/dl.7z from cache...
checking hash...ok
extracting...done
creating shim for git
creating shim for gitk
creating shim for git-gui
running post-install script...
git-preview was updated from v2.3.7.windows.1 to 2.4.0.windows.1
the latest version of go (1.4.2) is already installed.
run 'scoop update' to check for new versions.
the latest version of gow (0.8.0) is already installed.
run 'scoop update' to check for new versions.
the latest version of grep (2.5.4) is already installed.
run 'scoop update' to check for new versions.
the latest version of gzip (1.3.12) is already installed.
run 'scoop update' to check for new versions.
the latest version of hub (2.2.0) is already installed.
run 'scoop update' to check for new versions.
the latest version of iconv (1.14-3) is already installed.
run 'scoop update' to check for new versions.
the latest version of innounp (0.40) is already installed.
run 'scoop update' to check for new versions.
the latest version of invoke-build (2.12.1) is already installed.
run 'scoop update' to check for new versions.
the latest version of jkrypto (4.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of jq (1.4) is already installed.
run 'scoop update' to check for new versions.
the latest version of less (394) is already installed.
run 'scoop update' to check for new versions.
the latest version of nginx (1.9.0) is already installed.
run 'scoop update' to check for new versions.
the latest version of ninja (1.5.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of nircmd (2.75) is already installed.
run 'scoop update' to check for new versions.
the latest version of nodejs (0.12.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of octave (3.8.2-5) is already installed.
run 'scoop update' to check for new versions.
this is a nightly version: downloaded files won't be verified
the latest version of oneget (nightly-20150604) is already installed.
run 'scoop update' to check for new versions.
the latest version of openjdk (1.7.0-u60) is already installed.
run 'scoop update' to check for new versions.
the latest version of openssh (5.4p1-1) is already installed.
run 'scoop update' to check for new versions.
the latest version of openssl (1.0.2a) is already installed.
run 'scoop update' to check for new versions.
the latest version of perl (5.20.1.1) is already installed.
run 'scoop update' to check for new versions.
the latest version of pester (3.3.6) is already installed.
run 'scoop update' to check for new versions.
the latest version of pixel-dungeon (1.7.2a-1) is already installed.
run 'scoop update' to check for new versions.
the latest version of pkg-config (0.26-1) is already installed.
run 'scoop update' to check for new versions.
the latest version of pshazz (0.2014.11.25) is already installed.
run 'scoop update' to check for new versions.
the latest version of python (3.4.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of python27 (2.7.10) is already installed.
run 'scoop update' to check for new versions.
the latest version of rsync (3.1.1) is already installed.
run 'scoop update' to check for new versions.
the latest version of ruby (2.2.1) is already installed.
run 'scoop update' to check for new versions.
this is a nightly version: downloaded files won't be verified
the latest version of rust-nightly (nightly-20150604) is already installed.
run 'scoop update' to check for new versions.
the latest version of say (0.2013.09.08) is already installed.
run 'scoop update' to check for new versions.
the latest version of sbcl (1.2.6) is already installed.
run 'scoop update' to check for new versions.
the latest version of scala (2.11.6) is already installed.
run 'scoop update' to check for new versions.
the latest version of scholdoc (0.1.3-alpha) is already installed.
run 'scoop update' to check for new versions.
updating scoop-plist (latest -> 20150405)
uninstalling scoop-plist (latest)
removing shim for scoop-plist
installing scoop-plist (20150405)
loading https://gist.githubusercontent.com/deevus/b99755c6b0ef794bfafa/raw/22ea87eb81c0cd08aedaaacbab6756d5a0d649d9/scoop-plist.ps1 from cache...
checking hash...ok
creating shim for scoop-plist
scoop-plist was updated from latest to 20150405
the latest version of scoop-shellinit (latest) is already installed.
run 'scoop update' to check for new versions.
the latest version of scriptcs (0.13.2) is already installed.
run 'scoop update' to check for new versions.
the latest version of sed (4.2.1) is already installed.
run 'scoop update' to check for new versions.
the latest version of shasum (0.2013.09.29) is already installed.
run 'scoop update' to check for new versions.
the latest version of shim (0.2013.11.19) is already installed.
run 'scoop update' to check for new versions.
the latest version of sqlite (3.8.6) is already installed.
run 'scoop update' to check for new versions.
the latest version of ssh-copy-id (2015-03-22) is already installed.
run 'scoop update' to check for new versions.
the latest version of sudo (0.2014.07.18) is already installed.
run 'scoop update' to check for new versions.
the latest version of syncany-cli (0.4.0) is already installed.
run 'scoop update' to check for new versions.
the latest version of sysinternals (0.2015.1.19) is already installed.
run 'scoop update' to check for new versions.
the latest version of tar (1.23) is already installed.
run 'scoop update' to check for new versions.
the latest version of time (2013-08-10) is already installed.
run 'scoop update' to check for new versions.
the latest version of touch (2013-07-02) is already installed.
run 'scoop update' to check for new versions.
the latest version of util-linux-ng (2.14.1) is already installed.
run 'scoop update' to check for new versions.
the latest version of vim (7.4) is already installed.
run 'scoop update' to check for new versions.
the latest version of visualc (16.00.30319.01) is already installed.
run 'scoop update' to check for new versions.
the latest version of wget (1.16.3) is already installed.
run 'scoop update' to check for new versions.
the latest version of youtube-dl (2015.04.03) is already installed.
run 'scoop update' to check for new versions.
```

Turns into this: 

```
$ scoop update * --quiet
updating git-preview (v2.3.7.windows.1 -> 2.4.0.windows.1)
uninstalling git-preview (v2.3.7.windows.1)
removing shim for git
removing shim for gitk
removing shim for git-gui
installing git-preview (2.4.0.windows.1)
loading https://github.com/git-for-windows/git/releases/download/v2.4.0.windows.1/PortableGit-2.4.0.1-dev-preview-64-bit.7z.exe#/dl.7z from cache...
checking hash...ok
extracting...done
creating shim for git
creating shim for gitk
creating shim for git-gui
running post-install script...
git-preview was updated from v2.3.7.windows.1 to 2.4.0.windows.1
updating scoop-plist (latest -> 20150405)
uninstalling scoop-plist (latest)
removing shim for scoop-plist
installing scoop-plist (20150405)
loading https://gist.githubusercontent.com/deevus/b99755c6b0ef794bfafa/raw/22ea87eb81c0cd08aedaaacbab6756d5a0d649d9/scoop-plist.ps1 from cache...
checking hash...ok
creating shim for scoop-plist
scoop-plist was updated from latest to 20150405
```