### PR TITLE
Fixed an issue with the 32/64 bit versions of R

### DIFF
--- a/bucket/r.json
+++ b/bucket/r.json
@@ -5,11 +5,13 @@
     "url": "https://cran.rstudio.com/bin/windows/base/R-3.2.2-win.exe",
     "hash": "c5ea69d2142b65fc798ef3516c5f669d761010d065a743661341b66825d8348b",
     "innosetup": true,
+    "pre_install": "if ([intptr]::size -eq 8) { $r_arch = \"x64\" } else { $r_arch = \"i386\" }; copy-item -recurse $dir\\bin\\$r_arch $dir\\bin\\curr_arch;",
     "bin": [
-        "bin\\r.exe",
-        "bin\\rscript.exe"
+        "bin\\curr_arch\\r.exe",
+        "bin\\curr_arch\\rterm.exe",
+        "bin\\curr_arch\\rscript.exe"
     ],
-    "notes": "You'll need to type 'r.ps1' or 'r.cmd' to run R, because in Powershell 'r' runs the last command.
+    "notes": "You'll need to type 'r.ps1' or 'r.cmd' to run R, because in Powershell 'r' runs the last command. Alternatively 'rterm' can be used to start the interactive R terminal session.
 
 You can remove Powershell's 'r' command with:
     rm alias:\\r
@@ -17,6 +19,8 @@ You can remove Powershell's 'r' command with:
 ... but this only affects your current session: if you'd like to remove it for all future sessions you need to add the command above to your Powershell profile.
 
 Annoying, right?! You might want to check out Pshazz (scoop install pshazz)--this has a plugin to remove some crazy aliases from Powershell, as well as many other improvements.
+
+If you are on a 64-bit machine then R comes in a 32-bit and a 64-bit version. Currently scoop sets the shims depending on your machine's architecture.
 ",
     "checkver": {
         "url": "https://cran.rstudio.com/bin/windows/base/",


### PR DESCRIPTION
Addresses issue [#589](https://github.com/lukesampson/scoop/issues/589).

The R installer delivers the 32 as well as the 64 bit versions of R. I
added a pre_install to r.json to choose the correct version depending on
the user's architecture.

Additionally I added a new shim for 'rterm.exe' to have an alternative
way to start R without removing the 'r' alias in powershell.