### PR TITLE
WIP: gcc 6.1.0

### DIFF
--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -1,17 +1,9 @@
 {
-    "homepage": "http://mingw-w64.sourceforge.net/",
-    "version": "4.8.1",
-    "architecture": {
-        "64bit": {
-            "url": "http://ufpr.dl.sourceforge.net/project/mingwbuilds/host-windows/releases/4.8.1/64-bit/threads-posix/seh/x64-4.8.1-release-posix-seh-rev5.7z",
-            "hash": "bb8bd0fe45da3ed9412acd5e432f28c8dccc3b559610e43980760314a283168f",
-            "extract_dir": "mingw64"
-        },
-        "32bit": {
-            "url": "http://ufpr.dl.sourceforge.net/project/mingwbuilds/host-windows/releases/4.8.1/32-bit/threads-posix/sjlj/x32-4.8.1-release-posix-sjlj-rev5.7z",
-            "hash": "e438ca54e1df9c45b16898d8e9ee941295ad8cde6f20330294e5be4794988582",
-            "extract_dir": "mingw32"
-        }
-    },
+    "homepage": "http://mingw-w64.org/",
+    "version": "6.1.0",
+    "depends":  "7zip",
+    "url": "http://ufpr.dl.sourceforge.net/project/mingw-w64/Multilib%20Toolchains%28Targetting%20Win32%20and%20Win64%29/ray_linn/gcc-6.X-with-ada/gcc-6.1.0-multilib-mingw-4.0.6-with-ada-201605226.7z",
+    "hash": "b8d04ba821eb9838d80741124455d4e85b4ca3cf7575d39d8b60cee494f81deb",
+    "extract_dir": "mingw64",
     "env_add_path": "bin"
 }


### PR DESCRIPTION
This binary is multilib (supporting 32 and 64bit targets).
tested with

`go get -v github.com/go-gl/glfw/v3.1/glfw`

which requires a working gcc on the system.

currently I get this error, so please dont merge this branch yet.

```
$ go get -v github.com/go-gl/glfw/v3.1/glfw
github.com/go-gl/glfw/v3.1/glfw
# github.com/go-gl/glfw/v3.1/glfw
c:/users/m/appdata/local/scoop/apps/gcc/6.1.0/bin/../lib/gcc/x86_64-w64-mingw32/6.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lwinpthreads
c:/users/m/appdata/local/scoop/apps/gcc/6.1.0/bin/../lib/gcc/x86_64-w64-mingw32/6.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lwinpthreads
collect2.exe: error: ld returned 1 exit status
```

