### PR TITLE
Add the ability to have an additional php.ini file

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -28,6 +28,9 @@
         "php.exe",
         "php-cgi.exe"
     ],
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$dir\\..\\conf"
+    },
     "post_install": "
 #Copy PHP configuration file to expected location
 cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"


### PR DESCRIPTION
When upgrading PHP version, the php.ini file is reset. So, I used PHP_INI_SCAN_DIR $env var to add an additional path to load php config files: /php/conf/.

I think this little change can simplify the PHP upgrading process.