### PR TITLE
bump imagemagick 7.0.1-2 -> 7.0.1-6

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.imagemagick.org/script/index.php",
     "license": "http://www.imagemagick.org/script/license.php",
-    "version": "7.0.1-2",
+    "version": "7.0.1-6",
     "architecture": {
         "64bit": {
-            "url": "http://www.imagemagick.org/download/binaries/ImageMagick-7.0.1-2-portable-Q16-x64.zip",
-            "hash": "f70e26ec01d1457458ca8b186eb8fc46e45442cf9c5c585a8b18290dece2d582"
+            "url": "http://www.imagemagick.org/download/binaries/ImageMagick-7.0.1-6-portable-Q16-x64.zip",
+            "hash": "5d89f25024e32832163cff49b766754182255d9ab23d8c0e091f04e3b1d6f0e5"
         },
         "32bit": {
-            "url": "http://www.imagemagick.org/download/binaries/ImageMagick-7.0.1-2-portable-Q16-x86.zip",
-            "hash": "20dbce30b8137745cc519cbb09488cde5381dbb2a3f8668fb22cedb975704744"
+            "url": "http://www.imagemagick.org/download/binaries/ImageMagick-7.0.1-6-portable-Q16-x86.zip",
+            "hash": "b8e5a642425d9404aecba08d6d474042b4ffe976c3ba59d2fef5bbd8b062ed63"
         }
     },
     "env_add_path": ".",


### PR DESCRIPTION
Download for 7.0.1-2 returns a 404 since only the latest binary is stored
Bumped to 7.0.1-6 and updated hashes