### PR TITLE
Update rust-msvc to 1.11.0

### DIFF
--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.rust-lang.org",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.10.0-i686-pc-windows-msvc.msi",
-            "hash": "ef856744b02d8ffd471c1d458aeea024b129fcc134605d6722518a27a403e853"
+            "url": "https://static.rust-lang.org/dist/rust-1.11.0-i686-pc-windows-msvc.msi",
+            "hash": "a8f93aad272f7d69014830ecb761abec60fea85ae19a36ff47c428dad0176a72"
         },
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.10.0-x86_64-pc-windows-msvc.msi",
-            "hash": "2e15a1d1cbedea878929d0e2d8357e16b270f888254cecf1bc02be9efed4507e"
+            "url": "https://static.rust-lang.org/dist/rust-1.11.0-x86_64-pc-windows-msvc.msi",
+            "hash": "41c071ccd28cb81555623e8584fd071fd6e950840160da60c3fc1c483f830af9"
         }
     },
     "bin": [


### PR DESCRIPTION
Rust [1.11](https://blog.rust-lang.org/2016/08/18/Rust-1.11.html) was recently released.