### PR TITLE
upgrade to dart 1.11.1

### DIFF
--- a/bucket/dart.json
+++ b/bucket/dart.json
@@ -1,5 +1,5 @@
 {
-    "version":  "1.11.0",
+    "version":  "1.11.1",
     "license":  "BSD",
     "homepage":  "https://www.dartlang.org/",
     "extract_dir":  "dart-sdk",
@@ -8,12 +8,12 @@
                      ],
     "architecture":  {
                          "64bit":  {
-                                       "url":  "https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-windows-x64-release.zip",
-                                       "hash":  "891358dd2ac397d9059e823a6332cb1c9f02633ff507396ad78ec7fb5a2e0a2c"
+                                       "url":  "https://storage.googleapis.com/dart-archive/channels/stable/release/1.11.1/sdk/dartsdk-windows-x64-release.zip",
+                                       "hash":  "8b0dbf2d90055a0de2e8a9bf01500f88a3575ba0457a3c44ce29fd759a553bfb"
                                    },
                          "32bit":  {
-                                       "url":  "https://storage.googleapis.com/dart-archive/channels/stable/release/latest/sdk/dartsdk-windows-ia32-release.zip",
-                                       "hash":  "420c9554895add8ad630c2671844731676a0d039c3be3bb9df2004f12513c534"
+                                       "url":  "https://storage.googleapis.com/dart-archive/channels/stable/release/1.11.1/sdk/dartsdk-windows-ia32-release.zip",
+                                       "hash":  "d2abdfe9c1e44d3c77d2b84e448c5ff14a6e3d45ed39460ed096782f9651bbc1"
                                    }
                      },
     "checkver":  {


### PR DESCRIPTION
Upgrade to dart 1.11.1. This PR also changes the refs from /latest (had been 1.11.0) to a specific version. The contents of /latest will change every time there's a new release, and the checksum will no longer be valid. We now point to a specific version and use that version's checksum.