### PR TITLE
Update pngcrush manifest to version 1.8.6

### DIFF
--- a/bucket/pngcrush.json
+++ b/bucket/pngcrush.json
@@ -1,20 +1,20 @@
 {
     "homepage": "http://pmt.sourceforge.net/pngcrush/",
-    "version": "1.8.4",
+    "version": "1.8.6",
     "license": "libpng",
     "architecture": {
         "64bit": {
-            "url": "http://downloads.sourceforge.net/project/pmt/pngcrush-executables/1.8.4/pngcrush_1_8.4_w64.exe",
-            "hash": "0e6fe8d520689b471a7e30908181836421f3ce1c7e84924ca06e6738859a8116",
+            "url": "http://downloads.sourceforge.net/project/pmt/pngcrush-executables/1.8.6/pngcrush_1_8_6_w64.exe",
+            "hash": "sha1:d27e9498ee805ff3d32f4c58a5fc9e5c8efa2cc8",
             "bin": [
-                ["pngcrush_1_8.4_w64.exe", "pngcrush"]
+                ["pngcrush_1_8_6_w64.exe", "pngcrush"]
             ]
         },
         "32bit": {
-            "url": "http://downloads.sourceforge.net/project/pmt/pngcrush-executables/1.8.4/pngcrush_1_8.4_w32.exe",
-            "hash": "eeba7658d3c70d1d74cad078158de2a8ed18f8c5337b94ab93ade2b0b28c239f",
+            "url": "http://downloads.sourceforge.net/project/pmt/pngcrush-executables/1.8.6/pngcrush_1_8_6_w32.exe",
+            "hash": "sha1:d40781b68b4bded69400169c5e97157e17e2683a",
             "bin": [
-                ["pngcrush_1_8.4_w32.exe", "pngcrush"]
+                ["pngcrush_1_8_6_w32.exe", "pngcrush"]
             ]
         }
     }


### PR DESCRIPTION
Version 1.8.4 was moved to an old_versions directory so this manifest wasn't functioning any more.

Updated urls to those from here: https://sourceforge.net/projects/pmt/files/pngcrush-executables/1.8.6/
Used sha1 hash as listed on sourceforge.