### PR TITLE
Update outdated apps

### DIFF
--- a/bucket/aria2.json
+++ b/bucket/aria2.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://aria2.github.io/",
     "license": "GPL2 or later",
-    "version": "1.27.1",
+    "version": "1.28.0",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/aria2/aria2/releases/download/release-1.27.1/aria2-1.27.1-win-32bit-build1.zip",
-            "hash": "6a2bce7eeebe3b19d1a7cefc30e210d0a29a66b5c0179d904384f0e4cb66be58",
-            "extract_dir": "aria2-1.27.1-win-32bit-build1"
+            "url": "https://github.com/aria2/aria2/releases/download/release-1.28.0/aria2-1.28.0-win-32bit-build1.zip",
+            "hash": "0C3C27D31F20B745DB1802E19CF13D40E148DB4ED0BBED362D1C6F8B1029B5A0",
+            "extract_dir": "aria2-1.28.0-win-32bit-build1"
         },
         "64bit": {
-            "url": "https://github.com/aria2/aria2/releases/download/release-1.27.1/aria2-1.27.1-win-64bit-build1.zip",
-            "hash": "5cbb05356114aab24f5a98d465874c4cda8725e49b8315f2f6df95e6dffe10ef",
-            "extract_dir": "aria2-1.27.1-win-64bit-build1"
+            "url": "https://github.com/aria2/aria2/releases/download/release-1.28.0/aria2-1.28.0-win-64bit-build1.zip",
+            "hash": "4BC5F56219932F0DD26391A75DBF8C7175CA97797E4F0B1B122563B67205740A",
+            "extract_dir": "aria2-1.28.0-win-64bit-build1"
         }
     },
     "bin": "aria2c.exe",

