### PR TITLE
Bumped versions for Git and Node.js

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.7.0.windows.1",
+    "version": "2.7.1.windows.2",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.0.windows.1/PortableGit-2.7.0-64-bit.7z.exe#/dl.7z",
-            "hash": "d7cf3f8ceef88b824fd7dfa476e2bbffd1bff0011b7577bc864e7fbb61fb95f1"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.1.windows.2/PortableGit-2.7.1.2-64-bit.7z.exe#/dl.7z",
+            "hash": "92310dec60b0210acbfb31a0165f2628757b8413efcbcea1cfc95b2984a974dd"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.0.windows.1/PortableGit-2.7.0-32-bit.7z.exe#/dl.7z",
-            "hash": "d1d46375004451beceb15c33c4807d50c925c039173df9f4bd0de0c01cd0f30c"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.1.windows.2/PortableGit-2.7.1.2-32-bit.7z.exe#/dl.7z",
+            "hash": "7bf8da2b46f40c98d18a5f9c36e5b90df258936f43a0d230d0f29e0d729e3283"
         }
     },
     "bin": [ "cmd\\git.exe", "cmd\\gitk.exe", "cmd\\git-gui.exe" ],

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "5.5.0",
+    "version": "5.6.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v5.5.0/node-v5.5.0-x64.msi",
-            "hash": "ba1dcd3035b045fb4ecb254bab1e0dda24934f2a773e6e05d0a54ac4adc4ee3b"
+            "url": "https://nodejs.org/dist/v5.6.0/node-v5.6.0-x64.msi",
+            "hash": "dd4734d61ed2da37c114cdecfee298a6dc3cffc2c3a7c7998a74ea1428a4f667"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v5.5.0/node-v5.5.0-x86.msi",
-            "hash": "40b667ca279927aacbf65f32f0a3400ff2aba15db46fd3eb1a1d8b94b182bb12"
+            "url": "https://nodejs.org/dist/v5.6.0/node-v5.6.0-x86.msi",
+            "hash": "13f816a2b53a337721414577881a0786240ff53e26d687a4dbde17fbce9e1b15"
         }
     },
     "env_add_path": "nodejs",

--- a/bucket/nodejs4.json
+++ b/bucket/nodejs4.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "4.2.6",
+    "version": "4.3.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v4.2.6/node-v4.2.6-x64.msi",
-            "hash": "31556639d865e20fabe104dfe36ce148b4d046d00b35122a7261ff03ed5ded3a"
+            "url": "https://nodejs.org/dist/v4.3.0/node-v4.3.0-x64.msi",
+            "hash": "48d2a640d8d7f390cbe7f5e6ddb5a0240f1a5e49e1d6f97f222bc54a69773238"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v4.2.6/node-v4.2.6-x86.msi",
-            "hash": "854cda9bc59eb44a8bb8486b201aa2873fe6ae2b802cbaced8b83e6b4ec3c170"
+            "url": "https://nodejs.org/dist/v4.3.0/node-v4.3.0-x86.msi",
+            "hash": "eb22e601c152b0ebad11e4ddd24b777aff6e36c8e0de92f9a088959cad3d0f47"
         }
     },
     "env_add_path": "nodejs",


### PR DESCRIPTION
Updated Git from `2.7.0.windows.1` to version `2.7.1.windows.2` and bumped Node.js to `5.6.0` and `4.3.0`