### PR TITLE
#864 Fix following issue when searching on a new Win10

### DIFF
--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -49,7 +49,7 @@ function search_bucket($bucket, $query) {
 
 function download_json($url) {
     $progressPreference = 'silentlycontinue'
-    $result = invoke-webrequest $url | select -exp content | convertfrom-json
+    $result = invoke-webrequest $url -UseBasicParsing | select -exp content | convertfrom-json
     $progressPreference = 'continue'
     $result
 }


### PR DESCRIPTION
invoke-webrequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.