### PR TITLE
Add `.editorconfig` style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig (is awesome): http://EditorConfig.org
+
+# * top-most EditorConfig file
+root = true
+
+# default style settings
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{bat,cmd,[Bb][Aa][Tt],[Cc][Mm][Dd]]
+# DOS/Win *requires* BAT/CMD files to have CRLF newlines
+end_of_line = crlf
+
+[[Mm]akefile{,.*}]
+# TAB-style indentation
+indent_style = tab


### PR DESCRIPTION
* re-enforce requested project file formats and basic character-level coding style
* emphasize the Win/DOS requirement that BAT/CMD files *must* have CRLF line endings

.# Discussion

Using [EditorConfig](http://editorconfig.org) style rules helps devs to maintain the file formatting and style of the project, even while using different editors. This minimizes the semi-invisible, but, paradoxically, visually noisy, whitespace differences between commits. It can also help enforce file format requirements (such as the Win/DOS CMD shell requiring CRLF line endings for correct functioning of BAT/CMD files).