### PR TITLE
Update Pshazz app to latest commit

### DIFF
--- a/bucket/pshazz.json
+++ b/bucket/pshazz.json
@@ -1,8 +1,8 @@
 {
-    "version": "0.2014.11.25",
-    "url": "https://github.com/lukesampson/pshazz/archive/3b7b426320e42718b7ef3b0ebf9bbe06c6ee0430.zip",
-    "extract_dir": "pshazz-3b7b426320e42718b7ef3b0ebf9bbe06c6ee0430",
-    "hash": "b8ee4ccffa719bbe97b47856457592f13ce4103e92b6bb41ff421a00f21bb08a",
+    "version": "0.2015.11.10",
+    "url": "https://github.com/lukesampson/pshazz/archive/33620d2ead54dd2c27f05ef60833f0597e1ae978.zip",
+    "extract_dir": "pshazz-33620d2ead54dd2c27f05ef60833f0597e1ae978",
+    "hash": "71825ce737c857c52203696a01f26776e8715014a392cb1a497961f7051d4da3",
     "bin": [ "bin\\pshazz.ps1", "libexec\\askpass.exe" ],
     "installer": { "file": "bin\\install.ps1" }
 }


### PR DESCRIPTION
I'm just not sure about *hash* because as is written in https://github.com/lukesampson/scoop/wiki/App-Manifests I made SHA256 hash of URL, but as I tried SHA256 on original URL from app manifest then result was not `b8ee4ccffa719bbe97b47856457592f13ce4103e92b6bb41ff421a00f21bb08a`.

Did I do something wrong?

Thanks!