### PR TITLE
Update git-lfs to 1.2.0

### DIFF
--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -1,14 +1,16 @@
 {
-    "version": "1.1.2",
+    "version": "1.2.0",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-windows-386-1.1.2.zip",
-            "hash": "71c0eee9d5eb25081f2f85cbfda844bffe9ec2f5593108271f23af479632549f"
+            "url": "https://github.com/github/git-lfs/releases/download/v1.2.0/git-lfs-windows-386-1.2.0.zip",
+            "hash": "5e5780da1c63473782f080e91ed49305a4a5319b959f0ddb5bce12b4e2330d08",
+            "extract_dir": "git-lfs-windows-386-1.2.0"
         },
         "64bit": {
-            "url": "https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-windows-amd64-1.1.2.zip",
-            "hash": "db2fd14773d8d2c42a7bbe45fd5dee90c97cf89f56ddc4eb6ca5cf6d8559cd30"
+            "url": "https://github.com/github/git-lfs/releases/download/v1.2.0/git-lfs-windows-amd64-1.2.0.zip",
+            "hash": "2dd542cb4c729f6264ddce770ba14a6a955a2c7c8cf4fdd96f73967c1c4d895b",
+            "extract_dir": "git-lfs-windows-amd64-1.2.0"
         }
     },
     "depends": "git",


### PR DESCRIPTION
SHA-256 taken from 7zip;
extract directory now exists in release zip
-> added "extract_dir" for both architectures.

git-lfs manifest tested on external bucket.