### PR TITLE
Update rust to 1.7.0

### DIFF
--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.rust-lang.org",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.6.0-i686-pc-windows-gnu.msi",
-            "hash": "ce75afffd28534a35d9960044578031fa59dc47887d3e407e6dfacf96ee316f9"
+            "url": "https://static.rust-lang.org/dist/rust-1.7.0-i686-pc-windows-gnu.msi",
+            "hash": "8c16b9a48228b3a4af8b099fb4d4043656fa92aa50daf9d60bbc4c2d2bdc3ae1 "
         },
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.6.0-x86_64-pc-windows-gnu.msi",
-            "hash": "29ef477abae7a40080a4870e8a01d91019aef679749cca25f36a188560c2fe34"
+            "url": "https://static.rust-lang.org/dist/rust-1.7.0-x86_64-pc-windows-gnu.msi",
+            "hash": "495a4926e28217c0a7c2feb3a773c10445ead6d49c4281fdb21d037487be1cb1"
         }
     },
     "bin": [


### PR DESCRIPTION
[Rust 1.7](http://blog.rust-lang.org/2016/03/02/Rust-1.7.html) was just released so here's an update.