### PR TITLE
Make installers/uninstallers more flexible

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -360,12 +360,12 @@ function run($exe, $arg, $msg, $continue_exit_codes) {
         {
             $proc = start-process $exe -wait -ea stop -passthru -arg $arg
         }
-        
+
         else
         {
             $proc = start-process $exe -wait -ea stop -passthru
         }
-        
+
         if($proc.exitcode -ne 0) {
             if($continue_exit_codes -and ($continue_exit_codes.containskey($proc.exitcode))) {
                 warn $continue_exit_codes[$proc.exitcode]
@@ -476,7 +476,7 @@ function install_prog($fname, $dir, $installer) {
         if(!$installed) {
             abort "installation aborted. you might need to run 'scoop uninstall $app' before trying again."
         }
-        
+
         #Don't remove installer if "keep" flag is set to true
         if (!($keepInstaller.keep -eq "true"))
         {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -361,7 +361,7 @@ function run($exe, $arg, $msg, $continue_exit_codes) {
         {
             $parameters.arg = $arg;
         }
-        
+
         $proc = start-process $exe -wait -ea stop -passthru @parameters
 
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -478,7 +478,7 @@ function install_prog($fname, $dir, $installer) {
         }
 
         #Don't remove installer if "keep" flag is set to true
-        if (!($keepInstaller.keep -eq "true"))
+        if (!($installer.keep -eq "true"))
         {
             rm $prog
         }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -476,7 +476,12 @@ function install_prog($fname, $dir, $installer) {
         if(!$installed) {
             abort "installation aborted. you might need to run 'scoop uninstall $app' before trying again."
         }
-        rm $prog
+        
+        #Don't remove installer if "keep" flag is set to true
+        if (!($keepInstaller.keep -eq "true"))
+        {
+            rm $prog
+        }
     }
 }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -355,7 +355,17 @@ function args($config, $dir) {
 function run($exe, $arg, $msg, $continue_exit_codes) {
     if($msg) { write-host $msg -nonewline }
     try {
-        $proc = start-process $exe -wait -ea stop -passthru -arg $arg
+        #Check if arguments were provided in the manifest, and pass them to the installer if present
+        if ($arg)
+        {
+            $proc = start-process $exe -wait -ea stop -passthru -arg $arg
+        }
+        
+        else
+        {
+            $proc = start-process $exe -wait -ea stop -passthru
+        }
+        
         if($proc.exitcode -ne 0) {
             if($continue_exit_codes -and ($continue_exit_codes.containskey($proc.exitcode))) {
                 warn $continue_exit_codes[$proc.exitcode]

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -355,16 +355,15 @@ function args($config, $dir) {
 function run($exe, $arg, $msg, $continue_exit_codes) {
     if($msg) { write-host $msg -nonewline }
     try {
-        #Check if arguments were provided in the manifest, and pass them to the installer if present
+        #Allow null/no arguments to be passed
+        $parameters = @{ }
         if ($arg)
         {
-            $proc = start-process $exe -wait -ea stop -passthru -arg $arg
+            $parameters.arg = $arg;
         }
+        
+        $proc = start-process $exe -wait -ea stop -passthru @parameters
 
-        else
-        {
-            $proc = start-process $exe -wait -ea stop -passthru
-        }
 
         if($proc.exitcode -ne 0) {
             if($continue_exit_codes -and ($continue_exit_codes.containskey($proc.exitcode))) {


### PR DESCRIPTION
With some installers/uninstallers, there is no need to add arguments when running the executable, and scoop returns an error when there are no arguments present. 400284a fixes this by adding a check if there are arguments present in the manifest, only attempting to pass those arguments if they exist to avoid the error.

Additionally, the current installation method _always_ removes installers after installation; however, with programs such as the Visual C++ Redistributables, the installer is the same as the uninstaller, and needs to be kept for uninstalling in the future. Thus, ee57da6 adds a "keep" flag to the manifest, and does not remove the installer if that flag is present and set to the string "true". This change is fully backwards-compatible, and existing manifests without this flag will have their installers removed as normal.