### PR TITLE
Changed $scoopdir to use $env:LOCALAPPDATA\scoop from ~\appdata\local\scoop

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1,4 +1,4 @@
-$scoopdir = $env:SCOOP, "~\appdata\local\scoop" | select -first 1
+$scoopdir = $env:SCOOP, "$env:LOCALAPPDATA\scoop" | select -first 1
 $globaldir = $env:SCOOP_GLOBAL, "$($env:programdata.tolower())\scoop" | select -first 1
 $cachedir = "$scoopdir\cache" # always local
 


### PR DESCRIPTION
If the `SCOOP` environment variable is not set, scoop will install to the users home directory. In cases where an organization has decided to set a users home directory to another location, such as network drive, the use of `~\appdata\local\scoop` will cause scoop to perform poorly as it will install itself on the network drive. By using `$env:LOCALAPPDATA\scoop` will use users home directory on the local drive even if the `HOMEDRIVE` has been set to use a remote volume. 