--- a/bucket/cmake.json
+++ b/bucket/cmake.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://cmake.org/",
-    "version": "3.6.2",
+    "version": "3.6.3",
     "license": "https://cmake.org/licensing/",
     "architecture": {
         "64bit": {
-            "url": "https://cmake.org/files/v3.6/cmake-3.6.2-win64-x64.zip",
-            "hash": "61337a0528fc3902d7f2f7594959aa6aa48a52863dd2da335a0e248b5eb8acaf",
-            "extract_dir": "cmake-3.6.2-win64-x64"
+            "url": "https://cmake.org/files/v3.6/cmake-3.6.3-win64-x64.zip",
+            "hash": "263b78aba6e63098353b2f8beecf293f5f307f9a70575a81867c3f8cb18a6a99",
+            "extract_dir": "cmake-3.6.3-win64-x64"
         },
         "32bit": {
-            "url": "https://cmake.org/files/v3.6/cmake-3.6.2-win32-x86.zip",
-            "hash": "613eec5a8b2e2c49826e0e8e18f516b6f2b481309ae55925d226ce8ab78b0fba",
-            "extract_dir": "cmake-3.6.2-win32-x86"
+            "url": "https://cmake.org/files/v3.6/cmake-3.6.3-win32-x86.zip",
+            "hash": "556628f134b2372b8f02688787ca44b02d893c57b6eeaa9271ac51a4a2d4a4ed",
+            "extract_dir": "cmake-3.6.3-win32-x86"
         }
     },
     "bin": [

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -1,17 +1,17 @@
 {
-    "version": "20161015",
+    "version": "20161108",
     "homepage": "https://ffmpeg.zeranoe.com/builds/",
     "license": "GPL3",
     "architecture": {
         "64bit": {
-            "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20161015-4599e11-win64-static.zip",
-            "hash": "a7b400e1c67a172c168f62ce68181ac84e4e65a3305fd3a0efe232c67bf235be",
-            "extract_dir": "ffmpeg-20161015-4599e11-win64-static"
+            "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20161108-1bbb18f-win64-static.zip",
+            "hash": "6B3E69FB5100A8B2AA53446D8E74547FBF5B52154692E4B4597678DB496FB768",
+            "extract_dir": "ffmpeg-20161108-1bbb18f-win64-static"
         },
         "32bit": {
-            "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-20161015-4599e11-win32-static.zip",
-            "hash": "5ae383cfa9d73327a5a60380e66b51ae6680288c20a8c89f5a882cedb496703c",
-            "extract_dir": "ffmpeg-20161015-4599e11-win32-static"
+            "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-20161108-1bbb18f-win32-static.zip",
+            "hash": "DEEFD4AA6D85045EEBC8E53125B50C2F6CB8269C782E5E37438260985C26A7EA",
+            "extract_dir": "ffmpeg-20161108-1bbb18f-win32-static"
         }
     },
     "bin": [

--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.4.2",
+    "version": "1.4.4",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/github/git-lfs/releases/download/v1.4.2/git-lfs-windows-386-1.4.2.zip",
-            "hash": "c349a7b4ad2eac729c3d5fc1ef936215a1903ad89ecd1c6d2d2d43e689e6b93f",
-            "extract_dir": "git-lfs-windows-386-1.4.2"
+            "url": "https://github.com/github/git-lfs/releases/download/v1.4.4/git-lfs-windows-386-1.4.4.zip",
+            "hash": "84BA92866198F9DE71674580658C7F6FCDBE99200858023B6700C23FF414E79B",
+            "extract_dir": "git-lfs-windows-386-1.4.4"
         },
         "64bit": {
-            "url": "https://github.com/github/git-lfs/releases/download/v1.4.2/git-lfs-windows-amd64-1.4.2.zip",
-            "hash": "b3d673b616afbe34fb63e6d744c1e4595c4d0960a7d1a1addd1e48f2faf7d4ae",
-            "extract_dir": "git-lfs-windows-amd64-1.4.2"
+            "url": "https://github.com/github/git-lfs/releases/download/v1.4.4/git-lfs-windows-amd63-1.4.4.zip",
+            "hash": "CEBBCD8F138834E0BA42F468DC8707845217524FB98FE16C7C06AA0AFC984115",
+            "extract_dir": "git-lfs-windows-amd64-1.4.4"
         }
     },
     "depends": "git",

--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -2,15 +2,15 @@
     "_comment": "Maintainers: when updating this manifest to a new version, you might like to also update git.json",
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.10.1.windows.1",
+    "version": "2.10.2.windows.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/PortableGit-2.10.1-64-bit.7z.exe#/dl.7z",
-            "hash": "aa0634e026c70fe8b50207b8b125a18f45e259eac32cea246e068577a6546718"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.2.windows.1/PortableGit-2.10.2-64-bit.7z.exe#/dl.7z",
+            "hash": "101314826892480043D5B11989726FC8EE448991EB7B0A1C61ACA751161BC15B"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/PortableGit-2.10.1-32-bit.7z.exe#/dl.7z",
-            "hash": "3ca6f426e3b2e6675a11b680f719c23affa7e4dc060e315375c6a262ed2658a5"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.2.windows.1/PortableGit-2.10.2-32-bit.7z.exe#/dl.7z",
+            "hash": "EDC616817E96A6F15246BB0DD93C97E53D38D3B2A0B7375F26BD0BD082C41A73"
         }
     },
     "bin": [

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -2,15 +2,15 @@
     "_comment": "Maintainers: when updating this manifest to a new version, you might like to also update git-with-openssh.json",
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.10.1.windows.1",
+    "version": "2.10.2.windows.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/PortableGit-2.10.1-64-bit.7z.exe#/dl.7z",
-            "hash": "aa0634e026c70fe8b50207b8b125a18f45e259eac32cea246e068577a6546718"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.2.windows.1/PortableGit-2.10.2-64-bit.7z.exe#/dl.7z",
+            "hash": "101314826892480043D5B11989726FC8EE448991EB7B0A1C61ACA751161BC15B"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.1.windows.1/PortableGit-2.10.1-32-bit.7z.exe#/dl.7z",
-            "hash": "3ca6f426e3b2e6675a11b680f719c23affa7e4dc060e315375c6a262ed2658a5"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.10.2.windows.1/PortableGit-2.10.2-32-bit.7z.exe#/dl.7z",
+            "hash": "EDC616817E96A6F15246BB0DD93C97E53D38D3B2A0B7375F26BD0BD082C41A73"
         }
     },
     "bin": [

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.imagemagick.org/script/index.php",
     "license": "https://www.imagemagick.org/script/license.php",
-    "version": "7.0.3-4",
+    "version": "7.0.3-6",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.3-4-portable-Q16-x64.zip",
-            "hash": "4c590c1cd05b8937144442e77796b5e856db5a26b6434030a07dd7616c24b0e4"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.3-6-portable-Q16-x64.zip",
+            "hash": "b8a31b7591d416a824678252d9e148fc8a0b2f752f93eaabd82ae21b3bf60062"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.3-4-portable-Q16-x86.zip",
-            "hash": "99a0457e93f5dc7ce4ff332307af4c5d08b9009497fae8890f2eae71904b2353"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.3-6-portable-Q16-x86.zip",
+            "hash": "2ceebe9c3dd8b416887959330335d997bf71a1c2c97efaa836b00052470b3410"
         }
     },
     "env_add_path": ".",

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "7.0.0",
+    "version": "7.1.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v7.0.0/node-v7.0.0-x64.msi",
-            "hash": "4729fbe4f31122b2aed25d6f82412dac255ca233ccb00c870707936e330f69d0"
+            "url": "https://nodejs.org/dist/v7.1.0/node-v7.1.0-x64.msi",
+            "hash": "853936FE0AA946E16BBAB10D1C7E964BBF7A1820D12ADBFD748D7CF9F8059FA3"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v7.0.0/node-v7.0.0-x86.msi",
-            "hash": "75f9b61962884661fad941bb9c00bfc89dea78f4758cc661bb895f10d3c762d9"
+            "url": "https://nodejs.org/dist/v7.1.0/node-v7.1.0-x86.msi",
+            "hash": "5D95A909788239B4ED97C5F79B2D16837EA577A1A68E34E014D0A45DE7F27B1D"
         }
     },
     "env_add_path": "nodejs",

