### PR TITLE
Corrected r.json and updated from R 3.1.1 to 3.1.3

### DIFF
--- a/bucket/r.json
+++ b/bucket/r.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://www.r-project.org",
-    "version": "3.1.1",
+    "version": "3.1.3",
     "license": "GPL2",
-    "url": "https://cran.rstudio.com/bin/windows/base/old/3.1.1/R-3.1.1-win.exe",
-    "hash": "ce6fb76612aefc482583fb92f4f5c3cb8e8e3bf1a8dda97df7ec5caf746e53fe",
+    "url": "https://cran.rstudio.com/bin/windows/base/old/3.1.3/R-3.1.3-win.exe",
+    "hash": "08a722d075c30999649ecad82a60cb5375425e6c0f6660e35e08bb803f75633d",
     "innosetup": true,
     "bin": [
         "bin\\r.exe",

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "http://www.r-project.org",
+    "homepage": "https://www.r-project.org",
     "version": "3.1.1",
     "license": "GPL2",
-    "url": "http://cran.rstudio.com/bin/windows/base/R-3.1.1-win.exe",
+    "url": "https://cran.rstudio.com/bin/windows/base/old/3.1.1/R-3.1.1-win.exe",
     "hash": "ce6fb76612aefc482583fb92f4f5c3cb8e8e3bf1a8dda97df7ec5caf746e53fe",
     "innosetup": true,
     "bin": [
@@ -19,7 +19,7 @@ You can remove Powershell's 'r' command with:
 Annoying, right?! You might want to check out Pshazz (scoop install pshazz)--this has a plugin to remove some crazy aliases from Powershell, as well as many other improvements.
 ",
     "checkver": {
-        "url": "http://cran.rstudio.com/bin/windows/base/",
+        "url": "https://cran.rstudio.com/bin/windows/base/",
         "re": "<h1>R-([0-9\\.]+)"
     }
 }


### PR DESCRIPTION
The R 3.1 binaries were moved to an `old` directory on CRAN mirrors, so I updated the URL. I also updated `r.json` to use 3.1.3 instead of 3.1.1.

Note that R 3.2 packages now seem to have `bin/R,1.exe` and `bin/R,2.exe` instead of `bin/R.exe` and `bin/Rscript.exe`, which I am not sure how to handle. Might be a good idea to shim the architecture-dependent executables instead.
