### PR TITLE
Added leiningen.json to /bucket

### DIFF
--- a/bucket/leiningen.json
+++ b/bucket/leiningen.json
@@ -1,0 +1,10 @@
+{
+    "version": "2.5.3",
+    "license": "Eclipse Public License 1.0",
+    "url": "https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat",
+    "homepage": "https://github.com/technomancy/leiningen",
+    "bin": "lein.bat",
+    "hash": "8f2b72f66e7522005394b5640c876fe52db7f1fdd31f15f94392839c7c81725a",
+    "notes": "The command 'lein self-install' is required to complete the installation"
+}
+


### PR DESCRIPTION
JSON config for installing leiningen (Clojure) via Scoop. Originally found the how-to details at this blog: `http://offbytes.com/2015/02/03/scoop-leiningen.html`