### PR TITLE
Fix ruby19 to include omitted hash from URL's

### DIFF
--- a/bucket/ruby19.json
+++ b/bucket/ruby19.json
@@ -2,8 +2,8 @@
     "homepage": "http://rubyinstaller.org",
     "version": "1.9.3-p551",
     "url": [
-        "http://dl.bintray.com/oneclick/rubyinstaller/ruby-1.9.3-p551-i386-mingw32.7z",
-        "http://dl.bintray.com/oneclick/rubyinstaller/DevKit-tdm-32-4.5.2-20111229-1559-sfx.exe"
+        "http://dl.bintray.com/oneclick/rubyinstaller/ruby-1.9.3-p551-i386-mingw32.7z?direct#/dl.7z",
+        "http://dl.bintray.com/oneclick/rubyinstaller/DevKit-tdm-32-4.5.2-20111229-1559-sfx.exe#/dl2.7z"
     ],
     "hash": [
         "207fdb5b2f9436ad1ac27bf51918b913c14c443d1b83cd910cf5a59acaeab756",


### PR DESCRIPTION
It looks like omitting the hash from the Ruby DevKit URL's caused them not to extract properly to the devkit folder.  I'm adding the hash URL's back in.