--- a/bucket/packer.json
+++ b/bucket/packer.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.packer.io",
     "license": "Mozilla Public License 2.0",
-    "version": "0.10.2",
+    "version": "0.11.0",
     "architecture": {
         "32bit": {
-            "url": "https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_windows_386.zip",
-            "hash": "69a7a0a4d54aeb291459fa226a45b6bff0d15e78592697536e9ec1735a0074e5"
+            "url": "https://releases.hashicorp.com/packer/0.11.0/packer_0.11.0_windows_386.zip",
+            "hash": "FF8149F71021EE65E16C264E42423082B079733A612EB2B6A0A959ABD2160D4C"
         },
         "64bit": {
-            "url": "https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_windows_amd64.zip",
-            "hash": "9ca8e8836b5f2f5a39e4e5090d7faabcf5839fa87487fb46bb34532e07531ccf"
+            "url": "https://releases.hashicorp.com/packer/0.11.0/packer_0.11.0_windows_amd64.zip",
+            "hash": "0A5FAE47BD7269A3E739E7F9E6B6DEA7564A80E02F30A152C9A071155EAAA65D"
         }
     },
     "bin": [

--- a/bucket/perl.json
+++ b/bucket/perl.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://strawberryperl.com",
-    "version": "5.22.1.2",
+    "version": "5.24.0.1",
     "license": "GPL",
     "architecture": {
         "32bit": {
-            "url": "http://strawberryperl.com/download/5.22.1.2/strawberry-perl-5.22.1.2-32bit-portable.zip",
-            "hash": "e6bb5c3e4d936bb1067560a58a21260693a0fbe34e55afb0111fe14f7eebc92c"
+            "url": "http://strawberryperl.com/download/5.24.0.1/strawberry-perl-5.24.0.1-32bit-portable.zip",
+            "hash": "29CECD3CF448799C9BFF5D3647ED703729C42332931C093525582BA053CD6543"
         },
         "64bit": {
-            "url": "http://strawberryperl.com/download/5.22.1.2/strawberry-perl-5.22.1.2-64bit-portable.zip",
-            "hash": "79beabb4dbc7b04e0bb0506832df91fc5a4732ce1cc16c4a39a7492fe81be75a"
+            "url": "http://strawberryperl.com/download/5.24.0.1/strawberry-perl-5.24.0.1-64bit-portable.zip",
+            "hash": "98330F799134F1693BAA3C20CF4092DEC957DF89F7A26C7D0AF3232B0141B388"
         }
     },
     "post_install":"

--- a/bucket/php-nts.json
+++ b/bucket/php-nts.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.0.12",
+    "version": "7.0.13",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-7.0.12-nts-Win32-VC14-x64.zip",
-            "hash": "sha1:8eaaf9703b4e0139e3b786cba20396a11fb0ff9d"
+            "url": "http://windows.php.net/downloads/releases/php-7.0.13-nts-Win32-VC14-x64.zip",
+            "hash": "1D117986B57CC57441A3056F578BA56A7FCBB53A7CD2D7DDCA7C634A6012687F"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/releases/php-7.0.12-nts-Win32-VC14-x86.zip",
-            "hash": "sha1:99c38a95b84914fba450daad95086928570ea5d8"
+            "url": "http://windows.php.net/downloads/releases/php-7.0.13-nts-Win32-VC14-x86.zip",
+            "hash": "8A9A0F8A0C368AE75C398B93238B2EE14CA7746E5E265CAC6D8A50AE5F9624DB"
         }
     },
     "bin": ["php.exe", "php-cgi.exe"],

