### PR TITLE
Let PyWin32 extension installer find this python

### DIFF
--- a/bucket/python.json
+++ b/bucket/python.json
@@ -37,6 +37,8 @@
 		$create_reg.Invoke(\"Classes\\.py\", \"Python.File\")
 		$create_reg.Invoke(\"Python\\PythonCore\\3.4\\InstallPath\", `
 			\"$dir\")
+		$create_reg.Invoke(\"Python\\PythonCore\\3.4\\PythonPath\", `
+			\"$dir;$dir\\Lib\\;$dir\\DLLs\\\")
 	",
 	"checkver": "<p>Latest: <a href=\".*\">Python ([0-9\\.]+)</a> - <a.*>.*</a></p>"
 }

--- a/bucket/python27.json
+++ b/bucket/python27.json
@@ -20,11 +20,21 @@
 	"env_add_path": [ "scripts" ],
 	"post_install": "
 		python2 -m ensurepip
-
-		$reg_path = \"Registry::HKEY_CURRENT_USER\\Software\\Python\\PythonCore\\2.7\\InstallPath\"
-		new-item -path $reg_path -force | out-null
-		new-itemproperty -path $reg_path `
-			-name \"(Default)\" -value \"$dir\" -force | out-null
+		
+		$create_reg = {
+			param($path, $value)
+			
+			$reg_base = \"Registry::HKEY_CURRENT_USER\\Software\"
+			
+			new-item -path \"$reg_base\\$path\" -force | out-null
+			new-itemproperty -path \"$reg_base\\$path\" `
+				-name \"(Default)\" -value \"$value\" -force | out-null
+		}
+		
+		$create_reg.Invoke(\"Python\\PythonCore\\2.7\\InstallPath\", `
+			\"$dir\")
+		$create_reg.Invoke(\"Python\\PythonCore\\2.7\\PythonPath\", `
+			\"$dir;$dir\\Lib\\;$dir\\DLLs\\\")
 	",
 	"checkver": "<p>Latest: <a.*>.*</a> - <a href=\".*\">Python ([0-9\\.]+)</a></p>"
 }


### PR DESCRIPTION
These will fix the issue that pywin32 extension installer being unable to find python installed with scoop.
pywin32 installer : http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/
Reference : http://tech.valgog.com/2010/01/after-installing-64-bit-windows-7-at.html