### PR TITLE
Increase code robustness/integrity during `scoop update` (for "update code" changes)

### DIFF
--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -1,15 +1,21 @@
 #requires -v 3
-param($cmd)
+param(
+    [parameter(mandatory=$false)][int] $__updateRestart = 0,
+    [parameter(mandatory=$false,position=0)] $__cmd,
+    [parameter(ValueFromRemainingArguments=$true)][array] $__args = @()
+    )
 
 set-strictmode -off
 
 . "$psscriptroot\..\lib\core.ps1"
 . (relpath '..\lib\commands')
 
+$env:SCOOP__updateRestart = $__updateRestart
+
 reset_aliases
 
 $commands = commands
 
-if (@($null, '-h', '--help', '/?') -contains $cmd) { exec 'help' $args }
-elseif ($commands -contains $cmd) { exec $cmd $args }
-else { "scoop: '$cmd' isn't a scoop command. See 'scoop help'"; exit 1 }
+if (@($null, '-h', '--help', '/?') -contains $__cmd) { exec 'help' $__args }
+elseif ($commands -contains $__cmd) { exec $__cmd $__args }
+else { "scoop: '$__cmd' isn't a scoop command. See 'scoop help'"; exit 1 }


### PR DESCRIPTION
* when the update code itself is modified during an update, restart the update
  - allowing only a maximum of N restarts; default: N = 1
* fixes #480

.# Discussion

Updating `scoop` by using `scoop update` is currently implemented as a one-pass, self-modifying process. This update process overwrites the currently executing version with the newest available code. But, if the "update code" itself is modified by the `scoop update` command, it is possible to leave the executable in an inconsistent/"half-complete" state. At least one execution of the new "update code" would be needed to restore consistency.

For example, if the code generating the scoop shim is changed during an update, the shim artifact that is generated will have been generated by the *original code*. This may be inconsistent or incorrect when executed in the context of the newly updated, now current code.

To correct this, `scoop update` should be re-executed if modifications to the "update code" are detected.

It is, of course, possible that additional code modification to the "update code" could again occur if a repository modification occurrs during the restart. But that likelyhood is estimated to be much lower than the likelyhood of a logic error causing uncontrolled looping. So, the number of restarts is capped at N=1. If the likelyhood of a change in the source repository occuring during a `scoop update` becomes significant, then, by increasing the number of restarts allowed, the percentages of each likelyhood can be manipulated so that correct/full execution probability is maximized.

NOTE: "update code" is purposefully used within quotes here because subdividing the code base into partitions of "update-stable"/"update-volatile" is really an NP-complete problem. Theoretically, *any* change to the code base could cause an inconsistency. If that is estimated to be a concern of real significance, arbitrarily re-executing the code for any noted change is also reasonable (again, up to a maximum of N times, for the above reasons).