### PR TITLE
wget 1.18

### DIFF
--- a/bucket/wget.json
+++ b/bucket/wget.json
@@ -1,25 +1,25 @@
 {
     "homepage": "https://eternallybored.org/misc/wget/",
     "license": "GPL3",
-    "version": "1.16.3",
+    "version": "1.18",
     "architecture": {
         "64bit": {
             "url": [
-                "https://eternallybored.org/misc/wget/releases/wget-1.16.3-win64.zip",
+                "https://eternallybored.org/misc/wget/releases/wget-1.18-win64.zip",
                 "http://curl.haxx.se/ca/cacert.pem"
             ],
             "hash": [
-                "85e5393ffd473f7bec40b57637fd09b6808df86c06f846b6885b261a8acac8c5",
+                "1a0c1b5e4f2a62271c8881780e8949b5e5be0e022c993e0d4e654e5fb796f150",
                 ""
             ]
         },
         "32bit": {
             "url": [
-                "https://eternallybored.org/misc/wget/releases/wget-1.16.3-win32.zip",
+                "https://eternallybored.org/misc/wget/releases/wget-1.18-win32.zip",
                 "http://curl.haxx.se/ca/cacert.pem"
             ],
             "hash": [
-                "2ef82af3070abfdaf3862baff0bffdcb3c91c8d75e2f02c8720d90adb9d7a8f7",
+                "1e958d913fc1839b7cfb753db1d4f40c11a9b064e6ed3ca4876c0c406bce8735",
                 ""
             ]
         }


### PR DESCRIPTION
only tested 64-bit version but calculated 32bit hash from https://eternallybored.org/misc/wget/releases/wget-1.18-win32.zip, so it "should" work too