### PR TITLE
Update go to 1.6

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -1,15 +1,15 @@
 {
-    "version": "1.5.3",
+    "version": "1.6",
     "homepage": "http://golang.org",
     "license": "http://golang.org/LICENSE",
     "architecture": {
         "64bit": {
-            "url": "https://storage.googleapis.com/golang/go1.5.3.windows-amd64.zip",
-            "hash": "0a863ba10560c51fa6c4d4ad1180abbc3220b7ecd41159160c322f0b19e06460"
+            "url": "https://storage.googleapis.com/golang/go1.6.windows-amd64.zip",
+            "hash": "1be06afa469666d636a00928755c4bcd6403a01f5761946b2b13b8a664f86bac"
         },
         "32bit": {
-            "url": "https://storage.googleapis.com/golang/go1.5.3.windows-386.zip",
-            "hash": "f35cefa3f834611611249bc6607df804b0bb81ce06e444078e1fa00a1d811e06"
+            "url": "https://storage.googleapis.com/golang/go1.6.windows-386.zip",
+            "hash": "ac41a46f44d0ea5b83ad7e6a55ee1d58c6a01b7ab7342e243f232510342f16f0"
         }
     },
     "extract_dir": "go",


### PR DESCRIPTION
Go 1.6 just [shipped](http://blog.golang.org/go1.6) so let's update the bucket.