### PR TITLE
Feature/lessmsi install

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -6,6 +6,15 @@ function requires_7zip($manifest, $architecture) {
     }
 }
 
+function requires_lessmsi ($manifest, $architecture) {
+    $useLessMsi = get_config MSIEXTRACT_USE_LESSMSI
+    if (!$useLessMsi) { return $false }
+
+    $(url $manifest $architecture |? {
+        $_ -match '\.(msi)$'
+    } | measure | select -exp count) -gt 0
+}
+
 function file_requires_7zip($fname) {
     $fname -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(7z)|(rar)|(iso)|(xz))$'
 }

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -47,6 +47,7 @@ function install_deps($manifest, $arch) {
     $deps = @()
 
     if(requires_7zip $manifest $arch) { $deps += "7zip" }
+    if(requires_lessmsi $manifest $arch) { $deps += "lessmsi" }
     if($manifest.innosetup) { $deps += "innounp" }
 
     $deps

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -206,13 +206,7 @@ function dl_urls($app, $version, $manifest, $architecture, $dir, $use_cache = $t
             if(!$msi) {
                 $useLessMsi = get_config MSIEXTRACT_USE_LESSMSI
                 if ($useLessMsi -eq $true) {
-                    $extract_fn = 'extract_lessmsi'
-                    if ($extract_dir) {
-                        $extract_dir = join-path SourceDir $extract_dir
-                    }
-                    else {
-                        $extract_dir = "SourceDir"
-                    }
+                    $extract_fn, $extract_dir = lessmsi_config $extract_dir
                 }
                 else {
                     $extract_fn = 'extract_msi'
@@ -255,6 +249,18 @@ function dl_urls($app, $version, $manifest, $architecture, $dir, $use_cache = $t
     }
 
     $fname # returns the last downloaded file
+}
+
+function lessmsi_config ($extract_dir) {
+    $extract_fn = 'extract_lessmsi'
+    if ($extract_dir) {
+        $extract_dir = join-path SourceDir $extract_dir
+    }
+    else {
+        $extract_dir = "SourceDir"
+    }
+
+    $extract_fn, $extract_dir
 }
 
 function cookie_header($cookies) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -204,12 +204,18 @@ function dl_urls($app, $version, $manifest, $architecture, $dir, $use_cache = $t
             # check manifest doesn't use deprecated install method
             $msi = msi $manifest $architecture
             if(!$msi) {
-                $extract_fn = 'extract_lessmsi'
-                if ($extract_dir) {
-                    $extract_dir = join-path SourceDir $extract_dir
+                $useLessMsi = get_config MSIEXTRACT_USE_LESSMSI
+                if ($useLessMsi -eq $true) {
+                    $extract_fn = 'extract_lessmsi'
+                    if ($extract_dir) {
+                        $extract_dir = join-path SourceDir $extract_dir
+                    }
+                    else {
+                        $extract_dir = "SourceDir"
+                    }
                 }
                 else {
-                    $extract_dir = "SourceDir"
+                    $extract_fn = 'extract_msi'
                 }
             } else {
                 warn "MSI install is deprecated. If you maintain this manifest, please refer to the manifest reference docs"

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -204,7 +204,13 @@ function dl_urls($app, $version, $manifest, $architecture, $dir, $use_cache = $t
             # check manifest doesn't use deprecated install method
             $msi = msi $manifest $architecture
             if(!$msi) {
-                $extract_fn = 'extract_msi'
+                $extract_fn = 'extract_lessmsi'
+                if ($extract_dir) {
+                    $extract_dir = join-path SourceDir $extract_dir
+                }
+                else {
+                    $extract_dir = "SourceDir"
+                }
             } else {
                 warn "MSI install is deprecated. If you maintain this manifest, please refer to the manifest reference docs"
             }
@@ -406,6 +412,10 @@ function extract_msi($path, $to) {
     $ok = run 'msiexec' @('/a', "`"$path`"", '/qn', "TARGETDIR=`"$to`"", "/lwe `"$logfile`"")
     if(!$ok) { abort "failed to extract files from $path.`nlog file: $(friendly_path $logfile)" }
     if(test-path $logfile) { rm $logfile }
+}
+
+function extract_lessmsi($path, $to) {
+    iex "lessmsi x `"$path`" `"$to\`""
 }
 
 # deprecated


### PR DESCRIPTION
I have been having problems with `msiexec` on my machine where it just can't extract or install anything. Having discovered `lessmsi` I wanted to see if it would work in `msiexec`'s place, and it does

If you set `MSIEXTRACT_USE_LESSMSI` to `$true` using `scoop config`, it will use `lessmsi` over `msiexec`.