### PR TITLE
Update MariaDB to 10.0.25

### DIFF
--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -1,17 +1,17 @@
 {
     "homepage": "http://mariadb.org",
-    "version": "10.0.21",
+    "version": "10.0.25",
     "license": "GPL2",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.mariadb.org/f/mariadb-10.0.21/winx64-packages/mariadb-10.0.21-winx64.zip",
-            "hash": "md5:12e7a7c121a48904172b311f8aefcb15",
-            "extract_dir": "mariadb-10.0.21-winx64"
+            "url": "https://downloads.mariadb.org/f/mariadb-10.0.25/winx64-packages/mariadb-10.0.25-winx64.zip",
+            "hash": "md5:5474522e9987985b4eb3122bf8b9c2aa",
+            "extract_dir": "mariadb-10.0.25-winx64"
         },
         "32bit": {
             "url": "https://downloads.mariadb.org/f/mariadb-10.0.21/win32-packages/mariadb-10.0.21-win32.zip",
-            "hash": "md5:e6d79eabaedcccbf53ac0ef4ca8b1cd7",
-            "extract_dir": "mariadb-10.0.21-win32"
+            "hash": "md5:578a87c3a081653f32433f411d62cc27",
+            "extract_dir": "mariadb-10.0.25-win32"
         }
     },
     "bin": [


### PR DESCRIPTION
MD5 taken from site.

[Multiple stable releases exist for MariaDB;](https://downloads.mariadb.org/mariadb/+releases/)
Update taken from 10.0 series.