--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,25 +1,25 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.0.12",
+    "version": "7.0.13",
     "license": "https://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.12-Win32-VC14-x64.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.13-Win32-VC14-x64.zip",
                 "https://raw.githubusercontent.com/madbub/scoop-php/master/64-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:8ccc6b638ce88f1461bb9a39f6784ed92419163d",
+                "E54130C0036B107E36A928CC2F0D5B46E8FD6D894128671995917E7A9FEA26DA",
                 "acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
             ]
         },
         "32bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.12-Win32-VC14-x86.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.13-Win32-VC14-x86.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:9e4213b64b60be99692317b9b156929881698335",
+                "62CB37344611F75F42718DCBDE0A1EF2B767D3E6AE2DC8C986CAED888811B1A7",
                 "b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
             ]
         }

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://www.r-project.org",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "license": "GPL2",
     "architecture": {
         "64bit": {
-            "url": "https://cran.rstudio.com/bin/windows/base/R-3.3.1-win.exe",
-            "hash": "48D5B9812769E36B2893D3DBA8D37AB49CEDA8A2DA220329F26C2C6470DFBB22",
+            "url": "https://cran.rstudio.com/bin/windows/base/R-3.3.2-win.exe",
+            "hash": "2E16180226268B9B07FA8668A3AC80F9BEA25EC82A2275150B2F3E2CA1C1FC14",
             "pre_install": "copy-item -recurse $dir\\bin\\x64 $dir\\bin\\curr_arch"
         },
         "32bit": {
-            "url": "https://cran.rstudio.com/bin/windows/base/R-3.3.1-win.exe",
-            "hash": "48D5B9812769E36B2893D3DBA8D37AB49CEDA8A2DA220329F26C2C6470DFBB22",
+            "url": "https://cran.rstudio.com/bin/windows/base/R-3.3.2-win.exe",
+            "hash": "2E16180226268B9B07FA8668A3AC80F9BEA25EC82A2275150B2F3E2CA1C1FC14",
             "pre_install": "copy-item -recurse $dir\\bin\\i386 $dir\\bin\\curr_arch"
         }
     },

