### PR TITLE
Add Apache Thrift 0.9.3

### DIFF
--- a/bucket/thrift.json
+++ b/bucket/thrift.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "http://http://thrift.apache.org/",
+    "version": "0.9.3",
+    "licence": "Apache License v2.0",
+    "url": "http://www-us.apache.org/dist/thrift/0.9.3/thrift-0.9.3.exe",
+    "hash": "md5:d373614a4fac5cf0aff1340dfe630acb",
+    "bin": [["thrift-0.9.3.exe", "thrift"]],
+    "checkver": "<div class=\"span3 well center pull-right\"><p>Apache Thrift v([0-99\\.]+)</p></div>"
+}


### PR DESCRIPTION
Hi @lukesampson,

I would like to suggest the addition of [Apache Thrift](http://thrift.apache.org) to the main repo.
Thrift is a developer tool to create distributed services with serialization across several programming language

Thanks,
Gustavo