### PR TITLE
Upgrade PHP to 7.0.9

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,25 +1,25 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.0.8",
+    "version": "7.0.9",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.8-Win32-VC14-x64.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.9-Win32-VC14-x64.zip",
                 "https://raw.githubusercontent.com/madbub/scoop-php/master/64-bit/vcruntime140.dll"
             ],
             "hash": [
-                "3007c33353a3333acec5bab869ab59aad44f22dff9d6f35908077641e8c6ff6c",
+                "8d4629bbbd07f29e5ab1665f4ce1c59b34e3a8e0",
                 "acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
             ]
         },
         "32bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.8-Win32-VC14-x86.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.9-Win32-VC14-x86.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
             ],
             "hash": [
-                "7ec9a8a1b8b897f78fe1e6f619f780c13254c93b7b91a845901456f56c0da4bb",
+                "7fc3b5e2ef75f7aa8cde22d6a775664bcc690f05",
                 "b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
             ]
         }


### PR DESCRIPTION
- Core:
  - Fixed bug #72508 (strange references after recursive function call and "switch" statement).
  - Fixed bug #72513 (Stack-based buffer overflow vulnerability in virtual_file_ex).
  - Fixed bug #72573 (HTTP_PROXY is improperly trusted by some PHP libraries and applications).
- bz2:
  - Fixed bug #72613 (Inadequate error handling in bzread()).
- CLI:
  - Fixed bug #72484 (SCRIPT_FILENAME shows wrong path if the user specify router.php).
- COM:
  - Fixed bug #72498 (variant_date_from_timestamp null dereference).
- Curl:
  - Fixed bug #72541 (size_t overflow lead to heap corruption).
- Exif:
  - Fixed bug #72603 (Out of bound read in exif_process_IFD_in_MAKERNOTE).
  - Fixed bug #72618 (NULL Pointer Dereference in exif_process_user_comment).
- GD:
  - Fixed bug #43475 (Thick styled lines have scrambled patterns).
  - Fixed bug #53640 (XBM images require width to be multiple of 8).
  - Fixed bug #64641 (imagefilledpolygon doesn't draw horizontal line).
  - Fixed bug #72512 (gdImageTrueColorToPaletteBody allows arbitrary write/read access).
  - Fixed bug #72519 (imagegif/output out-of-bounds access).
  - Fixed bug #72558 (Integer overflow error within _gdContributionsAlloc()).
  - Fixed bug #72482 (Ilegal write/read access caused by gdImageAALine overflow).
  - Fixed bug #72494 (imagecropauto out-of-bounds access).
- Intl:
  - Fixed bug #72533 (locale_accept_from_http out-of-bounds access).
- Mbstring:
  - Fixed bug #72405 (mb_ereg_replace - mbc_to_code (oniguruma) - oob read access).
  - Fixed bug #72399 (Use-After-Free in MBString (search_re)).
- mcrypt:
  - Fixed bug #72551, bug #72552 (Incorrect casting from size_t to int lead to heap overflow in mdecrypt_generic).
- PDO_pgsql:
  - Fixed bug #72570 (Segmentation fault when binding parameters on a query without placeholders).
- PCRE:
  - Fixed bug #72476 (Memleak in jit_stack).
  - Fixed bug #72463 (mail fails with invalid argument).
- Readline:
  - Fixed bug #72538 (readline_redisplay crashes php).
- Standard:
  - Fixed bug #72505 (readfile() mangles files larger than 2G).
  - Fixed bug #72306 (Heap overflow through proc_open and $env parameter).
- Session:
  - Fixed bug #72531 (ps_files_cleanup_dir Buffer overflow).
  - Fixed bug #72562 (Use After Free in unserialize() with Unexpected Session Deserialization).
- SNMP:
  - Fixed bug #72479 (Use After Free Vulnerability in SNMP with GC and unserialize()).
- Streams:
  - Fixed bug #72439 (Stream socket with remote address leads to a segmentation fault).
- XMLRPC:
  - Fixed bug #72606 (heap-buffer-overflow (write) simplestring_addn simplestring.c).
- Zip:
  - Fixed bug #72520 (Stack-based buffer overflow vulnerability in php_stream_zip_opener).