### PR TITLE
Update Apache checksums/hashes

### DIFF
--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip",
-            "hash": "DC71519467DBB49229FEE7C789118B809AC2FFC0ED5F8BADA6C956DF3A4AF337"
+            "hash": "543AFF046B0EA2BF58BE76D7D20FCD1FA16EEC9AE836CA4639FEB1C2A7E09CFA"
         },
         "32bit": {
             "url": "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip",
-            "hash": "C42E2D9B9DD58AB64890BA2D871CAC22FB043A3C3361644B2325CAFEFF5EDBE5"
+            "hash": "2259BEA85CBCB4E9E525BFFF0863B4AE3EAE5F91FDDB153191FD310575A04F38"
         }
     },
     "extract_dir": "Apache24",


### PR DESCRIPTION
The checksums/hashes provided in the current manifest are wrong according to the Apache Lounge website ([64-bit](https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip.txt), [32-bit](https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip.txt)), and attempting to execute `scoop install apache` yields an error that the hash check failed.

There could have been a silent update or just old hashes kept when updating versions, but either way this change should fix the problem.