### PR TITLE
Update aria2 to 1.22.0

### DIFF
--- a/bucket/aria2.json
+++ b/bucket/aria2.json
@@ -1,19 +1,19 @@
 {
     "homepage": "https://aria2.github.io/",
     "license": "GPL2 or later",
-    "version": "1.19.3",
+    "version": "1.22.0",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/tatsuhiro-t/aria2/releases/download/release-1.19.3/aria2-1.19.3-win-32bit-build1.zip",
-            "hash": "a8dfb6437c8db265fdd7f4637ade0f5e5939ce6a7466f7fcd843aa1872b7dd44",
-            "extract_dir": "aria2-1.19.3-win-32bit-build1"
+            "url": "https://github.com/aria2/aria2/releases/download/release-1.22.0/aria2-1.22.0-win-32bit-build1.zip",
+            "hash": "9059b59d5903a4e7f0e46cd858583625c41dd93ed7f90b73caad438253d334fc",
+            "extract_dir": "aria2-1.22.0-win-32bit-build1"
         },
         "64bit": {
-            "url": "https://github.com/tatsuhiro-t/aria2/releases/download/release-1.19.3/aria2-1.19.3-win-64bit-build1.zip",
-            "hash": "da1050efb40d5f9bdb51eedbdc5dfe63eb062d0dfe5ead5fd0d631056e4720de",
-            "extract_dir": "aria2-1.19.3-win-64bit-build1"
+            "url": "https://github.com/aria2/aria2/releases/download/release-1.22.0/aria2-1.22.0-win-64bit-build1.zip",
+            "hash": "7ea1f891886d53a32e77d3592e6a9971ba548c4920aa314ddb2bf509229aeb38",
+            "extract_dir": "aria2-1.22.0-win-64bit-build1"
         }
     },
     "bin": "aria2c.exe",
-    "checkver": "<p>Download <a href=\"https://github.com/tatsuhiro-t/aria2/releases/tag/[^\"]+\">version ([^<]+)</a>"
+    "checkver": "<p>Download <a href=\"https://github.com/aria2/aria2/tag[^\"]+\">version ([^<]+)</a>"
 }


### PR DESCRIPTION
SHA-256 taken from 7zip;
confirmed repository relocation from github.com/tatsuhiro-t/aria2 to github.com/aria2/aria2.