### PR TITLE
yarn 0.16.1

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -1,9 +1,10 @@
 {
     "homepage": "https://yarnpkg.com/",
     "licence": "BSD",
-    "version": "0.15.0",
-    "url": "https://github.com/yarnpkg/yarn/releases/download/v0.15.0/yarn-0.15.0.msi",
-    "hash": "ab878b8d188257e6d3b127873610aa80d37c51b3ff1e0a0dd321adbfacc738fe",
+    "version": "0.16.1",
+    "depends": "nodejs",
+    "url": "https://github.com/yarnpkg/yarn/releases/download/v0.16.1/yarn-0.16.1.msi",
+    "hash": "77eadf9e1982d44e3fd95da48da12b37a43bcb8bf359b4c1bcdf4d6f261eab18",
     "bin": "Yarn\\bin\\yarn.cmd",
     "checkver": {
         "url": "https://github.com/yarnpkg/yarn/releases/latest",


### PR DESCRIPTION
This bucket currently fails to install on my system, because "nodejs" path is too long (bug #1104)