### PR TITLE
Fix hashes for git and ruby

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/git-for-windows/git/releases/download/v2.6.1.windows.1/PortableGit-2.6.1-64-bit.7z.exe#/dl.7z",
-            "hash": "4e1d75f04d080cba8e798806f0c01f80a5c421445ab9d10c517e5f6dae702543"
+            "hash": "5118b86924fd586caa1f31ebda2d71ed4f7c18ba6c0df4a71f06b90d625837e8"
         },
         "32bit": {
             "url": "https://github.com/git-for-windows/git/releases/download/v2.6.1.windows.1/PortableGit-2.6.1-32-bit.7z.exe#/dl.7z",
-            "hash": "27ad060b636cfc0feacf6cef25ddf3eb7ce7fb9ffcd8d53e4223ec5e61f44323"
+            "hash": "ec7fcd8e04835ecf0ce03eaecf74f437b4412f4b0e022573539ba7b2eba7b912"
         }
     },
     "bin": [ "cmd\\git.exe", "cmd\\gitk.exe", "cmd\\git-gui.exe" ],

--- a/bucket/ruby.json
+++ b/bucket/ruby.json
@@ -8,7 +8,7 @@
                 "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe#/dl2.7z"
             ],
             "hash": [
-                "07c586fce3394c77736bae63594385dcaf67e8f5c331df460aaee2d5f049122d",
+                "683270a7e09ef756476c00902eda9999137468eb21a371831b7c01602d2fd069",
                 "2ada04c7234199126c0f34f6ea7163a8f8dccb1e15814af175a189f6ac48b8ac"
             ],
             "extract_dir": "ruby-2.2.3-x64-mingw32"
@@ -19,7 +19,7 @@
                 "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe#/dl2.7z"
             ],
             "hash": [
-                "58bb5487c9cfe79ba5a3ea0b2719e71879cf1e9b8028a36f0bd842f0c27005c1",
+                "08b33a85ec26c01a6d305a258680976b57081e22ad9196623c1cf154e558e3ce",
                 "61a06b5da06dd94343e591163ac0d43c544e9cd4df770f01275645b268b44dc7"
             ],
             "extract_dir": "ruby-2.2.3-i386-mingw32"


### PR DESCRIPTION
Scoop failed to update git and ruby for me due to hash mismatches. I manually downloaded the files that failed the hash check and checked them myself, then corrected the hashes in the JSON files.