### PR TITLE
FIX portable perl to allow normal access to user's home directory

### DIFF
--- a/bucket/perl.json
+++ b/bucket/perl.json
@@ -12,6 +12,12 @@
 			"hash": "sha1:844e7c2d741bda915ece0688bf3a00ab12577460"
 		}
 	},
+	"post_install":"
+		# enable standard idiomatic access to user's home directory
+		## remove HomeDir section from portable.perl (disables Portable.pm override of File::HomeDir)
+		## NOTE: conversion to byte[] avoids adding an extra trailing newline to the output file
+		[byte[]][char[]]((Get-Content -raw $dir\\portable.perl) -replace \"(?ms)^HomeDir:.*?^(?=\\S)\",\"\") | Set-Content $dir\\portable.perl -encoding byte
+	",
 	"env_add_path": [ "perl\\site\\bin", "perl\\bin", "c\\bin" ],
 	"checkver": "<b>Recommended version:</b></p>\\s*<a[^>]*><b>Strawberry Perl ([0-9\\.]+) \\(32bit\\)</b>"
 }


### PR DESCRIPTION
* disable the File::HomeDir override performed by Portable.pm
  - achieved by removing the HomeDir section from "portable.perl" via post_install
  - ref: https://rt.cpan.org/Ticket/Display.html?id=105395 @@ https://archive.is/q7BYq

.# DISCUSSION

Strawberry Portable Perl is written to be usable from a non-privileged storage location, such as a plug-in USB drive. So, it is designed to be usable without access to the host filesystem beyond it's own directory.

As part of the machinations making this possible, Portable.pm overrides File::HomeDir to return resultant paths which are within the perl installation directory (specifically, "INSTALL_DIR/data"). Obviously, this obscures the user's true home directory and can be very inconvenient for common perl scripts which depend on access to data within the user's home directory (i.e., reading ".netrc").

This override/redirection is unnecessary for an installation by the user into the usual host file system (such as is done via `scoop`). Such an installation has user level privileges and will be able to access any user-accessible portion of the file system.