### PR TITLE
Revert "Update youtube-dl to latest version"

### DIFF
--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://rg3.github.io/youtube-dl/",
     "license": "Unlicense",
-    "version": "2016.08.07",
-    "url": "https://yt-dl.org/downloads/2016.08.07/youtube-dl.exe",
-    "hash": "c393ebf93919429919c00f23d38b1dc10c12984a97f138839d06ab65dac521ec",
+    "version": "2016.06.11.3",
+    "url": "https://yt-dl.org/downloads/2016.06.11.3/youtube-dl.exe",
+    "hash": "9473dd82871be6eafd37cbd64da5249fb32e046b0b5d3b58d7d98b550567f8c5",
     "bin": "youtube-dl.exe",
     "depends": [
         "ffmpeg"


### PR DESCRIPTION
Reverts lukesampson/scoop#984, due to failed hash check for some and Windows Defender detects malware (Win32/Tefau.A!cl).