### PR TITLE
add optional "test-time" customization of AppVeyor test runner

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,8 @@ branches:
 
 init:
   - ps: (get-psprovider 'FileSystem').Home = $(pwd)
-  - ps: choco install -y pester
+  - ps: "if($env:APPVEYOR_CHOCO_PESTER_OPTIONS -ne $null) { write-host -f yellow 'NOTE: customized `pester` installation is being used' }"
+  - ps: choco install -y pester $env:APPVEYOR_CHOCO_PESTER_OPTIONS
 
 build: off
 


### PR DESCRIPTION
* add $env:APPVEYOR_CHOCO_PESTER_OPTIONS to the `choco` install command for the `pester`
  test runner within the "appveyor.yml" config file
* NOTE: AppVeyor testing will issue advisory note when the variable is non-NULL

* allows customization of `pester` install, eg, version pinning, without requiring any
  further, future changes to "appveyor.yml", avoiding log noise
* mitigates test failures due solely to the test runner

.# Discussion

This change was implemented in response to multiple automated test failures which occurred due to a regression within the `pester` test runner. The change adds the ability to specify the `pester` version (aka, "version pinning") on AppVeyor via the "test-time" configurable environment variable, $env:APPVEYOR_CHOCO_PESTER_OPTIONS.

By using this configurability, no changes to the project code base are needed when testing with a specific test runner version is needed, eg, when "pester@latest" is bugged. This avoids adding commits, which are otherwise irrelevant to development, to the project history.

To pin a specific version of `pester`, set the "APPVEYOR_CHOCO_PESTER_OPTIONS" environment variable to "--version=M.m.b" (eg, "--version=3.3.11") via the AppVeyor project settings web page; a NULL or missing value will cause the usual installation of "pester@latest".

Notably, this does add a semi-hidden testing dependency. But, if testing is successful for a given setting of the environment variable (eg, empty/NULL or "--version=M.m.b"), it will continue to succeed for tests on subsequent commits. The only caveat is that if some added functionality of a "pester@later" version is used, the remote automated testing might fail due to `pester` being pinned to an earlier version. Because of this, the testing code issues an advisory notation that the test runner installation has been customized whenever the environment variable contains a non-NULL value.