### PR TITLE
PHP bucket upgrade to 5.6.13

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.6.12",
+    "version": "5.6.13",
     "license": "http://www.php.net/license/",
-    "url": "http://windows.php.net/downloads/releases/php-5.6.12-Win32-VC11-x86.zip",
-    "hash": "sha1:107f91cee686e18c695ebaa633efaabca9149d8c",
+    "url": "http://windows.php.net/downloads/releases/php-5.6.13-Win32-VC11-x86.zip",
+    "hash": "sha1: 4ecd51eb865e5c7c5548aab978664d3e5078f2d8",
     "bin": "php.exe",
     "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
     "checkver": {

--- a/bucket/php.json
+++ b/bucket/php.json
@@ -3,7 +3,7 @@
     "version": "5.6.13",
     "license": "http://www.php.net/license/",
     "url": "http://windows.php.net/downloads/releases/php-5.6.13-Win32-VC11-x86.zip",
-    "hash": "sha1: 4ecd51eb865e5c7c5548aab978664d3e5078f2d8",
+    "hash": "sha1:4ecd51eb865e5c7c5548aab978664d3e5078f2d8",
     "bin": "php.exe",
     "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
     "checkver": {


### PR DESCRIPTION
Avoids 404 error on new installs.