### PR TITLE
Update to php 7.0.7

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,25 +1,25 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.0.6",
+    "version": "7.0.7",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.6-Win32-VC14-x64.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.7-Win32-VC14-x64.zip",
                 "https://raw.githubusercontent.com/madbub/scoop-php/master/64-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:607e510e60903ea58e2194fb2a87a07d3744cdca",
+                "sha1:caeda6435908e448196325aabcdafddb4eb88f1b",
                 "md5:6c2c88ff1b3da84b44d23a253a06c01b"
             ]
         },
         "32bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.6-Win32-VC14-x86.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.7-Win32-VC14-x86.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:e0c41a01c16b3633cfffceac9528cf5a44019778",
+                "sha1:634c43fc04a787da7923508990607df236a0f29d",
                 "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
             ]
         }


### PR DESCRIPTION
- Core:
  - Fixed bug #72162 (use-after-free - error_reporting).
  - Add compiler option to disable special case function calls.
  - Fixed bug #72101 (crash on complex code).
  - Fixed bug #72100 (implode() inserts garbage into resulting string when joins very big integer).
  - Fixed bug #72057 (PHP Hangs when using custom error handler and typehint).
  - Fixed bug #72038 (Function calls with values to a by-ref parameter don't always throw a notice).
  - Fixed bug #71737 (Memory leak in closure with parameter named $this).
  - Fixed bug #72059 (?? is not allowed on constant expressions).
  - Fixed bug #72159 (Imported Class Overrides Local Class Name).
- Curl:
  - Fixed bug #68658 (Define CURLE_SSL_CACERT_BADFILE).
- DBA:
  - Fixed bug #72157 (use-after-free caused by dba_open).
- GD:
  - Fixed bug #72227 (imagescale out-of-bounds read). (CVE-2013-7456)
- Intl:
  - Fixed bug #72241 (get_icu_value_internal out-of-bounds read). (CVE-2016-5093)
- JSON:
  - Fixed bug #72069 (Behavior \JsonSerializable different from json_encode).
- Mbstring:
  - Fixed bug #72164 (Null Pointer Dereference - mb_ereg_replace).
- OCI8:
  - Fixed bug #71600 (oci_fetch_all segfaults when selecting more than eight columns).
- Opcache:
  - Fixed bug #72014 (Including a file with anonymous classes multiple times leads to fatal error).
- OpenSSL:
  - Fixed bug #72165 (Null pointer dereference - openssl_csr_new).
- PCNTL:
  - Fixed bug #72154 (pcntl_wait/pcntl_waitpid array internal structure overwrite).
- POSIX:
  - Fixed bug #72133 (php_posix_group_to_array crashes if gr_passwd is NULL).
- Postgres:
  - Fixed bug #72028 (pg_query_params(): NULL converts to empty string).
  - Fixed bug #71062 (pg_convert() doesn't accept ISO 8601 for datatype timestamp).
  - Fixed bug #72151 (mysqli_fetch_object changed behaviour).
- Reflection:
  - Fixed bug #72174 (ReflectionProperty#getValue() causes __isset call).
- Session:
  - Fixed bug #71972 (Cyclic references causing session_start(): Failed to decode session object).
- Sockets:
  - Added socket_export_stream() function for getting a stream compatible resource from a socket resource.
- SPL:
  - Fixed bug #72051 (The reference in CallbackFilterIterator doesn't work as expected).
- SQLite3:
  - Fixed bug #68849 (bindValue is not using the right data type).
- Standard:
  - Fixed bug #72075 (Referencing socket resources breaks stream_select).
  - Fixed bug #72031 (array_column() against an array of objects discards all values matching null).