### PR TITLE
Update PHP to 7.0.8

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,25 +1,25 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.0.7",
+    "version": "7.0.8",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.7-Win32-VC14-x64.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.8-Win32-VC14-x64.zip",
                 "https://raw.githubusercontent.com/madbub/scoop-php/master/64-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:caeda6435908e448196325aabcdafddb4eb88f1b",
+                "sha1:13de6d1637865eea590963e39e6b375beb63fdbf",
                 "md5:6c2c88ff1b3da84b44d23a253a06c01b"
             ]
         },
         "32bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.7-Win32-VC14-x86.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.8-Win32-VC14-x86.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:634c43fc04a787da7923508990607df236a0f29d",
+                "sha1:12c86a395ec0ae7c1864da30fd7a95562420ef20",
                 "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
             ]
         }


### PR DESCRIPTION
- Core:
  - Fixed bug #72218 (If host name cannot be resolved then PHP 7 crashes).
  - Fixed bug #72221 (segfault, past-the-end access).
  - Fixed bug #72268 (Integer Overflow in nl2br()).
  - Fixed bug #72275 (Integer Overflow in json_encode()/json_decode()/ json_utf8_to_utf16()).
  - Fixed bug #72400 (Integer Overflow in addcslashes/addslashes).
  - Fixed bug #72403 (Integer Overflow in Length of String-typed ZVAL).
- FPM:
  - Fixed bug #72308 (fastcgi_finish_request and logging environment variables).
- GD:
  - Fixed bug #72298 (pass2_no_dither out-of-bounds access).
  - Fixed bug #72337 (invalid dimensions can lead to crash) (Pierre)
  - Fixed bug #72339 (Integer Overflow in _gd2GetHeader() resulting in heap overflow).
  - Fixed bug #72407 (NULL Pointer Dereference at _gdScaleVert).
- Intl:
  - Fixed bug #64524 (Add intl.use_exceptions to php.ini-*).
- mbstring:
  - Fixed bug #72402 (_php_mb_regex_ereg_replace_exec - double free).
- mcrypt:
  - Fixed bug #72455 (Heap Overflow due to integer overflows).
- PCRE:
  - Fixed bug #72143 (preg_replace uses int instead of size_t).
- PDO_pgsql:
  - Fixed bug #71573 (Segfault (core dumped) if paramno beyond bound).
  - Fixed bug #72294 (Segmentation fault/invalid pointer in connection with pgsql_stmt_dtor).
- Phpdbg:
  - Fixed bug #72284 (phpdbg fatal errors with coverage).
- Postgres:
  - Fixed bug #72195 (pg_pconnect/pg_connect cause use-after-free).
  - Fixed bug #72197 (pg_lo_create arbitrary read).
- SPL:
  - Fixed bug #72262 (int/size_t confusion in SplFileObject::fread).
  - Fixed bug #72433 (Use After Free Vulnerability in PHP's GC algorithm and unserialize).
- Standard:
  - Fixed bug #72017 (range() with float step produces unexpected result).
  - Fixed bug #72193 (dns_get_record returns array containing elements of type 'unknown').
  - Fixed bug #72229 (Wrong reference when serialize/unserialize an object).
  - Fixed bug #72300 (ignore_user_abort(false) has no effect).
- XML:
  - Fixed bug #72206 (xml_parser_create/xml_parser_free leaks mem).
- XMLRPC:
  - Fixed bug #72155 (use-after-free caused by get_zval_xmlrpc_type).
- WDDX:
  - Fixed bug #72340 (Double Free Courruption in wddx_deserialize).
- Zip:
  - Fixed bug #72258 (ZipArchive converts filenames to unrecoverable form).
  - Fixed bug #72434 (ZipArchive class Use After Free Vulnerability in PHP's GC algorithm and unserialize).