### PR TITLE
Use standard (not ssl) mongodb version

### DIFF
--- a/bucket/mongodb.json
+++ b/bucket/mongodb.json
@@ -4,9 +4,9 @@
     "license": "http://www.mongodb.org/about/licensing/",
     "architecture": {
         "64bit": {
-            "url": "https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-3.2.4.zip",
-            "hash": "f875b23d25a7cc23c8e2b469c8a75bb9cc892b00a77288230cb3991bcf336ede",
-            "extract_dir": "mongodb-win32-x86_64-2008plus-ssl-3.2.4"
+            "url": "https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-3.2.4.zip",
+            "hash": "89a9f49a4fcc4ca9e5051ef33330cbeccca86c07d5ecbef4ea5cc3b7a43a9faa",
+            "extract_dir": "mongodb-win32-x86_64-3.2.4"
         },
         "32bit": {
             "url": "https://fastdl.mongodb.org/win32/mongodb-win32-i386-3.2.4.zip",


### PR DESCRIPTION
The current manifest points to the `2008plus-ssl` distribution, which doesn't work for me. I get this error when I try to execute `mongodb.exe`: *"The ordinal 341 could not be located in the dynamic link library C:\Users\William\AppData\Local\scoop\apps\mongodb\3.2.3\bin\mongod.exe"*. (The error can be solve by downloading some ssl libraries as described [here](http://stackoverflow.com/a/34020010). But then I might as well install mongodb manually).

Using the normal distribution fixes this problem.

Of course this is no good for people who need the ssl version. So maybe there should be a separate manifest for that?

