### PR TITLE
Fix hash for gibo

### DIFF
--- a/bucket/gibo.json
+++ b/bucket/gibo.json
@@ -3,9 +3,9 @@
     "homepage": "https://github.com/simonwhitaker/gibo",
     "license": "https://github.com/simonwhitaker/gibo/blob/master/UNLICENSE",
     "description": "gibo (short for .gitignore boilerplates) is a shell script to help you easily access .gitignore boilerplates from github.com/github/gitignore.",
-    "url": "https://github.com/simonwhitaker/gibo/archive/master.zip",
-    "hash": "b358ab0a2d39e304b3a79660ffebf6b0e99496a8b73854e0d230218cb49fc309",
-    "extract_dir": "gibo-master",
+    "url": "https://github.com/simonwhitaker/gibo/archive/1.0.4.zip",
+    "hash": "868144f463c82ede0159065940b893cd0b586d766b1349caa62faa2ec5d940fc",
+    "extract_dir": "gibo-1.0.4",
     "bin": [
         "gibo.bat"
     ]


### PR DESCRIPTION
When i try to install gibo, the following error occurred.

```posh
> scoop install gibo
installing gibo (1.0.4)
downloading https://github.com/simonwhitaker/gibo/archive/master.zip...done
checking hash...hash check failed for https://github.com/simonwhitaker/gibo/archive/master.zip. expected: b358ab0a2d39e304b3a79660ffebf6b0e99496a8b73854e0d230218cb49fc309, actual: 998c45acb27cd7bca5381312e5be360d85523f2bf849a69f39285c853243c1b3!
```

This pr specifies version 1.0.4 url to prevent hash check error.