### PR TITLE
OpenSSL: Add executables and DLLs to PATH.

### DIFF
--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -14,5 +14,6 @@
     },
     "innosetup": true,
     "bin": "bin\\openssl.exe",
-    "checkver": "<a href=\"[^\"]*\">Win32 OpenSSL v([^ ]+) Light</a>"
+    "checkver": "<a href=\"[^\"]*\">Win32 OpenSSL v([^ ]+) Light</a>",
+    "env_add_path": "bin"
 }


### PR DESCRIPTION
External apps depend on DLLs exported by openssl (ssleay32.dll and libeay32.dll in my particular case), so I thought it would be nice to have the in PATH automatically after installation.