### PR TITLE
Update dig (BIND9) to 9.9.9

### DIFF
--- a/bucket/dig.json
+++ b/bucket/dig.json
@@ -1,8 +1,8 @@
 {
   "homepage": "https://www.isc.org/",
     "license": "https://www.isc.org/downloads/software-support-policy/isc-license/",
-    "version": "9.9.6",
-    "url" : "ftp://ftp.isc.org/isc/bind9/9.9.6/BIND9.9.6.x86.zip",
-    "hash" : "CC03FC37502650D2DCEC6DB3FAA0256672B67B5CCDAF4AA5F8ED08F2F5755452",
+    "version": "9.9.9",
+    "url" : "ftp://ftp.isc.org/isc/bind9/9.9.9/BIND9.9.9.x86.zip",
+    "hash" : "4cc180ed9881930e5a0d4ecbff1327da5b83436e0866f7c58d984b6757229a35",
     "bin": "dig.exe"
 }


### PR DESCRIPTION
SHA-256 taken from 7zip;
zip date: 4/28/16, 10:41:00 PM.