### PR TITLE
Update rust.json

### DIFF
--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.rust-lang.org",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.5.0-i686-pc-windows-gnu.msi",
-            "hash": "e9b78afcd621e14511f44aa83be7640eecb76151abc2310b961ac7d3050b54fb"
+            "url": "https://static.rust-lang.org/dist/rust-1.6.0-i686-pc-windows-gnu.msi",
+            "hash": "ce75afffd28534a35d9960044578031fa59dc47887d3e407e6dfacf96ee316f9"
         },
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.5.0-x86_64-pc-windows-gnu.msi",
-            "hash": "6ef0732c1c09fc190bc1a897dda067605782bb19b56d59af84a185cf872511a9"
+            "url": "https://static.rust-lang.org/dist/rust-1.6.0-x86_64-pc-windows-gnu.msi",
+            "hash": "29ef477abae7a40080a4870e8a01d91019aef679749cca25f36a188560c2fe34"
         }
     },
     "bin": [


### PR DESCRIPTION
Rust 1.6.0 [shipped](http://blog.rust-lang.org/2016/01/21/Rust-1.6.html) January 21 so let's update the bucket.