### PR TITLE
mongodb 3.2.7

### DIFF
--- a/bucket/mongodb.json
+++ b/bucket/mongodb.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.mongodb.org",
-    "version": "3.2.6",
+    "version": "3.2.7",
     "license": "http://www.mongodb.org/about/licensing/",
     "architecture": {
         "64bit": {
-            "url": "http://downloads.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-3.2.6-signed.msi",
-            "hash": "4a90adce7801e9ffec17598805ff326b084b74050bce227634e8296bc1a51115"
+            "url": "https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-3.2.7-signed.msi",
+            "hash": "2054f84e217c092860fe95959eb814fffffe36b99be958a7fce120d3528ff5e5"
         },
         "32bit": {
-            "url": "http://downloads.mongodb.org/win32/mongodb-win32-i386-3.2.6-signed.msi",
-            "hash": "4b8f487e14bf4b3b3c3f789a4ffbafbf77e356ca5944597ce696feb9788c5ca5"
+            "url": "https://fastdl.mongodb.org/win32/mongodb-win32-i386-3.2.7-signed.msi",
+            "hash": "a84cc09f04fe9b89cd276f30fb1a9d0855d9bf8cba9db38875afe8a876f615be"
         }
     },
     "bin": [
@@ -30,5 +30,10 @@
     "checkver": {
         "url": "http://www.mongodb.org/downloads",
         "re": "Current Stable Release \\(([\\d.]+)\\)"
-    }
+    },
+    "post_install": "
+        # create initial directories
+        mkdir C:\\data
+        mkdir C:\\data\\db
+    "
 }


### PR DESCRIPTION
tested 32+64 bit install, verified 64-bit install working by starting mongod.exe and connecting using robomongo gui (https://robomongo.org)

there's an error on my 64bit system when starting the 32-bit mongod.exe:
```
scoop mongodb * $ mongod
2016-07-05T12:49:36.427+0200 I CONTROL  [main]
2016-07-05T12:49:36.429+0200 W CONTROL  [main] 32-bit servers don't have journaling enabled by default. Please use --journal if you want durability.
2016-07-05T12:49:36.429+0200 I CONTROL  [main]
2016-07-05T12:49:36.523+0200 I CONTROL  [main] Hotfix KB2731284 or later update is not installed, will zero-out data files
2016-07-05T12:49:36.526+0200 I CONTROL  [initandlisten] MongoDB starting : pid=10600 port=27017 dbpath=C:\data\db\ 32-bit host=xxx
2016-07-05T12:49:36.527+0200 I CONTROL  [initandlisten] targetMinOS: Windows Vista/Windows Server 2008
2016-07-05T12:49:36.527+0200 I CONTROL  [initandlisten] db version v3.2.7
2016-07-05T12:49:36.527+0200 I CONTROL  [initandlisten] git version: 4249c1d2b5999ebbf1fdf3bc0e0e3b3ff5c0aaf2
2016-07-05T12:49:36.527+0200 I CONTROL  [initandlisten] allocator: tcmalloc
2016-07-05T12:49:36.527+0200 I CONTROL  [initandlisten] modules: none
2016-07-05T12:49:36.527+0200 I CONTROL  [initandlisten] build environment:
2016-07-05T12:49:36.528+0200 I CONTROL  [initandlisten]     distarch: i386
2016-07-05T12:49:36.528+0200 I CONTROL  [initandlisten]     target_arch: i386
2016-07-05T12:49:36.528+0200 I CONTROL  [initandlisten] options: {}
2016-07-05T12:49:36.539+0200 I STORAGE  [initandlisten] exception in initAndListen: 28663 Cannot start server. The default storage engine 'wiredTiger' is not available with this build of mongod. Please specify a different storage engine explicitly, e.g. --storageEngine=mmapv1., terminating
2016-07-05T12:49:36.540+0200 I CONTROL  [initandlisten] dbexit:  rc: 100
```