### PR TITLE
Update Git to 2.8.1

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.8.0.windows.1",
+    "version": "2.8.1.windows.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-64-bit.7z.exe#/dl.7z",
-            "hash": "a4b199e9ec7b2660b5708a92959ff0eb748bf9bec29f3a05d0bd015f20c06da4"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.1.windows.1/PortableGit-2.8.1-64-bit.7z.exe#/dl.7z",
+            "hash": "dc9d971156cf3b6853bc0c1ad0ca76f1d2c24478cca80036919f12fe46acd64e"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-32-bit.7z.exe#/dl.7z",
-            "hash": "6ab6e75281dc61a64ea82a79305073ccfe8ee0ba572a2f1ee69e31b2ce94b66c"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.1.windows.1/PortableGit-2.8.1-32-bit.7z.exe#/dl.7z",
+            "hash": "0b6efaaeb4b127edb3a534261b2c9175bd86ee8683dff6e12ccb194e6abb990e"
         }
     },
     "bin": [

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.8.0.windows.1",
+    "version": "2.8.1.windows.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-64-bit.7z.exe#/dl.7z",
-            "hash": "a4b199e9ec7b2660b5708a92959ff0eb748bf9bec29f3a05d0bd015f20c06da4"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.1.windows.1/PortableGit-2.8.1-64-bit.7z.exe#/dl.7z",
+            "hash": "dc9d971156cf3b6853bc0c1ad0ca76f1d2c24478cca80036919f12fe46acd64e"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.0.windows.1/PortableGit-2.8.0-32-bit.7z.exe#/dl.7z",
-            "hash": "6ab6e75281dc61a64ea82a79305073ccfe8ee0ba572a2f1ee69e31b2ce94b66c"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.8.1.windows.1/PortableGit-2.8.1-32-bit.7z.exe#/dl.7z",
+            "hash": "0b6efaaeb4b127edb3a534261b2c9175bd86ee8683dff6e12ccb194e6abb990e"
         }
     },
     "bin": [


### PR DESCRIPTION
Update Git to 2.8.1:

https://github.com/git-for-windows/git/releases/tag/v2.8.1.windows.1