### PR TITLE
nginx 1.11.1

### DIFF
--- a/bucket/nginx.json
+++ b/bucket/nginx.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://nginx.org",
-    "version": "1.9.6",
+    "version": "1.11.1",
     "license": "BSD",
-    "url": "http://nginx.org/download/nginx-1.9.6.zip",
-    "hash": "728f857eed412afd136276828295d10b6345c6879e74c0bc8872bbd7a2a55652",
-    "extract_dir": "nginx-1.9.6",
+    "url": "http://nginx.org/download/nginx-1.11.1.zip",
+    "hash": "b0020735f7e37dbe81619040af72932444a3577d8c64b89c68a1d65ac33f8f44",
+    "extract_dir": "nginx-1.11.1",
     "bin": "nginx.exe"
 }


### PR DESCRIPTION
this version of nginx has HTTP/2 support.

note: both the previous packaged nginx and this new one errors out on startup with this error, so additional post-install would be better. unsure what to do to improve situation

```
nginx: [alert] could not open error log file: CreateFile() "logs/error.log" failed (3: The system cannot find the path specified)
2016/07/05 13:05:10 [emerg] 12452#10072: CreateFile() "C:\Users\m\dev\scoop/conf/nginx.conf" failed (3: The system cannot find the path specified)
```