### PR TITLE
Update path to scoop-extras

### DIFF
--- a/buckets.json
+++ b/buckets.json
@@ -1,5 +1,5 @@
 {
-    "extras": "https://github.com/lukesampson/extras.git",
+    "extras": "https://github.com/lukesampson/scoop-extras.git",
     "versions": "https://github.com/scoopinstaller/versions",
     "nightlies": "https://github.com/scoopinstaller/nightlies",
     "nirsoft": "https://github.com/kodybrown/scoop-nirsoft"


### PR DESCRIPTION
Seems like you renamed the extras repo? Failed for me at least, had to add it manually with name and the complete adress.