### PR TITLE
Update youtube-dl to version 2016.08.12

### DIFF
--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -8,4 +8,8 @@
     "depends": [
         "ffmpeg"
         ]
+    "checkver": {
+        "url": "http://rg3.github.io/youtube-dl/download.html"
+        "re": "<a href=\"https://yt-dl.org/downloads/([0-9\\.]+)/youtube-dl.exe\">Windows exe"
+    }
 }

--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://rg3.github.io/youtube-dl/",
-    "license": "Unlicense",
-    "version": "2016.06.11.3",
-    "url": "https://yt-dl.org/downloads/2016.06.11.3/youtube-dl.exe",
-    "hash": "9473dd82871be6eafd37cbd64da5249fb32e046b0b5d3b58d7d98b550567f8c5",
+    "license": "Public Domain",
+    "version": "2016.08.12",
+    "url": "https://yt-dl.org/downloads/2016.08.12/youtube-dl.exe",
+    "hash": "f72cbc484b954f2154d0ddc128bf76ba6cde0d4acbf1047ed286fe438c4155dd",
     "bin": "youtube-dl.exe",
     "depends": [
         "ffmpeg"

--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -7,7 +7,7 @@
     "bin": "youtube-dl.exe",
     "depends": [
         "ffmpeg"
-        ]
+        ],
     "checkver": {
         "url": "http://rg3.github.io/youtube-dl/download.html",
         "re": "<a href=\"https://yt-dl.org/downloads/([0-9\\.]+)/youtube-dl.exe\">Windows exe"

--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -9,7 +9,7 @@
         "ffmpeg"
         ]
     "checkver": {
-        "url": "http://rg3.github.io/youtube-dl/download.html"
+        "url": "http://rg3.github.io/youtube-dl/download.html",
         "re": "<a href=\"https://yt-dl.org/downloads/([0-9\\.]+)/youtube-dl.exe\">Windows exe"
     }
 }


### PR DESCRIPTION
Youtube-dl updated again.

Here is a link to the file on virustotal in case there's worry about there being something wrong with it this time:
https://virustotal.com/en/url/c5d7188f77b19ed13a0f9f00690aece860b70088a2b280f1c3711c87a4dcd83b/analysis/1471039807/

I also changed the license to public domain, which is more correct than "unlicensed" and added a checkver function, because this app updates frequently.