### PR TITLE
Updates Rust to 1.4.0, adds MSVC variant

### DIFF
--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "http://www.rust-lang.org",
+    "version": "1.4.0",
+    "license": "MIT/Apache 2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://static.rust-lang.org/dist/rust-1.4.0-x86_64-pc-windows-msvc.msi",
+            "hash": "ad1f8fd20384912d511728593eb22018461df35378c96b33b80276dfc5d76ca8"
+        }
+    },
+    "bin": [
+        "Rust\\bin\\rustc.exe",
+        "Rust\\bin\\rustdoc.exe",
+        "Rust\\bin\\cargo.exe"
+    ],
+    "checkver": "<h2>Docs \\(([0-9\\.]+)\\)</h2>"
+}

--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.rust-lang.org",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.3.0-i686-pc-windows-gnu.msi",
-            "hash": "711aff8d9b130f9dcaeb6fcc23066405a8db177f70d91a7689c80d0d220311b6"
+            "url": "https://static.rust-lang.org/dist/rust-1.4.0-i686-pc-windows-gnu.msi",
+            "hash": "f6f688bf5b8bad28992ed86e532f798c0333dbd5958040d2e610709b14c0afef"
         },
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.3.0-x86_64-pc-windows-gnu.msi",
-            "hash": "44a3acf40bb860fcbd152cf4bf5ad5f4a5224d451cbf5daa518d5c2907722729"
+            "url": "https://static.rust-lang.org/dist/rust-1.4.0-x86_64-pc-windows-gnu.msi",
+            "hash": "886416c96dba7acefc075a608a9fe36bf74c09343a183a9fb321104ddd9e09a0"
         }
     },
     "bin": [


### PR DESCRIPTION
My one concern about this at the moment is that the MSVC version of the compiler only supports x86_64 in this release, is there anything that should be done about this?