### PR TITLE
fix/improve Scoop-Alias and Scoop-Core tests

### DIFF
--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -1,12 +1,14 @@
-. "$psscriptroot\..\libexec\scoop-alias.ps1"
+. "$psscriptroot\..\libexec\scoop-alias.ps1" | out-null
 
 reset_aliases
 
 describe "add_alias" {
-  mock shimdir { "test\fixtures\shim" }
+  mock shimdir { "TestDrive:\shim" }
   mock set_config { }
   mock get_config { @{} }
+
   $shimdir = shimdir
+  mkdir $shimdir
 
   context "alias doesn't exist" {
     it "creates a new alias" {
@@ -28,17 +30,15 @@ describe "add_alias" {
       $alias_file | should contain ""
     }
   }
-
-  aftereach {
-    rm "test\fixtures\shim\scoop-rm.ps1" -ea ignore
-  }
 }
 
 describe "rm_alias" {
-  mock shimdir { "test\fixtures\shim" }
-  $shimdir = shimdir
+  mock shimdir { "TestDrive:\shim" }
   mock set_config { }
   mock get_config { @{} }
+
+  $shimdir = shimdir
+  mkdir $shimdir
 
   context "alias exists" {
     it "removes an existing alias" {
@@ -51,9 +51,5 @@ describe "rm_alias" {
       rm_alias "rm"
       $alias_file | should not exist
     }
-  }
-
-  afterall {
-    rm "test\fixtures\shim\scoop-rm.ps1" -ea ignore
   }
 }

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -2,6 +2,8 @@
 . "$psscriptroot\..\lib\install.ps1"
 . "$psscriptroot\Scoop-TestLib.ps1"
 
+$repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
+
 describe "movedir" {
     $extract_dir = "subdir"
     $extract_to = $null
@@ -59,7 +61,9 @@ describe "unzip_old" {
         it "unzips file with zero bytes without error" {
             $to = test-unzip $zerobyte
 
+            $to | should not be $null
             $to | should exist
+
             (gci $to).count | should be 0
         }
     }
@@ -136,7 +140,7 @@ describe "rm_shim" {
 
 describe "ensure_robocopy_in_path" {
     $shimdir = shimdir $false
-    mock versiondir { ".\" }
+    mock versiondir { $repo_dir }
 
     beforeall {
         reset_aliases


### PR DESCRIPTION
* Scoop-Alias: remove erroneous output from dot-sourcing the source file
* Scoop-Alias: using "TestDrive:\" for mocked shimdir
  - reduced cleanup
  - improved robustness; excution is now independent of CWD
* Scoop-Core: corrected directory location code
  - improved robustness; execution is now independent of CWD