--- a/bucket/sbcl.json
+++ b/bucket/sbcl.json
@@ -1,21 +1,21 @@
 {
     "homepage": "http://www.sbcl.org/",
-    "version": "1.3.10",
+    "version": "1.3.11",
     "license": "http://www.sbcl.org/history.html",
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/sbcl/files/sbcl/1.3.10/sbcl-1.3.10-x86-64-windows-binary.msi",
-            "hash": "45b3ee2366b26a294bf0dcf95cca5cdcd0c27f97c28d0028ada496f5a822e499"
+            "url": "https://sourceforge.net/projects/sbcl/files/sbcl/1.3.11/sbcl-1.3.11-x86-64-windows-binary.msi",
+            "hash": "29558087EEDFFDBA0EDB0DFE6739FE6142762624F8A7CE90A3E63BE3D5A39FB3"
         },
         "32bit": {
-            "url": "https://sourceforge.net/projects/sbcl/files/sbcl/1.3.10/sbcl-1.3.10-x86-windows-binary.msi",
-            "hash": "64a3bfa949df431182c173aa57df65ecd38bc0f1aa3c6c3accebd426f053ad69"
+            "url": "https://sourceforge.net/projects/sbcl/files/sbcl/1.3.11/sbcl-1.3.11-x86-windows-binary.msi",
+            "hash": "1ADB4BFBB51D54435FBCA94706BD99730962FE7E5342BC2569EC4BC40D624AAD"
         }
     },
     "env_set": {
-            "SBCL_HOME": "$dir\\PFiles\\Steel Bank Common Lisp\\1.3.10"
+            "SBCL_HOME": "$dir\\PFiles\\Steel Bank Common Lisp\\1.3.11"
         },
-    "bin": [ "PFiles\\Steel Bank Common Lisp\\1.3.10\\sbcl.exe"],
+    "bin": [ "PFiles\\Steel Bank Common Lisp\\1.3.11\\sbcl.exe"],
     "checkver": ">SBCL ([\\d.]+)<",
     "notes": "Please restart your command line for SBCL_HOME to take effect. Please consider installing http://www.quicklisp.org/"
 }

--- a/bucket/sqlite.json
+++ b/bucket/sqlite.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://www.sqlite.org/",
-    "version": "3.15.0",
+    "version": "3.15.1",
     "license": "Public Domain",
