### PR TITLE
add immediate in-process environment updates for CMD shell

### DIFF
--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -1,15 +1,21 @@
 #requires -v 3
-param($cmd)
+param(
+    [parameter(mandatory=$false)][string] $__CMDenvpipe = $null,
+    [parameter(mandatory=$false,position=0)] $__cmd,
+    [parameter(ValueFromRemainingArguments=$true)][array] $__args = @()
+    )
 
 set-strictmode -off
 
 . "$psscriptroot\..\lib\core.ps1"
 . (relpath '..\lib\commands')
 
+$env:SCOOP__CMDenvpipe = $__CMDenvpipe
+
 reset_aliases
 
 $commands = commands
 
-if (@($null, '-h', '--help', '/?') -contains $cmd) { exec 'help' $args }
-elseif ($commands -contains $cmd) { exec $cmd $args }
-else { "scoop: '$cmd' isn't a scoop command. See 'scoop help'"; exit 1 }
+if (@($null, '-h', '--help', '/?') -contains $__cmd) { exec 'help' $__args }
+elseif ($commands -contains $__cmd) { exec $__cmd $__args }
+else { "scoop: '$__cmd' isn't a scoop command. See 'scoop help'"; exit 1 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -2,6 +2,8 @@ $scoopdir = $env:SCOOP, "~\appdata\local\scoop" | select -first 1
 $globaldir = $env:SCOOP_GLOBAL, "$($env:programdata.tolower())\scoop" | select -first 1
 $cachedir = "$scoopdir\cache" # always local
 
+$CMDenvpipe = $env:SCOOP__CMDenvpipe
+
 # helper functions
 function coalesce($a, $b) { if($a) { return $a } $b }
 function format($str, $hash) {
@@ -84,6 +86,9 @@ function env { param($name,$value,$targetEnvironment)
 
     if($PSBoundParameters.ContainsKey('value')) {
         [environment]::setEnvironmentVariable($name,$value,$targetEnvironment)
+        if (($targetEnvironment -eq [System.EnvironmentVariableTarget]::Process) -and ($CMDenvpipe -ne $null)) {
+            "set " + ( CMD_SET_encode_arg("$name=$value") ) | out-file $CMDenvpipe -encoding OEM -append
+        }
     }
     else { [environment]::getEnvironmentVariable($name,$targetEnvironment) }
 }
@@ -154,6 +159,7 @@ function shim($path, $global, $name, $arg) {
         }
     } elseif($path -match '\.((bat)|(cmd))$') {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH
+        # NOTE: this code transfers execution flow via hand-off, not a call, so any modifications if/while in-progress are safe
         $shim_cmd = "$(strip_ext($shim)).cmd"
         ':: ensure $HOME is set for MSYS programs'           | out-file $shim_cmd -encoding oem
         '@if "%home%"=="" set home=%homedrive%%homepath%\'   | out-file $shim_cmd -encoding oem -append
@@ -162,8 +168,153 @@ function shim($path, $global, $name, $arg) {
     } elseif($path -match '\.ps1$') {
         # make ps1 accessible from cmd.exe
         $shim_cmd = "$(strip_ext($shim)).cmd"
-        "@powershell -noprofile -ex unrestricted `"& '$(resolve-path $path)' %*;exit `$lastexitcode`"" | out-file $shim_cmd -encoding oem
+        # default code; NOTE: only scoop knows about and manipulates shims so, by default, no special care is needed for other apps
+        $code = "@powershell -noprofile -ex unrestricted `"& '$(resolve-path $path)' $arg %* ; exit `$lastexitcode`""
+        if ($name -eq 'scoop') {
+            # shimming self; specialized code is required
+            $code = shim_scoop_cmd_code $shim_cmd $path $arg
+        }
+        $code | out-file $shim_cmd -encoding oem
     }
+}
+
+function shim_scoop_cmd_code($shim_cmd_path, $path, $arg) {
+    # specialized code for the scoop CMD shim
+    # * special handling is needed for in-progress updates
+    # * additional code needed to pipe environment variables back up and into to the original calling CMD process (see shim_scoop_cmd_code_body())
+
+    $CMD_shim_fullpath = resolve-path $shim_cmd_path
+    $CMD_shim_content = Get-Content $CMD_shim_fullpath
+
+    # prefix code ## handle in-progress updating
+    # updating an in-progress BAT/CMD must be done with precise pre-planning to avoid unanticipated execution paths (and associated possible errors)
+    # NOTE: must assume that the scoop CMD shim may be currently executing (since there is no simple way to determine that condition)
+
+    # NOTE: current scoop CMD shim is in one of two states:
+    # 1. update-naive (older) version which calls scoop.ps1 via powershell as the last statement
+    #    - control flow returns to the script, executing from the character position just after the call statement
+    #    - notably, the position is determined *when the call was initially made in the original source* ignoring any script changes
+    # 2. update-enabled version (by using either an exiting line/block or proxy execution) which can be modified without limitation
+
+    $safe_update_signal_text = '*(scoop:#update-enabled)' # "magic" signal string ## the presence of this signal within a shim indicates that it is designed to allow in-progress updates with safety
+
+    $code = "@::$safe_update_signal_text`r`n"
+
+    if (-not ($CMD_shim_content -cmatch [regex]::Escape($safe_update_signal_text))) {
+        # current shim is update-naive
+        $code += '@goto :__START__' + "`r`n"  # embed code for correct future executions; jumps past any buffer segment
+        # buffer the prefix with specifically designed & sized code for safe return/completion of current execution
+        $buffer_text = ''
+        $CMD_shim_original_size = (Get-ChildItem $CMD_shim_fullpath).length
+        $size_diff = $CMD_shim_original_size - $code.length
+        if ($size_diff -lt 0) {
+            # errors may occur upon exiting, ask user for re-run to help normalize the situation
+            warn 'scoop encountered an update inconsistency, please re-run "scoop update"'
+        }
+        elseif ( $size_diff -gt 0 ) {
+            # note: '@' characters, acting as NoOPs, are used to reduce the risk of wrong command execution in the case that we've miscalculated the return/continue location of the execution pointer
+            if ( $size_diff -eq 1 ) { $buffer_text = '@' <# no room for EOL CRLF #>}
+            else { $buffer_text = $('@' * ($size_diff-2)) + "`r`n" }
+        }
+        $code += $buffer_text + '@goto :EOF &:: safely end a returning, and now modified, in-progress script' + "`r`n"
+        $code += '@:__START__' + "`r`n"
+    }
+
+    # body code ## handles update-enabled scoop call and the environment variable pipe
+    $code += shim_scoop_cmd_code_body $(resolve-path $path) $arg
+
+    $code
+}
+
+function shim_scoop_cmd_code_body($path, $arg) {
+# shim startup / initialization code
+$code = '
+@set "ERRORLEVEL="
+@setlocal
+@echo off
+set __ME=%~n0
+
+:: NOTE: flow of control is passed (with *no return*) from this script to a proxy BAT/CMD script; any modification of this script is safe at any execution time after that control hand-off
+
+:: require temporary files
+:: * (needed for both out-of-source proxy contruction and for piping in-process environment variable updates)
+call :_tempfile __oosource "%__ME%.oosource" ".bat"
+if NOT DEFINED __oosource ( goto :TEMPFILE_ERROR )
+call :_tempfile __pipe "%__ME%.pipe" ".bat"
+if NOT DEFINED __pipe ( goto :TEMPFILE_ERROR )
+goto :TEMPFILES_FOUND
+:TEMPFILES_ERROR
+echo %__ME%: ERROR: unable to open needed temporary file(s) [make sure to set TEMP or TMP to an available writable temporary directory {try "set TEMP=%%LOCALAPPDATA%%\Temp"}] 1>&2
+exit /b -1
+:TEMPFILES_FOUND
+'
+# shim code initializing environment pipe
+$code += '
+@::* initialize environment pipe
+echo @:: TEMPORARY source/exec environment pipe [owner: "%~f0"] > "%__pipe%"
+'
+# shim code initializing proxy
+$code += '
+@::* initialize out-of-source proxy and add proxy initialization code
+echo @:: TEMPORARY out-of-source executable proxy [owner: "%~f0"] > "%__oosource%"
+echo (set ERRORLEVEL=) >> "%__oosource%"
+echo setlocal >> "%__oosource%"
+'
+# shim code adding scoop call to proxy
+$code += "
+@::* out-of-source proxy code to call scoop
+echo call powershell -NoProfile -ExecutionPolicy unrestricted -Command ^`"^& '$path' -__CMDenvpipe '%__pipe%' $arg %*^`" >> `"%__oosource%`"
+"
+# shim code adding piping of environment changes and cleanup/exit to proxy
+$code += '
+@::* out-of-source proxy code to source environment changes and cleanup
+echo (set __exit_code=%%ERRORLEVEL%%) >> "%__oosource%"
+echo ^( endlocal >> "%__oosource%"
+echo call ^"%__pipe%^"  >> "%__oosource%"
+echo call erase /q ^"%__pipe%^" ^>NUL 2^>NUL >> "%__oosource%"
+echo start ^"^" /b cmd /c del ^"%%~f0^" ^& exit /b %%__exit_code%% >> "%__oosource%"
+echo ^) >> "%__oosource%"
+'
+# shim code to hand-off execution to the proxy (makes this shim "update-enabled")
+$code += '
+endlocal & "%__oosource%" &:: hand-off to proxy; intentional non-call (no return from proxy) to allow for safe updates of this script
+'
+# shim script subroutines
+$code += '
+goto :EOF
+::#### SUBs
+
+::
+:_tempfile ( ref_RETURN [PREFIX [EXTENSION]])
+:: open a unique temporary file
+:: RETURN == full pathname of temporary file (with given PREFIX and EXTENSION) [NOTE: has NO surrounding quotes]
+:: PREFIX == optional filename prefix for temporary file
+:: EXTENSION == optional extension (including leading ".") for temporary file [default == ".bat"]
+setlocal
+set "_RETval="
+set "_RETvar=%~1"
+set "prefix=%~2"
+set "extension=%~3"
+if NOT DEFINED extension ( set "extension=.bat")
+:: find a temp directory (respect prior setup; default to creating/using "%LocalAppData%\Temp" as a last resort)
+if NOT EXIST "%temp%" ( set "temp=%tmp%" )
+if NOT EXIST "%temp%" ( mkdir "%LocalAppData%\Temp" 2>NUL & cd . & set "temp=%LocalAppData%\Temp" )
+if NOT EXIST "%temp%" ( goto :_tempfile_RETURN )    &:: undefined TEMP, RETURN (with NULL result)
+:: NOTE: this find unique/instantiate loop has an unavoidable race condition (but, as currently coded, the real risk of collision is virtually nil)
+:_tempfile_find_unique_temp
+set "_RETval=%temp%\%prefix%.%RANDOM%.%RANDOM%%extension%" &:: arbitrarily lower risk can be obtained by increasing the number of %RANDOM% entries in the file name
+if EXIST "%_RETval%" ( goto :_tempfile_find_unique_temp )
+:: instantiate tempfile
+set /p OUTPUT=<nul >"%_RETval%"
+:_tempfile_find_unique_temp_DONE
+:_tempfile_RETURN
+endlocal & set %_RETvar%^=%_RETval%
+goto :EOF
+::
+
+goto :EOF
+'
+$code
 }
 
 function ensure_in_path($dir, $global) {
@@ -275,3 +426,23 @@ function reset_aliases() {
     # set default aliases
     $default_aliases.keys | % { reset_alias $_ $default_aliases[$_] }
 }
+
+function CMD_SET_encode_arg {
+    # CMD_SET_encode_arg( @ )
+    # encode string(s) to equivalent CMD command line interpretable version(s) as arguments for SET
+    if ($args -ne $null) {
+        $args | ForEach-Object {
+            $val = $_
+            $val = $($val -replace '\^','^^')
+            $val = $($val -replace '\(','^(')
+            $val = $($val -replace '\)','^)')
+            $val = $($val -replace '<','^<')
+            $val = $($val -replace '>','^>')
+            $val = $($val -replace '\|','^|')
+            $val = $($val -replace '&','^&')
+            $val = $($val -replace '"','^"')
+            $val = $($val -replace '%','^%')
+            $val
+            }
+        }
+    }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -527,16 +527,16 @@ function rm_shims($manifest, $global) {
 
 # to undo after installers add to path so that scoop manifest can keep track of this instead
 function ensure_install_dir_not_in_path($dir, $global) {
-    $path = (env 'path' $global)
+    $path = (env 'path' -t $global)
 
     $fixed, $removed = find_dir_or_subdir $path "$dir"
     if($removed) {
         $removed | % { "installer added $(friendly_path $_) to path, removing"}
-        env 'path' $global $fixed
+        env 'path' -t $global $fixed
     }
 
     if(!$global) {
-        $fixed, $removed = find_dir_or_subdir (env 'path' $true) "$dir"
+        $fixed, $removed = find_dir_or_subdir (env 'path' -t $true) "$dir"
         if($removed) {
             $removed | % { warn "installer added $_ to system path: you might want to remove this manually (requires admin permission)"}
         }
@@ -570,12 +570,12 @@ function add_first_in_path($dir, $global) {
     $dir = fullpath $dir
 
     # future sessions
-    $null, $currpath = strip_path (env 'path' $global) $dir
-    env 'path' $global "$dir;$currpath"
+    $null, $currpath = strip_path (env 'path' -t $global) $dir
+    env 'path' -t $global "$dir;$currpath"
 
     # this session
     $null, $env:path = strip_path $env:path $dir
-    $env:path = "$dir;$env:path"
+    env 'path' "$dir;$env:path"
 }
 
 function env_rm_path($manifest, $dir, $global) {
@@ -591,8 +591,8 @@ function env_set($manifest, $dir, $global) {
         $manifest.env_set | gm -member noteproperty | % {
             $name = $_.name;
             $val = format $manifest.env_set.$($_.name) @{ "dir" = $dir }
-            env $name $global $val
-            sc env:\$name $val
+            env $name -t $global $val
+            env $name $val
         }
     }
 }
@@ -600,8 +600,8 @@ function env_rm($manifest, $global) {
     if($manifest.env_set) {
         $manifest.env_set | gm -member noteproperty | % {
             $name = $_.name
-            env $name $global $null
-            if(test-path env:\$name) { rm env:\$name }
+            env $name -t $global $null
+            env $name $null
         }
     }
 }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -62,7 +62,7 @@ function update_scoop() {
         popd
     }
 
-    ensure_scoop_in_path
+    ensure_scoop_in_path $false
     shim "$currentdir\bin\scoop.ps1" $false
 
     @(buckets) | % {


### PR DESCRIPTION
**note:** Without PR #484, for this update only, must run `scoop update` twice to get the final working product.

* for CMD shells, during install or update, pass environment changes back up the call stack into the calling CMD shell process
* adds feature parity with the PowerShell shell to the CMD shell
  - allows immediate use of newly installed packages
  - starting a new CMD shell is *no longer required* prior to use of an installed/updated application
  - eg, `scoop install xxx` can be immediately followed by using `xxx`
* uses an environment variable pipe

* fixes #485

* note: variables set within the adjunctive install script are not captured unless the install script uses the env() subroutine
* note: due to increased code complexity, proxy execution is now required for safe CMD shim updating

.# Discussion

When running `scoop install ...` (or `scoop update ...`), environment changes are performed and persisted to the USER or MACHINE store. Within a PowerShell shell, the PROCESS environment is also updated, allowing for immediate use of the installed application (from the same shell command line). But, when used from the CMD shell, `scoop install ...` does not update the PROCESS environment. Because of this, a new CMD shell must be executed to finalize the environment changes and allow use of the installed application.

However, BAT/CMD scripts can persist environment changes to the CMD shell PROCESS environment. By leveraging that ability, it is possible to pass environment updates back up to a calling CMD process via "environment piping". To use "environment piping", a temporary file is created and passed to its child process. The child process adds the environment changes to the temporary file and then exits, returning control to the parent process. The parent process then processes the temporary file, adding the changes to the current CMD shell PROCESS environment.

This does mean that the parent process (the `scoop.cmd` shim) must execute significant code after the child process (the main scoop application) returns. This impacts upon the method used to allow safe modification of the scoop CMD shim during a `scoop update` (see Issue #481 and the solution in commit c86cb30). It is difficult, if not impossible, to construct a parenthesis-block statement which can load the environment changes into the PROCESS environment and then exit cleanly. Because of this, it is necessary to switch to the proxy execution method mentioned in Issue #481 for safe CMD shim updates.