### PR TITLE
Update some apps / Some new autoupdate features / Add sha512 support

### DIFF
--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -1,10 +1,10 @@
 {
     "homepage": "http://ant.apache.org/",
-    "version": "1.9.7",
+    "version": "1.10.0",
     "license": "Apache 2.0",
-    "url": "http://www-us.apache.org/dist//ant/binaries/apache-ant-1.9.7-bin.zip",
-    "hash": "b28c5ea0b5ea90bb4ad6bab229b6a56ac4461760a251a12567803a69259cd9de",
-    "extract_dir": "apache-ant-1.9.7",
+    "url": "http://www-us.apache.org/dist/ant/binaries/apache-ant-1.10.0-bin.zip",
+    "hash": "sha512:6c2de8f8223fa852817155be0e7cd2057bfc7eb2c1b2a58c0f9c88172ea4b8c23167812bd32b9ec3ff423556e4e88ff1e85720d2515f62d0349b66cbc03aa5ee",
+    "extract_dir": "apache-ant-1.10.0",
     "env_add_path": "bin",
     "env_set": {
         "ANT_HOME": "$dir"
@@ -12,6 +12,15 @@
     "depends": "openjdk",
     "checkver": {
         "url": "https://ant.apache.org/bindownload.cgi",
-        "re": "Currently, Apache Ant ([\\d.]+) is the best"
+        "re": "Currently, Apache Ant (?:[\\d.]+ and )?([\\d.]+) (?:is|are) the best"
+    },
+    "autoupdate": {
+        "url": "http://www-us.apache.org/dist/ant/binaries/apache-ant-$version-bin.zip",
+        "extract_dir": "apache-ant-$version",
+        "hash": {
+            "mode": "extract",
+            "type": "sha512",
+            "url": "http://www-us.apache.org/dist/ant/binaries/apache-ant-$version-bin.zip.sha512"
+        }
     }
 }

--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -1,25 +1,40 @@
 {
-    "version": "0.9.3",
+    "version": "0.9.4",
     "homepage": "http://caddyserver.com",
     "license": "https://github.com/mholt/caddy/blob/master/LICENSE.txt",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mholt/caddy/releases/download/v0.9.3/caddy_windows_amd64.zip",
-            "hash": "19df428c8e16710b6376fef768b1a3be1d0297ccf0ec78ab1927d6ec41c1cc71",
+            "url": "https://github.com/mholt/caddy/releases/download/v0.9.4/caddy_windows_amd64.zip",
+            "hash": "8a73143fe859e0ba3b854fdc6ac4a81c7a69f32472fb6dc793fbf0c9a7ad3abc",
             "bin": [
-                ["caddy_windows_amd64.exe", "caddy"]
+                [
+                    "caddy_windows_amd64.exe",
+                    "caddy"
+                ]
             ]
         },
         "32bit": {
-            "url": "https://github.com/mholt/caddy/releases/download/v0.9.3/caddy_windows_386.zip",
-            "hash": "96c1eb95eee45bf304b26d78e2a1315494f5bd2d1f809fbb11d898a30aefab4b",
+            "url": "https://github.com/mholt/caddy/releases/download/v0.9.4/caddy_windows_386.zip",
+            "hash": "0cda4857e4a8a9f237b233e8755838e3e0bac05556e7fea8f035e6636232ad84",
             "bin": [
-                ["caddy_windows_386.exe", "caddy"]
+                [
+                    "caddy_windows_386.exe",
+                    "caddy"
+                ]
             ]
         }
     },
     "checkver": {
         "url": "https://github.com/mholt/caddy/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "re": "/releases/tag/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": {
+            "64bit": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_amd64.zip",
+            "32bit": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_386.zip"
+        },
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/curl.json
+++ b/bucket/curl.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://curl.haxx.se/",
-    "version": "7.52.0",
+    "version": "7.52.1",
     "licence": "MIT",
     "architecture": {
         "64bit": {
@@ -15,6 +15,15 @@
     "bin": "curl.exe",
     "checkver": {
       "url": "https://curl.haxx.se/download.html",
-      "re": "<a href=\"https://bintray\\.com/artifact/download/vszakats/generic/curl-([\\d.]+)-win64-mingw\\.7z\">"
+      "re": "curl ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": {
+            "64bit": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x64.7z",
+            "32bit": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x86.7z"
+        },
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.imagemagick.org/script/index.php",
     "license": "https://www.imagemagick.org/script/license.php",
-    "version": "7.0.4-0",
+    "version": "7.0.4-1",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-0-portable-Q16-x64.zip",
-            "hash": "f44f0f85c49cb844c171788328dfd02415315470c8ce498e890aeef163a8697f"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-1-portable-Q16-x64.zip",
+            "hash": "556c15330c27cae52dacc10eda1f034838e68c887524a040b6a1de49a7869eeb"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-0-portable-Q16-x86.zip",
-            "hash": "11e75283a12d99cd270f6af03b2b197caf4b43b17e557e6c2cd73e0c6062f638"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-1-portable-Q16-x86.zip",
+            "hash": "af30404e58c97bda5d4e1cceda5d06939878c0b8e8cc43ce58acbd98b6f9f601"
         }
     },
     "env_add_path": ".",
@@ -28,5 +28,15 @@
         "montage.exe",
         "stream.exe"
     ],
