### PR TITLE
Fix appveyor.yml, removing user-specific notification settings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,3 @@ test_script:
   - ps: $result = invoke-pester -path test/ -outputfile TestResults.xml -outputformat NUnitXML -passthru; $env:failedcount = $result.failedcount
   - ps: (new-object net.webclient).uploadfile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (resolve-path ./TestResults.xml))
   - ps: if($env:failedcount -gt 0) { exit $env:failedcount }
-
-notifications:
-  - provider: Slack
-    auth_token:
-      secure: lzkktSx/4RFbuzbztN3ZycdGJjr6ZqapatvExhwRjB4Va9QNutHw1lGPI0hWlPAq
-    channel: activity


### PR DESCRIPTION
.# Discussion

Appveyor doesn't have partial `appveyor.yml` suppression. So, unless the
`appveyor.yml` configuration file is completely suppressed, non-primary devs
receive notification errors with every build/test of the application. By
removing the user-specific notifications, other devs can now build/test the
application code (via the recipe specified within `appveyor.yml`) without
receiving notification errors.

For any given developer, personalized notification settings can be added on
top of the repo `appveyor.yml` project settings via the "Settings / Notifications"
section.