### PR TITLE
Start implementing support for installing specific versions

### DIFF
--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -14,6 +14,7 @@
 # Options:
 #   -a, --arch <32bit|64bit>  use the specified architecture, if the app supports it
 #   -g, --global              install the app globally
+#   -v, --version             install a specific version
 
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
@@ -41,9 +42,10 @@ function ensure_none_installed($apps, $global) {
     }
 }
 
-$opt, $apps, $err = getopt $args 'ga:' 'global', 'arch='
+$opt, $apps, $err = getopt $args 'ga:v:' 'global', 'arch=', 'version='
 if($err) { "scoop install: $err"; exit 1 }
 
+$version = $opt.v + $opt.version
 $global = $opt.g -or $opt.global
 $architecture = ensure_architecture $opt.a + $opt.arch
 
@@ -59,6 +61,6 @@ $apps = install_order $apps $architecture # adds dependencies
 ensure_none_failed $apps $global
 $apps = prune_installed $apps $global # removes dependencies that are already installed
 
-$apps | % { install_app $_ $architecture $global }
+$apps | % { install_app $_ $architecture $global $version }
 
 exit 0

--- a/libexec/scoop-versions.ps1
+++ b/libexec/scoop-versions.ps1
@@ -7,10 +7,17 @@ param($app)
 . "$psscriptroot\..\lib\install.ps1"
 . "$psscriptroot\..\lib\buckets.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
+. "$psscriptroot\..\lib\versions.ps1"
+
+function script:reverse {
+    $arr = @($input)
+    [array]::reverse($arr)
+    $arr
+}
 
 $history = app_history $app
 $versions = $history | select -expandproperty version
 if ($versions) {
     "versions of $app available:"
-    $versions |% { "  $_" }
+    sort_versions $versions | reverse |% { "  $_" }
 }

--- a/libexec/scoop-versions.ps1
+++ b/libexec/scoop-versions.ps1
@@ -1,0 +1,16 @@
+# Usage: scoop versions <app>
+# Summary: List available versions for <app>
+# Help: 'scoop versions' lists all the available versions of the given app within scoop
+
+param($app)
+
+. "$psscriptroot\..\lib\install.ps1"
+. "$psscriptroot\..\lib\buckets.ps1"
+. "$psscriptroot\..\lib\manifest.ps1"
+
+$history = app_history $app
+$versions = $history | select -expandproperty version
+if ($versions) {
+    "versions of $app available:"
+    $versions |% { "  $_" }
+}

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -1,6 +1,8 @@
 . "$psscriptroot\Scoop-TestLib.ps1"
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\install.ps1"
+. "$psscriptroot\..\lib\buckets.ps1"
+. "$psscriptroot\..\lib\manifest.ps1"
 
 describe "travel_dir" {
     beforeall {
@@ -39,5 +41,13 @@ describe "travel_dir" {
 
     it 'common file remains unchanged in destination' {
         "$to\common_file.txt" | should contain "version 1.1"
+    }
+}
+
+describe "app history" {
+    it "gets all current and previous manifests of an app" {
+        $history = app_history python
+        $history | should not benullorempty
+        write-host $history
     }
 }


### PR DESCRIPTION
By leveraging `git rev-list` and `git show` I discovered that it was
possible to crawl the git history and get the json manifests for the
entire history of an app.

From there it was just a matter of parsing the json into an array of
manifests and patching support into `scoop install`. I also added a
rudimentary `scoop versions <app>` which will list all the versions of
the particular app from git history

I haven't tested all the edge cases yet so this is strictly WIP. 

Fixes #538 
