### PR TITLE
Print '0 B' when cache is empty

### DIFF
--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -26,7 +26,7 @@ switch($cmd) {
     }
     'show' {
         $files = @(gci "$scoopdir\cache" | ? { $_.name -match "^$app" })
-        $total_length = ($files | measure length -sum).sum
+        $total_length = ($files | measure length -sum).sum -as [double]
 
         $f_app  = @{ expression={"$($_.app) ($($_.version))" }}
         $f_url  = @{ expression={$_.url};alignment='right'}


### PR DESCRIPTION
If cache is empty `$total_length` is null, and the output is:
```
λ scoop cache show some-non-existing-app
total: 0 files,  B
```

Cast sum to double to get '0 B' instead