### PR TITLE
Update NodeJS to 6.2.0

### DIFF
--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "6.1.0",
+    "version": "6.2.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v6.1.0/node-v6.1.0-x64.msi",
-            "hash": "b32b1105da5c08023976717d9aaeb0e3ba93d09f170aa3d81ad8ddfb0abfbdd4"
+            "url": "https://nodejs.org/dist/v6.2.0/node-v6.2.0-x64.msi",
+            "hash": "bd1d766e15f75f67befa76738bc0212ee3016444eb0396b29c6fc319658e21a2"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v6.1.0/node-v6.1.0-x86.msi",
-            "hash": "26b762f6066feeae59107c064eeaf70019880cb113279d51e35dff46c6c81be2"
+            "url": "https://nodejs.org/dist/v6.2.0/node-v6.2.0-x86.msi",
+            "hash": "e0e20da53fd7e8ccdd61acf93b4f268189b32c43c15516a272df57808d94b941"
         }
     },
     "env_add_path": "nodejs",


### PR DESCRIPTION
Notable changes

- buffer: fix lastIndexOf and indexOf in various edge cases (Anna Henningsen) #6511
- child_process: use /system/bin/sh on android (Ben Noordhuis) #6745
deps:
- upgrade npm to 3.8.9 (Rebecca Turner) #6664
- upgrade to V8 5.0.71.47 (Ali Ijaz Sheikh) #6572
- upgrade libuv to 1.9.1 (Saúl Ibarra Corretgé) #6796
- Intl: ICU 57 bump (Steven R. Loomis) #6088
- repl:
  - copying tabs shouldn't trigger completion (Eugene Obrezkov) #5958
  - exports Recoverable (Blake Embrey) #3488
  - src: add O_NOATIME constant (Rich Trott) #6492
  - src,module: add --preserve-symlinks command line flag (James M Snell) #6537
  - util: adhere to noDeprecation set at runtime (Anna Henningsen) #6683

As of this release the 6.X line now includes 64-bit binaries for Linux on Power Systems running in big endian mode in addition to the existing 64-bit binaries for running in little endian mode.