### PR TITLE
Update NuGet to 3.4.3

### DIFF
--- a/bucket/nuget.json
+++ b/bucket/nuget.json
@@ -1,8 +1,8 @@
 {
     "homepage": "https://github.com/nuget",
-    "version": "3.3.0",
+    "version": "3.4.3",
     "license": "Apache 2.0",
-    "url": "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe",
-    "hash": "af8ee5c2299a7d71f4bfefe046701af551c348b8c9f6c10302598262f16d42aa",
+    "url": "https://dist.nuget.org/win-x86-commandline/v3.4.3/nuget.exe",
+    "hash": "3b1ea72943968d7af6bacdb4f2f3a048a25afd14564ef1d8b1c041fdb09ebb0a",
     "bin": "nuget.exe"
 }


### PR DESCRIPTION
SHA-256 taken from 7zip.

There exists a ["latest"](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) download location for NuGet, but corresponding version link is used.