### PR TITLE
Update Ghostscript to 9.19

### DIFF
--- a/bucket/ghostscript.json
+++ b/bucket/ghostscript.json
@@ -1,18 +1,16 @@
 {
     "homepage": "http://www.ghostscript.com",
-    "version": "9.18",
+    "version": "9.19",
     "license": "http://www.gnu.org/licenses/agpl-3.0.html",
     "architecture": {
         "64bit": {
-            "url": "http://downloads.ghostscript.com/public/gs918w64.exe#/dl.7z",
-            "hash": "a01e11e602b42bca29619bc18b7aea29431fe77cfbbb4eb6e4d04e5e9a0ffd1a"
+            "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs919/gs919w64.exe#/dl.7z",
+            "hash": "272fbe49981935f9393b829045756b5cfd5946d7acc88753250ab678816a57fc"
         },
         "32bit": {
-            "url": "http://downloads.ghostscript.com/public/gs918w32.exe#/dl.7z",
-            "hash": "e4646c4ad0754a0848099a8606fb9bc6ca4cb882d29eba27dca96d12b477cb0d"
+            "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs919/gs919w32.exe#/dl.7z",
+            "hash": "36fd0d44cd8a978254bba597881313f31ddf4ea83470c10c7858ced00620c3e1"
         }
     },
-    "bin": [
-        "bin\\gswin32c.exe"
-    ]
+    "env_add_path": "bin"
 }


### PR DESCRIPTION
SHA-256 taken from 7zip;

gs919w64 contains gswin64.exe & gswin64c.exe
-> replaced "bin": ["bin\\\gswin32c.exe"] with "env_add_path": "bin";
Ghostscript manifest tested on external bucket.

[Ghostscript releases from 9.19 have been moved to GitHub](http://downloads.ghostscript.com/public/).

Current links are inaccessible (9.18):
http://downloads.ghostscript.com/public/gs918w64.exe
http://downloads.ghostscript.com/public/gs918w32.exe

Working links (9.18):
http://downloads.ghostscript.com/public/old-gs-releases/gs918w64.exe
http://downloads.ghostscript.com/public/old-gs-releases/gs918w32.exe