### PR TITLE
Update git-with-openssh to 2.10.1.windows.1

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -4,12 +4,12 @@
     "version": "2.10.0.windows.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.0.windows.1/PortableGit-2.10.0-64-bit.7z.exe#/dl.7z",
-            "hash": "d23b81e88949042d34e97bfd1e5b579d4b6aadec085c6ff6b05c4579da1d49e4"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/PortableGit-2.10.1-64-bit.7z.exe#/dl.7z",
+            "hash": "aa0634e026c70fe8b50207b8b125a18f45e259eac32cea246e068577a6546718"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.0.windows.1/PortableGit-2.10.0-32-bit.7z.exe#/dl.7z",
-            "hash": "89940cca2a8e1b18b5ed6e3d46c97ea4fcfe1628cda3ae452cd2a8984a3c25c8"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/PortableGit-2.10.1-32-bit.7z.exe#/dl.7z",
+            "hash": "3ca6f426e3b2e6675a11b680f719c23affa7e4dc060e315375c6a262ed2658a5"
         }
     },
     "bin": [


### PR DESCRIPTION
Again, simply copied and pasted the changes from #1067.

Should we add some kind of a comment to both manifests, so that maintainers are aware that there are two of them?