### PR TITLE
PHP updated to 5.6.16

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.6.15",
+    "version": "5.6.16",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.15-Win32-VC11-x64.zip",
-            "hash": "sha1:626aa7ac0642eab2d6167f556fd564e4503e17b8"
+            "url": "http://windows.php.net/downloads/releases/php-5.6.16-Win32-VC11-x64.zip",
+            "hash": "sha1:d9151cdafe6c3e95401d4294da2db94d7dcd28ed"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.15-Win32-VC11-x86.zip",
-            "hash": "sha1:f33b3a724a0dc8657f868f9f47f3eabcf94ff393"
+            "url": "http://windows.php.net/downloads/releases/php-5.6.16-Win32-VC11-x86.zip",
+            "hash": "sha1:3034759a5ffe15eae6c3ef0434f0dc5d279a8c51"
         }
     },
     "bin": "php.exe",


### PR DESCRIPTION
Changed filenames and SHA1 checksums in php.json for 5.6.16 update (current version now returns a 404 when attempting to retrieve).