-    "checkver": "The current release is ImageMagick <a.*?>([0-9\\.p-]+)</a>"
+    "checkver": "The current release is ImageMagick <a.*?>([0-9\\.p-]+)</a>",
+    "autoupdate": {
+        "url": {
+            "64bit": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x64.zip",
+            "32bit": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x86.zip"
+        },
+        "hash": {
+            "mode": "rdf",
+            "url": "https://www.imagemagick.org/download/binaries/digest.rdf"
+        }
+    }
 }

--- a/bucket/nginx.json
+++ b/bucket/nginx.json
@@ -1,10 +1,10 @@
 {
     "homepage": "http://nginx.org",
-    "version": "1.11.6",
+    "version": "1.11.8",
     "license": "BSD",
-    "url": "http://nginx.org/download/nginx-1.11.6.zip",
-    "hash": "4b80ee51b3d044e49cd5d63a8f237f60a046aaf912ad7002a1b9b419f2c33480",
-    "extract_dir": "nginx-1.11.6",
+    "url": "http://nginx.org/download/nginx-1.11.8.zip",
+    "hash": "0f06c91e86322a7658fcd4c210e1af69512ae9ff974df5e2beb4e4952e678016",
+    "extract_dir": "nginx-1.11.8",
     "bin": "nginx.exe",
     "checkver": {
         "url": "https://nginx.org/en/CHANGES",

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "7.2.1",
+    "version": "7.3.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v7.2.1/node-v7.2.1-x64.msi",
-            "hash": "789af29eba3a43213dfab7a71ada7e2c513a9fa023f0987b2076b10754da907e"
+            "url": "https://nodejs.org/dist/v7.3.0/node-v7.3.0-x64.msi",
+            "hash": "4a08a27f816140f31cd826d14c31c84634e3c4e05f3cf71143496dbe96c241a9"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v7.2.1/node-v7.2.1-x86.msi",
-            "hash": "8302c95d26d343c131f403c088f8812540f4bebc5a01a98972599c03658e547b"
+            "url": "https://nodejs.org/dist/v7.3.0/node-v7.3.0-x86.msi",
+            "hash": "0451c0350a6d8feb78e8e81ca3dcb37183a3fd30c790055a8d1932b1eab0c5e4"
         }
     },
     "env_add_path": "nodejs",

--- a/bucket/pt.json
+++ b/bucket/pt.json
@@ -1,28 +1,29 @@
 {
     "homepage": "https://github.com/monochromegane/the_platinum_searcher",
     "licence": "MIT",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.4/pt_windows_amd64.zip"
-            ],
-            "hash": [
-                "6b227dc5e7e8bea2a0f20ae6301aceda60d394c86fb327db0caa8450fe89c86c"
-            ]
+            "url": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.5/pt_windows_amd64.zip",
+            "hash": "0f02db8eba977bc50b743ed18b4ba8efb769b7ade5f8a5c84e869d44117924bb"
         },
         "32bit": {
-            "url": [
-                "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.4/pt_windows_386.zip"
-            ],
-            "hash": [
-                "0c473879071a7e4d4e0cd47a59db973f296fe7d753a838c9811eac51dd4b8414"
-            ]
+            "url": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.5/pt_windows_386.zip",
+            "hash": "5756ebf64d3d65aa4ef7bb176f5170ea8abfd5e23bf349d7c64a408b2201732b"
         }
     },
     "bin": "pt.exe",
     "checkver": {
         "url": "https://github.com/monochromegane/the_platinum_searcher/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "re": "/releases/tag/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": {
+            "64bit": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_amd64.zip",
+            "32bit": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_386.zip"
+        },
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://yarnpkg.com/",
     "licence": "BSD",
