### PR TITLE
Update ReSharper CLT to 2016.2

### DIFF
--- a/bucket/resharper-clt.json
+++ b/bucket/resharper-clt.json
@@ -1,9 +1,12 @@
 {
-    "version": "2016.1.2",
+    "version": "2016.2",
     "homepage": "https://www.jetbrains.com/resharper/download/index.html#section=resharper-clt",
     "license": "https://www.jetbrains.com/resharper/buy/command_line_license.html",
-    "url": "https://download-cf.jetbrains.com/resharper/JetBrains.ReSharper.CommandLineTools.2016.1.20160523.144749.zip",
-    "hash": "95e40e9f8d34690e4d1b47954a2b2a4e97eca6a8284c53d7b6d5f45718019ea2",
+    "url": "https://download.jetbrains.com/resharper/JetBrains.ReSharper.CommandLineTools.2016.2.20160818.172304.zip",
+    "hash": "060cae3b5bb9000465f6e402e12da4c15e3c1339ad4bd6178b6e69d754ccc937",
     "bin": ["dupfinder.exe", "inspectcode.exe"],
-    "checkver": "<span data-release-version data-code=\"RSU\">([\\w+.*]+)</span>"
+    "checkver": {
+      "url": "https://www.jetbrains.com/help/resharper/Introduction__Whats_New.html",
+      "re": "<h2>ReSharper/ReSharper\\s+C\\+\\+\\s+((\\d+\\.*)+)</h2>"
+    }
 }

--- a/bucket/thrift.json
+++ b/bucket/thrift.json
@@ -5,5 +5,5 @@
     "url": "http://www-us.apache.org/dist/thrift/0.9.3/thrift-0.9.3.exe",
     "hash": "md5:d373614a4fac5cf0aff1340dfe630acb",
     "bin": [["thrift-0.9.3.exe", "thrift"]],
-    "checkver": "<div class=\"span3 well center pull-right\"><p>Apache Thrift v([0-99\\.]+)</p></div>"
+    "checkver": "Apache\\s+Thrift\\s+v([0-99\\.]+)"
 }


### PR DESCRIPTION
Hi @lukesampson,

JetBrains launched an updated version of its popular ReSharper plugin and this PR update it to the latest version.

I've also fixed update checkers for thrift and resharper-clt packages as now I can use ```checkver.ps1``` script to detect new versions.

Thanks