### PR TITLE
Update Apache to 2.4.18

### DIFF
--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://www.apachelounge.com",
-    "version": "2.4.17",
+    "version": "2.4.18",
     "license": "Apache 2.0",
-    "url": "https://www.apachelounge.com/download/VC11/binaries/httpd-2.4.17-win32-VC11.zip",
-    "hash": "7DFE0AD3F58593AE5032B8FE895A3670C1BD8E65D0E56102CA9E879AC2D1E6BF",
+    "url": "https://www.apachelounge.com/download/VC11/binaries/httpd-2.4.18-win32-VC11.zip",
+    "hash": "EAE58A1499BEFD0BFC86F84767AC595633C62C8E7ACE093961AEB1DBE3966086",
     "extract_dir": "Apache24",
     "bin": [
         "bin\\ab.exe",


### PR DESCRIPTION
It is reported in Issue [#629](https://github.com/lukesampson/scoop/issues/629). The url was out of date.