### PR TITLE
Remove shortcuts from `Scoop Apps` on uninstall

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -596,7 +596,7 @@ function startmenu_shortcut($target, $shortcutName) {
 function rm_startmenu_shortcuts($manifest, $global) {
     $manifest.shortcuts | ?{ $_ -ne $null } | % {
         $name = $_.item(1)
-        $shortcut = "$env:USERPROFILE\Start Menu\Programs\$name.lnk"
+        $shortcut = "$env:USERPROFILE\Start Menu\Programs\Scoop Apps\$name.lnk"
         if(Test-Path -Path $shortcut) {
              Remove-Item $shortcut
              echo "Removed shortcut $shortcut"


### PR DESCRIPTION
Very minor change. I noticed that on some of the test install/uninstalls that I was doing from the `extras` bucket, the shortcuts weren't being removed from the correct start menu group.