### PR TITLE
Update rust-msvc to 1.14.0

### DIFF
--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.rust-lang.org",
-    "version": "1.13.0",
+    "version": "1.14.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
         "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.13.0-i686-pc-windows-msvc.msi",
-            "hash": "34a2af41e51baef4193ae7e89582dbced69836c2f6d8cbf9d6ab2298f195b8f1"
+            "url": "https://static.rust-lang.org/dist/rust-1.14.0-i686-pc-windows-msvc.msi",
+            "hash": "ede76354e87b383594754024c38de7e6a6884ee10468cfa627709a9994d2088f"
         },
         "64bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.13.0-x86_64-pc-windows-msvc.msi",
-            "hash": "2be534fb76715048405ba53da5488a9268d441007777cbd327af47ca63547cc5"
+            "url": "https://static.rust-lang.org/dist/rust-1.14.0-x86_64-pc-windows-msvc.msi",
+            "hash": "af9d1e2d7804f5c75b694bc87f924d75d7e3b34776755eba277793a070ea3799"
         }
     },
     "bin": [


### PR DESCRIPTION
Rust [1.14.0](https://blog.rust-lang.org/2016/12/22/Rust-1.14.html) shipped today.