### PR TITLE
Upgrade NodeJS to 6.1.0

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v6.0.0/node-v6.0.0-x64.msi",
-            "hash": "933a15791a67a2740cbd082a8d9aebc43162ec6d4db335abf62121a9561c57d4"
+            "url": "https://nodejs.org/dist/v6.1.0/node-v6.1.0-x64.msi",
+            "hash": "b32b1105da5c08023976717d9aaeb0e3ba93d09f170aa3d81ad8ddfb0abfbdd4"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v6.0.0/node-v6.0.0-x86.msi",
-            "hash": "614380711039b7cc23db8d8cbf42ed9f4a6f0501eb8a143490f7ece952037bc9"
+            "url": "https://nodejs.org/dist/v6.1.0/node-v6.1.0-x86.msi",
+            "hash": "26b762f6066feeae59107c064eeaf70019880cb113279d51e35dff46c6c81be2"
         }
     },
     "env_add_path": "nodejs",


### PR DESCRIPTION
**Notable Changes**

- assert: deep{Strict}Equal() now works correctly with circular references. (Rich Trott) #6432
- debugger: Arrays are now formatted correctly in the debugger repl. (cjihrig) #6448
- deps: Upgrade OpenSSL sources to 1.0.2h (Shigeki Ohtsu) #6550
- net: Introduced a Socket#connecting property. (Fedor Indutny) #6404
- Previously this information was only available as the undocumented, internal _connecting property.
- process: Introduced process.cpuUsage(). (Patrick Mueller) #6157
- stream: Writable#setDefaultEncoding() now returns this. (Alexander Makarenko) #5040
- util: Two new additions to util.inspect():
- Added a maxArrayLength option to truncate the formatting of Arrays. (James M Snell) #6334
This is set to 100 by default.
- Added a showProxy option for formatting proxy intercepting handlers. (James M Snell) #6465
- Inspecting proxies is non-trivial and as such this is off by default.

https://nodejs.org/en/blog/release/v6.1.0/