### PR TITLE
Update to PHP 5.5.30

### DIFF
--- a/bucket/php55.json
+++ b/bucket/php55.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.5.28",
+    "version": "5.5.30",
     "license": "http://www.php.net/license/",
-    "url": "http://windows.php.net/downloads/releases/php-5.5.28-Win32-VC11-x86.zip",
-    "hash": "sha1:ed8ca7c5726174a04ee50e2cac33e5fabeaacf1f",
+    "url": "http://windows.php.net/downloads/releases/php-5.5.30-Win32-VC11-x86.zip",
+    "hash": "sha1:a0e94993cb5544104b5f76159fc96be8f5c8de39",
     "bin": "php.exe",
     "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
     "checkver": {


### PR DESCRIPTION
it will avoid errors when pulling PHP 5.5 via Scoop. 