### PR TITLE
Update rust-msvc to 1.6.0

### DIFF
--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -1,11 +1,11 @@
 {
     "homepage": "http://www.rust-lang.org",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.5.0-x86_64-pc-windows-msvc.msi",
-            "hash": "186339748eb83dbb588231f66511134b77ac93bdcf41e330954e51b04edf467e"
+            "url": "https://static.rust-lang.org/dist/rust-1.6.0-x86_64-pc-windows-msvc.msi",
+            "hash": "b83a3839d87267185862ff2ec6d2955b15318b5134f59c6b9fa435f7f5911374"
         }
     },
     "bin": [


### PR DESCRIPTION
Let's update the MSVC ABI build of Rust 1.6.0 as well.