### PR TITLE
Add mysql app manifest

### DIFF
--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -23,7 +23,6 @@
 		"bin\\mysqlimport.exe",
 		"bin\\mysqlshow.exe",
 		"bin\\mysqlslap.exe",
-		"bin\\mysqltest.exe",
 		"bin\\my_print_defaults.exe"
 		]
 }

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -1,32 +1,32 @@
 {
-	"homepage": "https://dev.mysql.com/downloads/mysql/",
-	"version": "5.7.11",
-	"license": "GPLv2",
-	"architecture": {
-		"64bit": {
-			"url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-winx64.zip",
-			"hash": "md5:9805750100ab3e2411f4887eb5f4cb77",
-			"extract_dir": "mysql-5.7.11-winx64"
-		},
-		"32bit": {
-			"url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-win32.zip",
-			"hash": "md5:710b588c8df3134c87818f765118329a",
-			"extract_dir": "mysql-5.7.11-win32"
-		}
-	},
-	"bin": [
-		"bin\\mysqld.exe",
-		"bin\\mysql.exe",
-		"bin\\mysqldump.exe",
-		"bin\\mysqladmin.exe",
-		"bin\\mysqlbinlog.exe",
-		"bin\\mysqlcheck.exe",
-		"bin\\mysqlimport.exe",
-		"bin\\mysqlshow.exe",
-		"bin\\mysqlslap.exe",
-		"bin\\my_print_defaults.exe"
-		],
-	"post_install": "
+    "homepage": "https://dev.mysql.com/downloads/mysql/",
+    "version": "5.7.11",
+    "license": "GPLv2",
+    "architecture": {
+        "64bit": {
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-winx64.zip",
+            "hash": "md5:9805750100ab3e2411f4887eb5f4cb77",
+            "extract_dir": "mysql-5.7.11-winx64"
+        },
+        "32bit": {
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-win32.zip",
+            "hash": "md5:710b588c8df3134c87818f765118329a",
+            "extract_dir": "mysql-5.7.11-win32"
+        }
+    },
+    "bin": [
+        "bin\\mysqld.exe",
+        "bin\\mysql.exe",
+        "bin\\mysqldump.exe",
+        "bin\\mysqladmin.exe",
+        "bin\\mysqlbinlog.exe",
+        "bin\\mysqlcheck.exe",
+        "bin\\mysqlimport.exe",
+        "bin\\mysqlshow.exe",
+        "bin\\mysqlslap.exe",
+        "bin\\my_print_defaults.exe"
+        ],
+    "post_install": "
 #Initialize data directory (without generating root password)
 mysqld --initialize-insecure
 

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -1,0 +1,28 @@
+{
+	"homepage": "https://dev.mysql.com/downloads/mysql/",
+	"version": "5.7.11",
+	"license": "GPLv2",
+	"architecture": {
+		"64bit": {
+			"url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-winx64.zip",
+			"hash": "md5:9805750100ab3e2411f4887eb5f4cb77"
+		},
+		"32bit": {
+			"url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-win32.zip",
+			"hash": "md5:710b588c8df3134c87818f765118329a"
+		}
+	},
+	"bin": [
+		"bin\\mysqld.exe",
+		"bin\\mysql.exe",
+		"bin\\mysqldump.exe",
+		"bin\\mysqladmin.exe",
+		"bin\\mysqlbinlog.exe",
+		"bin\\mysqlcheck.exe",
+		"bin\\mysqlimport.exe",
+		"bin\\mysqlshow.exe",
+		"bin\\mysqlslap.exe",
+		"bin\\mysqltest.exe",
+		"bin\\my_print_defaults.exe"
+		]
+}

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -26,8 +26,14 @@
 		"bin\\my_print_defaults.exe"
 		],
 	"post_install": "
-$dir/bin/mysqld --initialize-insecure
+#Initialize data directory (without generating root password)
+mysqld --initialize-insecure
+
+#Copy provided sample file to live file location
 cp $dir/my-default.ini $dir/my.ini
+
+#Output client configuration to my.ini file so no username is required when connecting
+echo \"\" >> $dir/my.ini
 echo \"[client]\" >> $dir/my.ini
 echo \"user=root\" >> $dir/my.ini
 "

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -5,14 +5,15 @@
 	"architecture": {
 		"64bit": {
 			"url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-winx64.zip",
-			"hash": "md5:9805750100ab3e2411f4887eb5f4cb77"
+			"hash": "md5:9805750100ab3e2411f4887eb5f4cb77",
+			"extract_dir": "mysql-5.7.11-winx64"
 		},
 		"32bit": {
 			"url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-win32.zip",
-			"hash": "md5:710b588c8df3134c87818f765118329a"
+			"hash": "md5:710b588c8df3134c87818f765118329a",
+			"extract_dir": "mysql-5.7.11-win32"
 		}
 	},
-	"extract_dir": "mysql-5.7.11-winx64",
 	"bin": [
 		"bin\\mysqld.exe",
 		"bin\\mysql.exe",

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -24,5 +24,11 @@
 		"bin\\mysqlshow.exe",
 		"bin\\mysqlslap.exe",
 		"bin\\my_print_defaults.exe"
-		]
+		],
+	"post_install": "
+$dir/bin/mysqld --initialize-insecure
+cp $dir/my-default.ini $dir/my.ini
+echo \"[client]\" >> $dir/my.ini
+echo \"user=root\" >> $dir/my.ini
+"
 }

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -12,6 +12,7 @@
 			"hash": "md5:710b588c8df3134c87818f765118329a"
 		}
 	},
+	"extract_dir": "mysql-5.7.11-winx64",
 	"bin": [
 		"bin\\mysqld.exe",
 		"bin\\mysql.exe",

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -34,8 +34,8 @@ mysqld --initialize-insecure
 cp $dir/my-default.ini $dir/my.ini
 
 #Output client configuration to my.ini file so no username is required when connecting
-echo \"\" >> $dir/my.ini
-echo \"[client]\" >> $dir/my.ini
-echo \"user=root\" >> $dir/my.ini
+echo \"\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+echo \"[client]\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+echo \"user=root\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
 "
 }


### PR DESCRIPTION
This new manifest provides a MySQL installation. The manifest itself should be pretty self-explanatory, but I'll explain the steps of the post-install script a little more below just for the sake of clarity:

1. The data directory is initialized without generating a root password (this is left for the user if they need it; hence the `--initialize-insecure` option)
2. The existing `my-default.ini` provided with the ZIP archive is copied to `my.ini`, where MySQL is expecting it to be
3. Default client configuration is appended to the `my.ini` file to allow connection on the command line with just `mysql` rather than `mysql --user=root`


This should leave MySQL entirely configurable, yet functioning well enough out-of-the-box for a development machine.


Credit: this manifest is based on [one created by](https://github.com/dennislloydjr/scoop-bucket-devbox/blob/master/mysql.json) @dennislloydjr; thanks for laying out a good template!