### PR TITLE
Upgrade to PHP 7.0

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,21 +1,21 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.6.16",
+    "version": "7.0.0",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.16-Win32-VC11-x64.zip",
-            "hash": "sha1:d9151cdafe6c3e95401d4294da2db94d7dcd28ed"
+            "url": "http://windows.php.net/downloads/releases/php-7.0.0-Win32-VC14-x64.zip",
+            "hash": "sha1:651a0aad1522ea8c6568f3153f0a4de742d880be"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.16-Win32-VC11-x86.zip",
-            "hash": "sha1:3034759a5ffe15eae6c3ef0434f0dc5d279a8c51"
+            "url": "http://windows.php.net/downloads/releases/php-7.0.0-Win32-VC14-x86.zip",
+            "hash": "sha1:c37a1ce5883c39278eefda624e4bd3821f1af24c"
         }
     },
     "bin": "php.exe",
     "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
     "checkver": {
         "url": "http://windows.php.net/download/",
-        "re": "<h3 id=\"php-5.6\".*?>.*?\\(([0-9\\.]+)\\)</h3>"
+        "re": "<h3 id=\"php-7.0\".*?>.*?\\(([0-9\\.]+)\\)</h3>"
     }
 }


### PR DESCRIPTION
PHP 5.6.16 moves to php56 bucket. Upgrades default install to PHP 7.0.0