-    "version": "0.17.10",
+    "version": "0.18.1",
     "depends": "nodejs",
-    "url": "https://github.com/yarnpkg/yarn/releases/download/v0.17.10/yarn-0.17.10.msi",
-    "hash": "5937c247697f43b305018438e2e4040842046402d264fb7a0863389d3776912e",
+    "url": "https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-0.18.1.msi",
+    "hash": "931405a771ec8f02e09aeea405a33bbde7b2d2610c42139397b22852a75cb786",
     "bin": "Yarn\\bin\\yarn.cmd",
     "checkver": {
         "url": "https://github.com/yarnpkg/yarn/releases/latest",

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -57,13 +57,17 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
         $hashfile_url = substitute $config.url @{'$version' = $version; '$url' = $url};
         $hashfile = (new-object net.webclient).downloadstring($hashfile_url)
 
-        $regex = substitute $config.find @{'$basename' = [regex]::Escape($basename)}
+        $regex = $config.find
+        if ($regex -eq $null) {
+            $regex = "([a-z0-9]+)"
+        }
+        $regex = substitute $regex @{'$basename' = [regex]::Escape($basename)}
 
         if ($hashfile -match $regex) {
             $hash = $matches[1]
 
-            if ($config.type -eq "sha1") {
-                $hash = "sha1:$hash"
+            if ($config.type -and !($config.type -eq "sha256")) {
+                $hash = $config.type + ":$hash"
             }
         }
     } elseif ($hashmode -eq "download") {

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -49,6 +49,7 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
     <#
     TODO implement more hashing types
     `extract` Should be able to extract from origin page source (checkver)
+    `rdf` Find hash from a RDF Xml file
     `download` Last resort, download the real file and hash it
     #>
     $hashmode = $config.mode
@@ -70,12 +71,12 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
                 $hash = $config.type + ":$hash"
             }
         }
+    } elseif ($hashmode -eq "rdf") {
+        return find_hash_in_rdf $config.url $basename
     } elseif ($hashmode -eq "download") {
         dl_with_cache $app $version $url $null $null $true
         $file = fullpath (cache_path $app $version $url)
         return compute_hash $file "sha256"
-    } elseif ($hashmode -eq "rdf") {
-        return find_hash_in_rdf $config.url $basename
     } else {
         Write-Host "Unknown hashmode $hashmode"
     }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -116,7 +116,7 @@ function prepareDownloadUrl([String] $template, [String] $version)
     <#
     TODO There should be a second option to extract the url from the page
     #>
-    return substitute $template @{'$version' = $version}
+    return substitute $template @{'$version' = $version; '$underscoreVersion' = ($version -replace "\.", "_")}
 }
 
 function autoupdate([String] $app, $json, [String] $version)

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -340,7 +340,7 @@ function check_hash($file, $url, $manifest, $arch) {
         $type, $expected = 'sha256', $type
     }
 
-    if(@('md5','sha1','sha256') -notcontains $type) {
+    if(@('md5','sha1','sha256', 'sha512') -notcontains $type) {
         return $false, "hash type $type isn't supported"
     }
 


### PR DESCRIPTION
While updating `ant` I only found official sha1 and sha512 hashes, instead of using sha1 I added support for sha512 to scoop.
@lukesampson Trying to install the updated `ant` manifest with an old version of scoop will fail, but this should never happen as `scoop update` will update scoop and the manifests. Am I right?

Autoupdate can now extract hashes from RDF XML files. (The imagemagick already use it)
_More autoupdate changes will follow_