### PR TITLE
set execution policy on scoop install

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -4,6 +4,15 @@
 #   iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
 $erroractionpreference='stop' # quit if anything goes wrong
 
+# set correct execution policy automatically if not set already:
+$ep = get-executionpolicy cu; 
+if ($ep -ne "unrestricted") {
+    # Set execution policy on the process to hide error message
+    # that will otherwise show first time this script is run
+    set-executionpolicy unrestricted p
+    set-executionPolicy unrestricted cu 
+}
+
 # get core functions
 $core_url = 'https://raw.github.com/lukesampson/scoop/master/lib/core.ps1'
 echo 'initializing...'

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -5,12 +5,12 @@
 $erroractionpreference='stop' # quit if anything goes wrong
 
 # set correct execution policy automatically if not set already:
-$ep = get-executionpolicy cu; 
+$ep = get-executionpolicy cu;
 if ($ep -ne "unrestricted") {
     # Set execution policy on the process to hide error message
     # that will otherwise show first time this script is run
     set-executionpolicy unrestricted p
-    set-executionPolicy unrestricted cu 
+    set-executionPolicy unrestricted cu
 }
 
 # get core functions

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -7,8 +7,8 @@ $erroractionpreference='stop' # quit if anything goes wrong
 # show notification to change execution policy:
 $ep = get-executionpolicy cu;
 if ($ep -ne "unrestricted") {
-    "in order to be able to install programs scoop needs powershell execution policy for current user to be set to unrestricted."
-    "to make this change, please run 'set-executionPolicy unrestricted -s cu'"
+    "scoop needs powershell execution policy to be set to 'unrestricted' in order to install programs."
+    "to make this change please run 'set-executionPolicy unrestricted -s cu'"
     break
 }
 

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -7,10 +7,21 @@ $erroractionpreference='stop' # quit if anything goes wrong
 # set correct execution policy automatically if not set already:
 $ep = get-executionpolicy cu;
 if ($ep -ne "unrestricted") {
+    "in order to be able to install programs scoop needs to update"
+    "powershell execution policy for current user to be unrestricted."
+    "(alternatively you can make this change manually by running: set-executionPolicy unrestricted cu)"
+    $yn = read-host 'would you like to make this change? (yN)'
+    if ($yn -notlike 'y*') {
+        "installation stopped, cannot continue without correct execution policy."
+        break
+    }
     # Set execution policy on the process to hide error message
     # that will otherwise show first time this script is run
     set-executionpolicy unrestricted p
     set-executionPolicy unrestricted cu
+    $ep = get-executionpolicy cu;
+    "execution policy is set to unrestricted"
+    "continuing installation..."
 }
 
 # get core functions

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -4,24 +4,12 @@
 #   iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
 $erroractionpreference='stop' # quit if anything goes wrong
 
-# set correct execution policy automatically if not set already:
+# show notification to change execution policy:
 $ep = get-executionpolicy cu;
 if ($ep -ne "unrestricted") {
-    "in order to be able to install programs scoop needs to update"
-    "powershell execution policy for current user to be unrestricted."
-    "(alternatively you can make this change manually by running: set-executionPolicy unrestricted cu)"
-    $yn = read-host 'would you like to make this change? (yN)'
-    if ($yn -notlike 'y*') {
-        "installation stopped, cannot continue without correct execution policy."
-        break
-    }
-    # Set execution policy on the process to hide error message
-    # that will otherwise show first time this script is run
-    set-executionpolicy unrestricted p
-    set-executionPolicy unrestricted cu
-    $ep = get-executionpolicy cu;
-    "execution policy is set to unrestricted"
-    "continuing installation..."
+    "in order to be able to install programs scoop needs powershell execution policy for current user to be set to unrestricted."
+    "to make this change, please run 'set-executionPolicy unrestricted -s cu'"
+    break
 }
 
 # get core functions


### PR DESCRIPTION
I've tested this by running updated script as below:
```iex (new-object net.webclient).downloadstring('https://gist.githubusercontent.com/mikhail-tsennykh/f65a3addf22b36681b1eb7c6d708bed2/raw/4040fe0c156512a63b1dcfea2fd5595b26e1a1f1/scoop%2520auto%2520set%2520execution%2520policy%2520test')```

nice to skip extra step (unless there is some good reason not to do it on scoop install).