### PR TITLE
Restore separate app for Apache/PHP Visual C++ dependency

### DIFF
--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -4,26 +4,15 @@
     "license": "Apache 2.0",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
-            ],
-            "hash": [
-                "sha256:543aff046b0ea2bf58be76d7d20fcd1fa16eec9ae836ca4639feb1c2a7e09cfa",
-                "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
-            ]
+            "url": "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip",
+            "hash": "sha256:543aff046b0ea2bf58be76d7d20fcd1fa16eec9ae836ca4639feb1c2a7e09cfa"
         },
         "32bit": {
-            "url": [
-                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
-            ],
-            "hash": [
-                "sha256:2259bea85cbcb4e9e525bfff0863b4ae3eae5f91fddb153191fd310575a04f38",
-                "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
-            ]
+            "url": "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip",
+            "hash": "sha256:2259bea85cbcb4e9e525bfff0863b4ae3eae5f91fddb153191fd310575a04f38"
         }
     },
+    "depends": "vc-redist14",
     "extract_dir": "Apache24",
     "bin": [
         "bin\\ab.exe",

--- a/bucket/php.json
+++ b/bucket/php.json
@@ -5,7 +5,7 @@
     "architecture": {
         "64bit": {
             "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x64.zip",
-            "hash": "sha1:52b0ce7ee7600672383694c65071966ff3a20b92",
+            "hash": "sha1:52b0ce7ee7600672383694c65071966ff3a20b92"
         },
         "32bit": {
             "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x86.zip",

--- a/bucket/php.json
+++ b/bucket/php.json
@@ -4,26 +4,15 @@
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x64.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
-            ],
-            "hash": [
-                "sha1:52b0ce7ee7600672383694c65071966ff3a20b92",
-                "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
-            ]
+            "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x64.zip",
+            "hash": "sha1:52b0ce7ee7600672383694c65071966ff3a20b92",
         },
         "32bit": {
-            "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x86.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
-            ],
-            "hash": [
-               "sha1:60569b17d7883c710675d217f3521821f97b4a0d",
-                "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
-            ]
+            "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x86.zip",
+            "hash": "sha1:60569b17d7883c710675d217f3521821f97b4a0d"
         }
     },
+    "depends": "vc-redist14",
     "bin": "php.exe",
     "post_install": "
 #Copy PHP configuration file to expected location

--- a/bucket/vc-redist14.json
+++ b/bucket/vc-redist14.json
@@ -1,0 +1,49 @@
+{
+    "homepage": "https://www.visualstudio.com",
+    "version": "2015",
+    "license": "https://www.visualstudio.com/DownloadEula/en-us/mt171552",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe",
+            "hash": "sha256:5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3",
+            "installer": {
+                "file": "vc_redist.x64.exe",
+                "args": [
+                    "/install",
+                    "/quiet",
+                    "/norestart"
+                ],
+                "keep": "true"
+            },
+            "uninstaller": {
+                "file": "vc_redist.x64.exe",
+                "args": [
+                    "/uninstall",
+                    "/quiet",
+                    "/norestart"
+                ]
+            }
+        },
+        "32bit": {
+            "url": "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe",
+            "hash": "sha256:fdd1e1f0dcae2d0aa0720895eff33b927d13076e64464bb7c7e5843b7667cd14",
+            "installer": {
+                "file": "vc_redist.x86.exe",
+                "args": [
+                    "/install",
+                    "/quiet",
+                    "/norestart"
+                ],
+                "keep": "true"
+            },
+            "uninstaller": {
+                "file": "vc_redist.x86.exe",
+                "args": [
+                    "/uninstall",
+                    "/quiet",
+                    "/norestart"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reverts the changes in #756, and restores a separate app manifest for the Visual C++ Redistributables, which both `apache` and `php` depend on.

Fixes #763, so this pull request can be merged to restore functionality if there is not another solution found in that issue thread that keeps the preferred method of direct DLL downloads.