### PR TITLE
Add Gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Scoop [![Build status](https://ci.appveyor.com/api/projects/status/05foxatmrqo0l788?svg=true)](https://ci.appveyor.com/project/lukesampson/scoop)
+Scoop [![Build status](https://ci.appveyor.com/api/projects/status/05foxatmrqo0l788?svg=true)](https://ci.appveyor.com/project/lukesampson/scoop) [![Gitter chat](https://badges.gitter.im/lukesampson/scoop.png)](https://gitter.im/lukesampson/scoop)
 =====
 
 Scoop is a command-line installer for Windows.


### PR DESCRIPTION
This repo seems prime to have a bunch of conversation going in the Gitter channel - all sorts of other projects use it to great effect.

Whilst @lukesampson isn't on Gitter, the channel already has a few lurkers!

Might be worth adding a Gitter chat badge?