### PR TITLE
Moved the pre-install in r.json to the architecture specific part

### DIFF
--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -1,25 +1,25 @@
 {
     "homepage": "http://www.apachelounge.com",
-    "version": "2.4.18",
+    "version": "2.4.20",
     "license": "Apache 2.0",
     "architecture": {
         "64bit": {
             "url": [
-                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip",
+                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.20-win64-VC14.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha256:543aff046b0ea2bf58be76d7d20fcd1fa16eec9ae836ca4639feb1c2a7e09cfa",
+                "sha256:4EC8A8B25F30809A1D8700FBE8CFAA6C1511E10DB3BBD44FC36B206F5C097200",
                 "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
             ]
         },
         "32bit": {
             "url": [
-                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip",
+                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.20-win32-VC14.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha256:2259bea85cbcb4e9e525bfff0863b4ae3eae5f91fddb153191fd310575a04f38",
+                "sha256:5EBC9F372E049C6B604A5D8A3EF621B269FBF603D76385578E992CE2856AD748",
                 "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
             ]
         }

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -2,10 +2,19 @@
     "homepage": "https://www.r-project.org",
     "version": "3.2.4",
     "license": "GPL2",
-    "url": "https://cran.rstudio.com/bin/windows/base/R-3.2.4revised-win.exe",
-    "hash": "E0BCD1D3552670B6E7604AF54AC0B75E8538694D8FC5B38086BF8A81FDB6EF40",
+    "architecture": {
+        "64bit": {
+            "url": "https://cran.rstudio.com/bin/windows/base/R-3.2.4revised-win.exe",
+            "hash": "E0BCD1D3552670B6E7604AF54AC0B75E8538694D8FC5B38086BF8A81FDB6EF40",
+            "pre_install": "copy-item -recurse $dir\\bin\\x64 $dir\\bin\\curr_arch"
+        },
+        "32bit": {
+            "url": "https://cran.rstudio.com/bin/windows/base/R-3.2.4revised-win.exe",
+            "hash": "E0BCD1D3552670B6E7604AF54AC0B75E8538694D8FC5B38086BF8A81FDB6EF40",
+            "pre_install": "copy-item -recurse $dir\\bin\\i386 $dir\\bin\\curr_arch"
+        }
+    },
     "innosetup": true,
-    "pre_install": "if ([intptr]::size -eq 8) { $r_arch = \"x64\" } else { $r_arch = \"i386\" }; copy-item -recurse $dir\\bin\\$r_arch $dir\\bin\\curr_arch;",
     "bin": [
         "bin\\curr_arch\\r.exe",
         "bin\\curr_arch\\rterm.exe",
@@ -19,8 +28,6 @@ You can remove Powershell's 'r' command with:
 ... but this only affects your current session: if you'd like to remove it for all future sessions you need to add the command above to your Powershell profile.
 
 Annoying, right?! You might want to check out Pshazz (scoop install pshazz)--this has a plugin to remove some crazy aliases from Powershell, as well as many other improvements.
-
-If you are on a 64-bit machine then R comes in a 32-bit and a 64-bit version. Currently scoop sets the shims depending on your machine's architecture.
 ",
     "checkver": {
         "url": "https://cran.rstudio.com/bin/windows/base/",


### PR DESCRIPTION
Finally the user can choose wether he or she wants to install the 32bit or 64bit version, thanks to the new `pre-install` feature in the architecture block of the manifest.

Thanks for that, @lukesampson!