### PR TITLE
+php 5.6.15, +curl 7.45.0, +nginx 1.9.6, -php52

### DIFF
--- a/bucket/curl.json
+++ b/bucket/curl.json
@@ -1,17 +1,17 @@
 {
     "homepage": "http://curl.haxx.se/",
-    "version": "7.43.0",
+    "version": "7.45.0",
     "licence": "MIT",
     "architecture": {
         "64bit": {
-            "url": "http://www.confusedbycode.com/curl/curl-7.43.0-win64.zip",
-            "hash": "ef2eb41ddfbecd7ec4b186decdf7a9257894eb3f75b9624460a1bb34e4941019",
-            "extract_dir": "curl-7.43.0-win64"
+            "url": "http://www.confusedbycode.com/curl/curl-7.45.0-win64.zip",
+            "hash": "880ebdb790effa1b28e7fd2d26b18941efb9b167f336baa3d789bc226f0a05eb",
+            "extract_dir": "curl-7.45.0-win64"
         },
         "32bit": {
-            "url": "http://www.confusedbycode.com/curl/curl-7.43.0-win32.zip",
-            "hash": "0ff74737d4df54a955c8cb2689dd27abd0e835210951c4401825e95a95273690",
-            "extract_dir": "curl-7.43.0-win32"
+            "url": "http://www.confusedbycode.com/curl/curl-7.45.0-win32.zip",
+            "hash": "ae3e468a14bfdf28babc12aa605bf94f45c750fa5aa97b0aaccf05d5d8dae43e",
+            "extract_dir": "curl-7.45.0-win32"
         }
     },
     "bin": "bin/curl.exe",

--- a/bucket/nginx.json
+++ b/bucket/nginx.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://nginx.org",
-    "version": "1.9.0",
+    "version": "1.9.6",
     "license": "BSD",
-    "url": "http://nginx.org/download/nginx-1.9.0.zip",
-    "hash": "b8fcb510377234fb874d2504e54fe2e7ae09ab8996fe408a3c1a54a709695d65",
-    "extract_dir": "nginx-1.9.0",
+    "url": "http://nginx.org/download/nginx-1.9.6.zip",
+    "hash": "728f857eed412afd136276828295d10b6345c6879e74c0bc8872bbd7a2a55652",
+    "extract_dir": "nginx-1.9.6",
     "bin": "nginx.exe"
 }

--- a/bucket/php-nts.json
+++ b/bucket/php-nts.json
@@ -4,12 +4,12 @@
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.15-Win32-VC11-x64.zip",
-            "hash": "sha1:626aa7ac0642eab2d6167f556fd564e4503e17b8"
+            "url": "http://windows.php.net/downloads/releases/php-5.6.15-nts-Win32-VC11-x64.zip",
+            "hash": "sha1:1108a921c993c0f767aa03262b0f02cab9a83f9b"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.15-Win32-VC11-x86.zip",
-            "hash": "sha1:f33b3a724a0dc8657f868f9f47f3eabcf94ff393"
+            "url": "http://windows.php.net/downloads/releases/php-5.6.15-nts-Win32-VC11-x86.zip",
+            "hash": "sha1:c9f0aefb6add0b0afa9dab1b640333d8a7789a66"
         }
     },
     "bin": "php.exe",

--- a/bucket/php52.json
+++ b/bucket/php52.json
@@ -1,9 +1,0 @@
-{
-    "homepage": "http://windows.php.net",
-    "version": "5.2.9-2",
-    "license": "http://www.php.net/license/",
-    "url": "http://windows.php.net/downloads/releases/archives/php-5.2.9-2-Win32-VC6-x86.zip",
-    "hash": "sha1:6069BC2BEE6928F5B053CDFD65EBF709F902F3CA",
-    "bin": "php.exe",
-    "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\""
-}


### PR DESCRIPTION
**php** 5.6.15 (*including NTS version*)
**curl** 7.45.0
**nginx** 1.9.6
Dropped PHP 5.2 (**php52**) per https://secure.php.net/supported-versions.php