-    "url": "https://www.sqlite.org/2016/sqlite-tools-win32-x86-3150000.zip",
-    "hash": "78e9666ddd7df9ebf0beaf6c16a5d7b4efefa1577a992f17a66438e0f6f4dec7",
-    "extract_dir": "sqlite-tools-win32-x86-3150000",
+    "url": "https://www.sqlite.org/2016/sqlite-tools-win32-x86-3150100.zip",
+    "hash": "sha1:6f6a93dd3a79aae994109bcf07e8e9706a33956c",
+    "extract_dir": "sqlite-tools-win32-x86-3150100",
     "bin": [
         "sqlite3.exe",
         "sqldiff.exe",

--- a/bucket/terraform.json
+++ b/bucket/terraform.json
@@ -1,61 +1,18 @@
 {
     "homepage": "https://www.terraform.io",
     "license": "Mozilla Public License 2.0",
-    "version": "0.7.6",
+    "version": "0.7.10",
     "architecture": {
         "32bit": {
-            "url": "https://releases.hashicorp.com/terraform/0.7.6/terraform_0.7.6_windows_386.zip",
-            "hash": "1f95c2ee23cbf2acedb157ad5db668bde65720eab63b3439ff2383f5cf3dfdc3"
+            "url": "https://releases.hashicorp.com/terraform/0.7.10/terraform_0.7.10_windows_386.zip",
+            "hash": "6bac894a144d8dc5556855726611e4f48c41f208908e2836471399c1b716b4d4"
         },
         "64bit": {
-            "url": "https://releases.hashicorp.com/terraform/0.7.6/terraform_0.7.6_windows_amd64.zip",
-            "hash": "a14213e119eaa884ab18d482de295dfc794257e57345c93a09c5a0686844960d"
+            "url": "https://releases.hashicorp.com/terraform/0.7.10/terraform_0.7.10_windows_amd64.zip",
+            "hash": "caa7ae92e05f7ea24d66dee8a2af3788d277697666fd4d45f0d7e1f7be1e2186"
         }
     },
     "bin": [
-        "terraform-provider-atlas.exe",
-        "terraform-provider-aws.exe",
-        "terraform-provider-azure.exe",
-        "terraform-provider-azurerm.exe",
-        "terraform-provider-chef.exe",
-        "terraform-provider-clc.exe",
-        "terraform-provider-cloudflare.exe",
-        "terraform-provider-cloudstack.exe",
-        "terraform-provider-cobbler.exe",
-        "terraform-provider-consul.exe",
-        "terraform-provider-datadog.exe",
-        "terraform-provider-digitalocean.exe",
-        "terraform-provider-dme.exe",
-        "terraform-provider-dnsimple.exe",
-        "terraform-provider-docker.exe",
-        "terraform-provider-dyn.exe",
-        "terraform-provider-fastly.exe",
-        "terraform-provider-github.exe",
-        "terraform-provider-google.exe",
-        "terraform-provider-heroku.exe",
-        "terraform-provider-influxdb.exe",
-        "terraform-provider-librato.exe",
-        "terraform-provider-mailgun.exe",
-        "terraform-provider-mysql.exe",
-        "terraform-provider-null.exe",
-        "terraform-provider-openstack.exe",
-        "terraform-provider-packet.exe",
-        "terraform-provider-postgresql.exe",
-        "terraform-provider-powerdns.exe",
-        "terraform-provider-rundeck.exe",
-        "terraform-provider-softlayer.exe",
-        "terraform-provider-statuscake.exe",
-        "terraform-provider-template.exe",
-        "terraform-provider-terraform.exe",
-        "terraform-provider-tls.exe",
-        "terraform-provider-triton.exe",
-        "terraform-provider-ultradns.exe",
-        "terraform-provider-vcd.exe",
-        "terraform-provider-vsphere.exe",
-        "terraform-provisioner-chef.exe",
-        "terraform-provisioner-file.exe",
-        "terraform-provisioner-local-exec.exe",
-        "terraform-provisioner-remote-exec.exe",
         "terraform.exe"
     ],
     "checkver": {

--- a/bucket/vagrant.json
+++ b/bucket/vagrant.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://www.vagrantup.com/",
-    "version": "1.8.6",
+    "version": "1.8.7",
     "license": "MIT",
-    "url": "https://releases.hashicorp.com/vagrant/1.8.6/vagrant_1.8.6.msi",
-    "hash": "f80598f7a0cc0379e55e84dba32f3f683c5c73a9df7bf51245abed6d3255e8b3",
+    "url": "https://releases.hashicorp.com/vagrant/1.8.7/vagrant_1.8.7.msi",
+    "hash": "42e182946d1001bf3bd78f7610d4b5b5b4497133ad67abd9bbf4c43b3878e100",
     "extract_dir": "HashiCorp/Vagrant",
     "bin": "bin\\vagrant.exe",
     "checkver": {


### PR DESCRIPTION
I found the `bin/checkver` tool and was bored :-)

All apps expect `nano` (can't find a binary) and `rancher-compose` (not a stable release) are now up-to-date.