### PR TITLE
Correct the MD5 hash for 0.6.0 forge release

### DIFF
--- a/bucket/forge.json
+++ b/bucket/forge.json
@@ -2,7 +2,7 @@
     "homepage": "http://fsprojects.github.io/Forge/",
     "version": "0.6.0",
     "url": "https://github.com/fsprojects/Forge/releases/download/0.6.0/forge.zip",
-    "hash": "md5:66316278C884B8C00D167DC78255528B",
+    "hash": "md5:B71ADC9850E3D3EE13A9C2664E1EB36B",
     "bin": [
         "bin\\forge.exe"
     ]


### PR DESCRIPTION
Regenerated the hash for forge as the MD5 hash currently mismatches. This issue has been raised in the Forge repo https://github.com/fsprojects/Forge/issues/47