### PR TITLE
Update to 0.7

### DIFF
--- a/bucket/minisign.json
+++ b/bucket/minisign.json
@@ -2,8 +2,8 @@
     "homepage": "https://jedisct1.github.io/minisign/",
     "version": "0.6",
     "license": "https://github.com/jedisct1/minisign/blob/master/LICENSE",
-    "url": "https://github.com/jedisct1/minisign/releases/download/0.6/minisign-win32.zip",
-    "hash": "a49f1cab83d9503336bf16c6e77a217996cee32fcf82f43b79d6d0cdab9524e5",
+    "url": "https://github.com/jedisct1/minisign/releases/download/0.7/minisign-win32.zip",
+    "hash": "2a1cc74a608b24a3475b78b8943125e799c270cc8d0b940cceaec34e8f5e0e33",
     "extract_dir": "minisign-win32",
     "bin": "minisign.exe"
 }


### PR DESCRIPTION
* The default location of the secret key was changed to ~/.minisign/minisign.key.

* Generating a new set of keys (-G) doesn't replace an existing key pair any more; the additional -f switch is required in order to force this operation.

* Improved error messages and Windows compatibility.

* A man page was added.