### PR TITLE
Updated Git to 2.8.0

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.7.4.windows.1",
+    "version": "2.8.0.windows.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.4.windows.1/PortableGit-2.7.4-64-bit.7z.exe#/dl.7z",
-            "hash": "d32918f10812b4e60ecbf0524960cff00c8b20d1f0464dab1506d67dbaf8d6cf"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-64-bit.7z.exe#/dl.7z",
+            "hash": "a4b199e9ec7b2660b5708a92959ff0eb748bf9bec29f3a05d0bd015f20c06da4"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.4.windows.1/PortableGit-2.7.4-32-bit.7z.exe#/dl.7z",
-            "hash": "4d5a2729b4443ab2d80b899ceebd19ae2cbd17a3b2121178def3590a7dc91987"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-32-bit.7z.exe#/dl.7z",
+            "hash": "6ab6e75281dc61a64ea82a79305073ccfe8ee0ba572a2f1ee69e31b2ce94b66c"
         }
     },
     "bin": [

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.7.4.windows.1",
+    "version": "2.8.0.windows.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.4.windows.1/PortableGit-2.7.4-64-bit.7z.exe#/dl.7z",
-            "hash": "d32918f10812b4e60ecbf0524960cff00c8b20d1f0464dab1506d67dbaf8d6cf"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-64-bit.7z.exe#/dl.7z",
+            "hash": "a4b199e9ec7b2660b5708a92959ff0eb748bf9bec29f3a05d0bd015f20c06da4"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.7.4.windows.1/PortableGit-2.7.4-32-bit.7z.exe#/dl.7z",
-            "hash": "4d5a2729b4443ab2d80b899ceebd19ae2cbd17a3b2121178def3590a7dc91987"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-32-bit.7z.exe#/dl.7z",
+            "hash": "6ab6e75281dc61a64ea82a79305073ccfe8ee0ba572a2f1ee69e31b2ce94b66c"
         }
     },
     "bin": [


### PR DESCRIPTION
Updated Git to 2.8.0 due to new release:

https://github.com/git-for-windows/git/releases/tag/v2.8.0.windows.1