### PR TITLE
Autoupdate improvments / App update / SHA512 support

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -3,7 +3,8 @@
 param(
     [String]$app,
     [String]$dir,
-    [Switch]$update = $false
+    [Switch]$update = $false,
+    [Switch]$forceUpdate = $false
 )
 
 if (!$app -and $update) {
@@ -90,6 +91,11 @@ while($in_progress -gt 0) {
             $ver = $matches[1]
             if($ver -eq $expected_ver) {
                 write-host "$ver" -f darkgreen
+
+                if ($forceUpdate -and $json.autoupdate) {
+                    Write-Host "Forcing autoupdate!" -f DarkMagenta
+                    autoupdate $app $json $ver
+                }
             } else {
                 write-host "$ver" -f darkred -nonewline
                 write-host " (scoop version is $expected_ver)" -NoNewline

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -49,12 +49,35 @@ $queue | % {
 
     $name, $json = $_
 
-    $url = $json.checkver.url
-    if(!$url) { $url = $json.homepage }
+    $githubRegex = "\/releases\/tag\/(?:v)?([\d.]+)"
+    if ($json.checkver -is [String]) {
+        if ($json.checkver -eq "github") {
+            if (!$json.homepage.StartsWith("https://github.com/")) {
+                write-host "ERROR: $name checkver expects the homepage to be a github repository" -f DarkYellow
+            }
+
+            $url = $json.homepage + "/releases/latest"
+            $regex = $githubRegex
+        } else {
+            $url = $json.homepage
+            $regex = $json.checkver
+        }
+    } else {
+        if ($json.checkver.github) {
+            $url = $json.checkver.github + "/releases/latest"
+            $regex = $githubRegex
+        } else {
+            $url = $json.checkver.url
+            if(!$url) { $url = $json.homepage }
+
+            $regex = $json.checkver.re
+        }
+    }
 
     $state = new-object psobject @{
         app = (strip_ext $name);
         url = $url;
+        regex = $regex;
         json = $json;
     }
 
@@ -73,14 +96,10 @@ while($in_progress -gt 0) {
     $json = $state.json
     $url = $state.url
     $expected_ver = $json.version
+    $regexp = $state.regex
 
     $err = $ev.sourceeventargs.error
     $page = $ev.sourceeventargs.result
-
-    $regexp = $json.checkver.re
-    if(!$regexp) { $regexp = $json.checkver }
-
-    $regexp = "(?s)$regexp"
 
     write-host "$app`: " -nonewline
 

--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -1,10 +1,10 @@
 {
     "homepage": "http://ant.apache.org/",
-    "version": "1.9.7",
+    "version": "1.10.0",
     "license": "Apache 2.0",
-    "url": "http://www-us.apache.org/dist//ant/binaries/apache-ant-1.9.7-bin.zip",
-    "hash": "b28c5ea0b5ea90bb4ad6bab229b6a56ac4461760a251a12567803a69259cd9de",
-    "extract_dir": "apache-ant-1.9.7",
+    "url": "http://www-us.apache.org/dist/ant/binaries/apache-ant-1.10.0-bin.zip",
+    "hash": "sha512:6c2de8f8223fa852817155be0e7cd2057bfc7eb2c1b2a58c0f9c88172ea4b8c23167812bd32b9ec3ff423556e4e88ff1e85720d2515f62d0349b66cbc03aa5ee",
+    "extract_dir": "apache-ant-1.10.0",
     "env_add_path": "bin",
     "env_set": {
         "ANT_HOME": "$dir"
@@ -12,6 +12,15 @@
     "depends": "openjdk",
     "checkver": {
         "url": "https://ant.apache.org/bindownload.cgi",
-        "re": "Currently, Apache Ant ([\\d.]+) is the best"
+        "re": "Currently, Apache Ant (?:[\\d.]+ and )?([\\d.]+) (?:is|are) the best"
+    },
+    "autoupdate": {
+        "url": "http://www-us.apache.org/dist/ant/binaries/apache-ant-$version-bin.zip",
+        "extract_dir": "apache-ant-$version",
+        "hash": {
+            "mode": "extract",
+            "type": "sha512",
+            "url": "http://www-us.apache.org/dist/ant/binaries/apache-ant-$version-bin.zip.sha512"
+        }
     }
 }

--- a/bucket/apex.json
+++ b/bucket/apex.json
@@ -16,7 +16,6 @@
     "pre_install": "Rename-Item @(Get-ChildItem $dir\\apex_*.exe)[0] $dir\\apex.exe",
     "bin": [ "apex.exe" ],
     "checkver": {
-        "url": "https://github.com/apex/apex/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/apex/apex"
     }
 }

--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -35,9 +35,6 @@
             "32bit": {
                 "url": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_386.zip"
             }
-        },
-        "hash": {
-            "mode": "download"
         }
     }
 }

--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -29,9 +29,13 @@
         "re": "/releases/tag/v([\\d.]+)"
     },
     "autoupdate": {
-        "url": {
-            "64bit": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_amd64.zip",
-            "32bit": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_386.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_386.zip"
+            }
         },
         "hash": {
             "mode": "download"

--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -1,25 +1,40 @@
 {
-    "version": "0.9.3",
+    "version": "0.9.4",
     "homepage": "http://caddyserver.com",
     "license": "https://github.com/mholt/caddy/blob/master/LICENSE.txt",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mholt/caddy/releases/download/v0.9.3/caddy_windows_amd64.zip",
-            "hash": "19df428c8e16710b6376fef768b1a3be1d0297ccf0ec78ab1927d6ec41c1cc71",
+            "url": "https://github.com/mholt/caddy/releases/download/v0.9.4/caddy_windows_amd64.zip",
+            "hash": "8a73143fe859e0ba3b854fdc6ac4a81c7a69f32472fb6dc793fbf0c9a7ad3abc",
             "bin": [
-                ["caddy_windows_amd64.exe", "caddy"]
+                [
+                    "caddy_windows_amd64.exe",
+                    "caddy"
+                ]
             ]
         },
         "32bit": {
-            "url": "https://github.com/mholt/caddy/releases/download/v0.9.3/caddy_windows_386.zip",
-            "hash": "96c1eb95eee45bf304b26d78e2a1315494f5bd2d1f809fbb11d898a30aefab4b",
+            "url": "https://github.com/mholt/caddy/releases/download/v0.9.4/caddy_windows_386.zip",
+            "hash": "0cda4857e4a8a9f237b233e8755838e3e0bac05556e7fea8f035e6636232ad84",
             "bin": [
-                ["caddy_windows_386.exe", "caddy"]
+                [
+                    "caddy_windows_386.exe",
+                    "caddy"
+                ]
             ]
         }
     },
     "checkver": {
         "url": "https://github.com/mholt/caddy/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "re": "/releases/tag/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": {
+            "64bit": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_amd64.zip",
+            "32bit": "https://github.com/mholt/caddy/releases/download/v$version/caddy_windows_386.zip"
+        },
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -25,8 +25,7 @@
         }
     },
     "checkver": {
-        "url": "https://github.com/mholt/caddy/releases/latest",
-        "re": "/releases/tag/v([\\d.]+)"
+        "github": "https://github.com/mholt/caddy"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/casperjs.json
+++ b/bucket/casperjs.json
@@ -10,7 +10,6 @@
 
     phantom19 is available in the versions bucket (scoop bucket add versions)",
     "checkver": {
-        "url": "https://github.com/n1k0/casperjs/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
+        "github": "https://github.com/n1k0/casperjs"
     }
 }

--- a/bucket/chromedriver.json
+++ b/bucket/chromedriver.json
@@ -6,9 +6,6 @@
     "bin":  "chromedriver.exe",
     "checkver": "Latest Release: <a href=\"[^\"]+\">ChromeDriver ([\\d.]+)",
     "autoupdate": {
-        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip"
     }
 }

--- a/bucket/curl.json
+++ b/bucket/curl.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://curl.haxx.se/",
-    "version": "7.52.0",
+    "version": "7.52.1",
     "licence": "MIT",
     "architecture": {
         "64bit": {
@@ -15,6 +15,15 @@
     "bin": "curl.exe",
     "checkver": {
       "url": "https://curl.haxx.se/download.html",
-      "re": "<a href=\"https://bintray\\.com/artifact/download/vszakats/generic/curl-([\\d.]+)-win64-mingw\\.7z\">"
+      "re": "curl ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": {
+            "64bit": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x64.7z",
+            "32bit": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x86.7z"
+        },
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/curl.json
+++ b/bucket/curl.json
@@ -14,13 +14,17 @@
     },
     "bin": "curl.exe",
     "checkver": {
-      "url": "https://curl.haxx.se/download.html",
-      "re": "curl ([\\d.]+)"
+        "url": "https://curl.haxx.se/download.html",
+        "re": "curl ([\\d.]+)"
     },
     "autoupdate": {
-        "url": {
-            "64bit": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x64.7z",
-            "32bit": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x86.7z"
+        "architecture": {
+            "64bit": {
+                "url": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x64.7z"
+            },
+            "32bit": {
+                "url": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x86.7z"
+            }
         },
         "hash": {
             "mode": "download"

--- a/bucket/curl.json
+++ b/bucket/curl.json
@@ -25,9 +25,6 @@
             "32bit": {
                 "url": "http://winampplugins.co.uk/curl/curl_$underscoreVersion_openssl_nghttp2_x86.7z"
             }
-        },
-        "hash": {
-            "mode": "download"
         }
     }
 }

--- a/bucket/devd.json
+++ b/bucket/devd.json
@@ -7,7 +7,6 @@
     "extract_dir":  "devd-0.5-windows64",
     "bin":  "devd.exe",
     "checkver": {
-        "url": "https://github.com/cortesi/devd/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/cortesi/devd"
     }
 }

--- a/bucket/docker-compose.json
+++ b/bucket/docker-compose.json
@@ -12,8 +12,5 @@
     "bin": [
         ["docker-compose.exe", "docker-compose"]
     ],
-    "checkver": {
-        "url": "https://github.com/docker/compose/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
-    }
+    "checkver": "github"
 }

--- a/bucket/docker-machine.json
+++ b/bucket/docker-machine.json
@@ -16,8 +16,5 @@
     "bin": [
         ["docker-machine.exe", "docker-machine"]
     ],
-    "checkver": {
-        "url": "https://github.com/docker/machine/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
-    }
+    "checkver": "github"
 }

--- a/bucket/elixir.json
+++ b/bucket/elixir.json
@@ -11,7 +11,6 @@
         "bin\\mix.bat"
     ],
     "checkver": {
-        "url": "https://github.com/elixir-lang/elixir/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/elixir-lang/elixir"
     }
 }

--- a/bucket/flow.json
+++ b/bucket/flow.json
@@ -7,7 +7,6 @@
     "bin":  "flow.exe",
     "extract_dir":  "flow",
     "checkver": {
-        "url": "https://github.com/facebook/flow/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/facebook/flow"
     }
 }

--- a/bucket/forge.json
+++ b/bucket/forge.json
@@ -7,7 +7,6 @@
         "bin\\forge.exe"
     ],
     "checkver": {
-        "url": "https://github.com/fsharp-editing/Forge/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
+        "github": "https://github.com/fsharp-editing/Forge"
     }
 }

--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -17,7 +17,6 @@
     "homepage": "https://git-lfs.github.com/",
     "bin": "git-lfs.exe",
     "checkver": {
-        "url": "https://github.com/github/git-lfs/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/github/git-lfs"
     }
 }

--- a/bucket/git-up.json
+++ b/bucket/git-up.json
@@ -15,8 +15,5 @@
         finally {
             popd
         }",
-    "checkver": {
-        "url": "https://github.com/msiemens/PyGitUp/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
-    }
+    "checkver": "github"
 }

--- a/bucket/glide.json
+++ b/bucket/glide.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/Masterminds",
+    "homepage": "https://glide.sh/",
     "license": "https://github.com/Masterminds/glide/blob/master/LICENSE",
     "version": "0.12.3",
     "architecture": {
@@ -16,7 +16,6 @@
     },
     "bin": "glide.exe",
     "checkver": {
-        "url": "https://github.com/Masterminds/glide/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/Masterminds/glide"
     }
 }

--- a/bucket/go.json
+++ b/bucket/go.json
@@ -19,9 +19,13 @@
     },
     "checkver": "Build version go([\\d\\.]+)\\.",
     "autoupdate": {
-        "url": {
-            "64bit": "https://storage.googleapis.com/golang/go$version.windows-amd64.zip",
-            "32bit": "https://storage.googleapis.com/golang/go$version.windows-386.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://storage.googleapis.com/golang/go$version.windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://storage.googleapis.com/golang/go$version.windows-386.zip"
+            }
         },
         "hash": {
             "mode": "extract",

--- a/bucket/grails.json
+++ b/bucket/grails.json
@@ -13,7 +13,6 @@
     },
     "depends": "openjdk",
     "checkver": {
-        "url": "https://github.com/grails/grails-core/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/grails/grails-core"
     }
 }

--- a/bucket/hub.json
+++ b/bucket/hub.json
@@ -16,7 +16,6 @@
         "bin\\hub.exe"
     ],
     "checkver": {
-        "url": "https://github.com/github/hub/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/github/hub"
     }
 }

--- a/bucket/hugo.json
+++ b/bucket/hugo.json
@@ -15,7 +15,6 @@
     },
     "homepage": "http://gohugo.io",
     "checkver": {
-        "url": "https://github.com/spf13/hugo/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/spf13/hugo"
     }
 }

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -30,9 +30,13 @@
     ],
     "checkver": "The current release is ImageMagick <a.*?>([0-9\\.p-]+)</a>",
     "autoupdate": {
-        "url": {
-            "64bit": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x64.zip",
-            "32bit": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x86.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x64.zip"
+            },
+            "32bit": {
+                "url": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x86.zip"
+            }
         },
         "hash": {
             "mode": "rdf",

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.imagemagick.org/script/index.php",
     "license": "https://www.imagemagick.org/script/license.php",
-    "version": "7.0.4-0",
+    "version": "7.0.4-1",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-0-portable-Q16-x64.zip",
-            "hash": "f44f0f85c49cb844c171788328dfd02415315470c8ce498e890aeef163a8697f"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-1-portable-Q16-x64.zip",
+            "hash": "556c15330c27cae52dacc10eda1f034838e68c887524a040b6a1de49a7869eeb"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-0-portable-Q16-x86.zip",
-            "hash": "11e75283a12d99cd270f6af03b2b197caf4b43b17e557e6c2cd73e0c6062f638"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-1-portable-Q16-x86.zip",
+            "hash": "af30404e58c97bda5d4e1cceda5d06939878c0b8e8cc43ce58acbd98b6f9f601"
         }
     },
     "env_add_path": ".",
@@ -28,5 +28,15 @@
         "montage.exe",
         "stream.exe"
     ],
-    "checkver": "The current release is ImageMagick <a.*?>([0-9\\.p-]+)</a>"
+    "checkver": "The current release is ImageMagick <a.*?>([0-9\\.p-]+)</a>",
+    "autoupdate": {
+        "url": {
+            "64bit": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x64.zip",
+            "32bit": "https://www.imagemagick.org/download/binaries/ImageMagick-$version-portable-Q16-x86.zip"
+        },
+        "hash": {
+            "mode": "rdf",
+            "url": "https://www.imagemagick.org/download/binaries/digest.rdf"
+        }
+    }
 }

--- a/bucket/kotlin.json
+++ b/bucket/kotlin.json
@@ -16,7 +16,6 @@
     },
     "depends": "openjdk",
     "checkver": {
-        "url": "https://github.com/JetBrains/kotlin/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/JetBrains/kotlin"
     }
 }

--- a/bucket/leiningen.json
+++ b/bucket/leiningen.json
@@ -6,9 +6,5 @@
     "bin": "lein.bat",
     "hash": "32385e54b54ec99ac8a37792347ca4f1a3c7feb792066d7ffc8f1e4c5b7c7ad1",
     "notes": "The command 'lein self-install' is required to complete the installation",
-    "checkver": {
-        "url": "https://github.com/technomancy/leiningen/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
-    }
+    "checkver": "github"
 }
-

--- a/bucket/lessmsi.json
+++ b/bucket/lessmsi.json
@@ -5,8 +5,5 @@
     "hash": "ea16da35477aff1ab63d71e0f1c08ca697cad6f7211ccdf7fb8fa2c7206a1ffa",
     "url": "https://github.com/activescott/lessmsi/releases/download/v1.4/lessmsi-v1.4.zip",
     "bin": "lessmsi.exe",
-    "checkver": {
-        "url": "https://github.com/activescott/lessmsi/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
-    }
+    "checkver": "github"
 }

--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -1,17 +1,17 @@
 {
     "homepage": "http://mariadb.org",
-    "version": "10.1.19",
+    "version": "10.1.20",
     "license": "GPL2",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.mariadb.org/f/mariadb-10.1.19/winx64-packages/mariadb-10.1.19-winx64.zip",
-            "hash": "sha1:7feb863b355bbf73d77ce3dafd416928e2459545",
-            "extract_dir": "mariadb-10.1.19-winx64"
+            "url": "https://downloads.mariadb.org/f/mariadb-10.1.20/winx64-packages/mariadb-10.1.20-winx64.zip",
+            "hash": "21e411b8c33c677bec954cea7b58f5bbd98037bba758a8b7fd8d8d9d861bf3ac",
+            "extract_dir": "mariadb-10.1.20-winx64"
         },
         "32bit": {
-            "url": "https://downloads.mariadb.org/f/mariadb-10.1.19/win32-packages/mariadb-10.1.19-win32.zip",
-            "hash": "sha1:e107f9b8b3ec60def3077880bec502150f45a340",
-            "extract_dir": "mariadb-10.1.19-win32"
+            "url": "https://downloads.mariadb.org/f/mariadb-10.1.20/win32-packages/mariadb-10.1.20-win32.zip",
+            "hash": "0e16c27c3e64f53f7e8d5b0e979ad2a30d00bcbab70a9d444d1d5e8e6c381de6",
+            "extract_dir": "mariadb-10.1.20-win32"
         }
     },
     "bin": [
@@ -50,5 +50,20 @@
     "checkver": {
         "url": "https://downloads.mariadb.org/",
         "re": "Download ([\\d.]+) Stable"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.mariadb.org/f/mariadb-$version/winx64-packages/mariadb-$version-winx64.zip",
+                "extract_dir": "mariadb-$version-winx64"
+            },
+            "32bit": {
+                "url": "https://downloads.mariadb.org/f/mariadb-$version/win32-packages/mariadb-$version-win32.zip",
+                "extract_dir": "mariadb-$version-win32"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -61,9 +61,6 @@
                 "url": "https://downloads.mariadb.org/f/mariadb-$version/win32-packages/mariadb-$version-win32.zip",
                 "extract_dir": "mariadb-$version-win32"
             }
-        },
-        "hash": {
-            "mode": "download"
         }
     }
 }

--- a/bucket/minisign.json
+++ b/bucket/minisign.json
@@ -7,7 +7,6 @@
     "extract_dir": "minisign-win32",
     "bin": "minisign.exe",
     "checkver": {
-        "url": "https://github.com/jedisct1/minisign/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
+        "github": "https://github.com/jedisct1/minisign"
     }
 }

--- a/bucket/modd.json
+++ b/bucket/modd.json
@@ -7,7 +7,6 @@
     "extract_dir":  "modd-0.3-windows64",
     "bin":  "modd.exe",
     "checkver": {
-        "url": "https://github.com/cortesi/modd/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/cortesi/modd"
     }
 }

--- a/bucket/nginx.json
+++ b/bucket/nginx.json
@@ -1,10 +1,10 @@
 {
     "homepage": "http://nginx.org",
-    "version": "1.11.6",
+    "version": "1.11.8",
     "license": "BSD",
-    "url": "http://nginx.org/download/nginx-1.11.6.zip",
-    "hash": "4b80ee51b3d044e49cd5d63a8f237f60a046aaf912ad7002a1b9b419f2c33480",
-    "extract_dir": "nginx-1.11.6",
+    "url": "http://nginx.org/download/nginx-1.11.8.zip",
+    "hash": "0f06c91e86322a7658fcd4c210e1af69512ae9ff974df5e2beb4e4952e678016",
+    "extract_dir": "nginx-1.11.8",
     "bin": "nginx.exe",
     "checkver": {
         "url": "https://nginx.org/en/CHANGES",

--- a/bucket/nginx.json
+++ b/bucket/nginx.json
@@ -12,9 +12,6 @@
     },
     "autoupdate": {
         "url": "http://nginx.org/download/nginx-$version.zip",
-        "hash": {
-            "mode": "download"
-        },
         "extract_dir": "nginx-$version"
     }
 }

--- a/bucket/ninja.json
+++ b/bucket/ninja.json
@@ -8,7 +8,6 @@
         "ninja.exe"
     ],
     "checkver": {
-        "url": "https://github.com/ninja-build/ninja/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/ninja-build/ninja"
     }
 }

--- a/bucket/nodejs-lts.json
+++ b/bucket/nodejs-lts.json
@@ -22,9 +22,13 @@ npm update -g",
         "re": "LTS version: <strong>v([\\d.]+)</strong>"
     },
     "autoupdate": {
-        "url": {
-            "64bit": "https://nodejs.org/dist/v$version/node-v$version-x64.msi",
-            "32bit": "https://nodejs.org/dist/v$version/node-v$version-x86.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-x64.msi"
+            },
+            "32bit": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-x86.msi"
+            }
         },
         "hash": {
             "mode": "extract",

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -22,9 +22,13 @@ npm update -g",
         "re": "Current version: <strong>v([\\d.]+)</strong>"
     },
     "autoupdate": {
-        "url": {
-            "64bit": "https://nodejs.org/dist/v$version/node-v$version-x64.msi",
-            "32bit": "https://nodejs.org/dist/v$version/node-v$version-x86.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-x64.msi"
+            },
+            "32bit": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-x86.msi"
+            }
         },
         "hash": {
             "mode": "extract",

--- a/bucket/nodejs.json
+++ b/bucket/nodejs.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "7.2.1",
+    "version": "7.3.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v7.2.1/node-v7.2.1-x64.msi",
-            "hash": "789af29eba3a43213dfab7a71ada7e2c513a9fa023f0987b2076b10754da907e"
+            "url": "https://nodejs.org/dist/v7.3.0/node-v7.3.0-x64.msi",
+            "hash": "4a08a27f816140f31cd826d14c31c84634e3c4e05f3cf71143496dbe96c241a9"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v7.2.1/node-v7.2.1-x86.msi",
-            "hash": "8302c95d26d343c131f403c088f8812540f4bebc5a01a98972599c03658e547b"
+            "url": "https://nodejs.org/dist/v7.3.0/node-v7.3.0-x86.msi",
+            "hash": "0451c0350a6d8feb78e8e81ca3dcb37183a3fd30c790055a8d1932b1eab0c5e4"
         }
     },
     "env_add_path": "nodejs",

--- a/bucket/nssm.json
+++ b/bucket/nssm.json
@@ -31,9 +31,6 @@
             "32bit": {
                 "extract_dir": "nssm-$version/win32"
             }
-        },
-        "hash": {
-            "mode": "download"
         }
     },
     "notes": "Manage Services with NSSM (GUI based) (e.g., 'nssm install nginx' to install nginx as service gui will popup or 'nssm start/status/stop apache').

--- a/bucket/nssm.json
+++ b/bucket/nssm.json
@@ -1,23 +1,41 @@
 {
-  "homepage": "https://nssm.cc",
-  "version": "2.24",
-  "url": "https://nssm.cc/release/nssm-2.24.zip",
-  "hash": "727d1e42275c605e0f04aba98095c38a8e1e46def453cdffce42869428aa6743",
-  "architecture": {
-    "64bit": {
-      "extract_dir": "nssm-2.24/win64"
+    "homepage": "https://nssm.cc",
+    "version": "2.24",
+    "url": "https://nssm.cc/release/nssm-2.24.zip",
+    "hash": "727d1e42275c605e0f04aba98095c38a8e1e46def453cdffce42869428aa6743",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "nssm-2.24/win64"
+        },
+        "32bit": {
+            "extract_dir": "nssm-2.24/win32"
+        }
     },
-    "32bit": {
-      "extract_dir": "nssm-2.24/win32"
-    }
-  },
-  "bin": [
-    "nssm.exe",
-    ["nssm.exe", "service"]
-  ],
-  "checkver": {
-    "re": "<a href=\"/release/nssm-([\\d.]+)\\.zip\"",
-    "url": "https://nssm.cc/download"
-  },
-  "notes": "Manage Services with NSSM (GUI based) (e.g., 'nssm install nginx' to install nginx as service gui will popup or 'nssm start/status/stop apache').\nVisit https://nssm.cc/commands for more info"
+    "bin": [
+        "nssm.exe",
+        [
+            "nssm.exe",
+            "service"
+        ]
+    ],
+    "checkver": {
+        "re": "<a href=\"/release/nssm-([\\d.]+)\\.zip\"",
+        "url": "https://nssm.cc/download"
+    },
+    "autoupdate": {
+        "url": "https://nssm.cc/release/nssm-$version.zip",
+        "architecture": {
+            "64bit": {
+                "extract_dir": "nssm-$version/win64"
+            },
+            "32bit": {
+                "extract_dir": "nssm-$version/win32"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        }
+    },
+    "notes": "Manage Services with NSSM (GUI based) (e.g., 'nssm install nginx' to install nginx as service gui will popup or 'nssm start/status/stop apache').
+Visit https://nssm.cc/commands for more info"
 }

--- a/bucket/nvm.json
+++ b/bucket/nvm.json
@@ -1,4 +1,5 @@
 {
+    "homepage": "https://github.com/coreybutler/nvm-windows",
     "version": "1.1.1",
     "url": "https://github.com/coreybutler/nvm-windows/releases/download/1.1.1/nvm-noinstall.zip",
     "extract_dir": "\\",
@@ -18,8 +19,5 @@
         }
     },
     "notes":"You'll need to restart powershell/cmd to have it reload Environment Variables so nvm will work correctly",
-    "checkver": {
-        "url": "https://github.com/coreybutler/nvm-windows/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
-    }
+    "checkver": "github"
 }

--- a/bucket/pcregrep.json
+++ b/bucket/pcregrep.json
@@ -19,7 +19,6 @@
        ,[ "pcre2test.exe", "pcretest" ]
     ],
     "checkver": {
-        "url": "https://github.com/rivy/PCRE/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
+        "github": "https://github.com/rivy/PCRE"
     }
 }

--- a/bucket/pester.json
+++ b/bucket/pester.json
@@ -29,8 +29,5 @@
         'importing pester for current session...'
         iex \"$import\"
     ",
-    "checkver": {
-        "url": "https://github.com/pester/pester/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
-    }
+    "checkver": "github"
 }

--- a/bucket/php-nts.json
+++ b/bucket/php-nts.json
@@ -22,9 +22,13 @@
         "re": "<h3 id=\"php-7.1\".*?>.*?\\(([\\d.]+)\\)</h3>"
     },
     "autoupdate": {
-        "url": {
-            "64bit": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x64.zip",
-            "32bit": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x86.zip"
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x86.zip"
+            }
         },
         "hash": {
             "mode": "extract",

--- a/bucket/php.json
+++ b/bucket/php.json
@@ -43,9 +43,13 @@ cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"
         "re": "<h3 id=\"php-7.1\".*?>.*?\\(([\\d.]+)\\)</h3>"
     },
     "autoupdate": {
-        "url": {
-            "64bit": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x64.zip",
-            "32bit": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x86.zip"
+        "architecture": {
+            "64bit": {
+                "url": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x64.zip"
+            },
+            "32bit": {
+                "url": "http://windows.php.net/downloads/releases/php-$version-Win32-VC14-x86.zip"
+            }
         },
         "hash": {
             "mode": "extract",

--- a/bucket/pt.json
+++ b/bucket/pt.json
@@ -25,9 +25,6 @@
             "32bit": {
                 "url": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_386.zip"
             }
-        },
-        "hash": {
-            "mode": "download"
         }
     }
 }

--- a/bucket/pt.json
+++ b/bucket/pt.json
@@ -1,28 +1,29 @@
 {
     "homepage": "https://github.com/monochromegane/the_platinum_searcher",
     "licence": "MIT",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.4/pt_windows_amd64.zip"
-            ],
-            "hash": [
-                "6b227dc5e7e8bea2a0f20ae6301aceda60d394c86fb327db0caa8450fe89c86c"
-            ]
+            "url": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.5/pt_windows_amd64.zip",
+            "hash": "0f02db8eba977bc50b743ed18b4ba8efb769b7ade5f8a5c84e869d44117924bb"
         },
         "32bit": {
-            "url": [
-                "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.4/pt_windows_386.zip"
-            ],
-            "hash": [
-                "0c473879071a7e4d4e0cd47a59db973f296fe7d753a838c9811eac51dd4b8414"
-            ]
+            "url": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.5/pt_windows_386.zip",
+            "hash": "5756ebf64d3d65aa4ef7bb176f5170ea8abfd5e23bf349d7c64a408b2201732b"
         }
     },
     "bin": "pt.exe",
     "checkver": {
         "url": "https://github.com/monochromegane/the_platinum_searcher/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "re": "/releases/tag/v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": {
+            "64bit": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_amd64.zip",
+            "32bit": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_386.zip"
+        },
+        "hash": {
+            "mode": "download"
+        }
     }
 }

--- a/bucket/pt.json
+++ b/bucket/pt.json
@@ -18,9 +18,13 @@
         "re": "/releases/tag/v([\\d.]+)"
     },
     "autoupdate": {
-        "url": {
-            "64bit": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_amd64.zip",
-            "32bit": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_386.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_amd64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/monochromegane/the_platinum_searcher/releases/download/v$version/pt_windows_386.zip"
+            }
         },
         "hash": {
             "mode": "download"

--- a/bucket/rancher-compose.json
+++ b/bucket/rancher-compose.json
@@ -17,7 +17,6 @@
         "rancher-compose.exe"
     ],
     "checkver": {
-        "url": "https://github.com/rancher/rancher-compose/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/rancher/rancher-compose"
     }
 }

--- a/bucket/rancher-compose.json
+++ b/bucket/rancher-compose.json
@@ -28,9 +28,6 @@
                 "url": "https://github.com/rancher/rancher-compose/releases/download/v$version/rancher-compose-windows-amd64-v$version.zip"
             }
         },
-        "hash": {
-            "mode": "download"
-        },
         "extract_dir": "rancher-compose-v$version"
     }
 }

--- a/bucket/rancher-compose.json
+++ b/bucket/rancher-compose.json
@@ -1,22 +1,36 @@
 {
     "homepage": "https://rancher.com/",
-    "version": "0.10.0",
+    "version": "0.12.0",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.10.0/rancher-compose-windows-386-v0.10.0.zip",
-            "hash":"5398e068e503f4b394cb185527b5876d5fb9f5a56072a34312d36512e60ec205"
+            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.12.0/rancher-compose-windows-386-v0.12.0.zip",
+            "hash": "64af3942c7327a2aab8dc07c961b78e7cbeced3c83cb8a072eb4f2532b09df12"
         },
         "64bit": {
-            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.10.0/rancher-compose-windows-amd64-v0.10.0.zip",
-            "hash": "cf095e0783f720cd51ca4cbeccb0074f495ab0d41dcf824575fce569fc8418aa"
+            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.12.0/rancher-compose-windows-amd64-v0.12.0.zip",
+            "hash": "825a7024e749c6beaab3294f5ae3f426eeb1f68afada348b00301822dce7617e"
         }
     },
     "license": "Apache 2.0",
-    "extract_dir": "rancher-compose-v0.10.0",
+    "extract_dir": "rancher-compose-v0.12.0",
     "bin": [
         "rancher-compose.exe"
     ],
     "checkver": {
         "github": "https://github.com/rancher/rancher-compose"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/rancher/rancher-compose/releases/download/v$version/rancher-compose-windows-386-v$version.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/rancher/rancher-compose/releases/download/v$version/rancher-compose-windows-amd64-v$version.zip"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        },
+        "extract_dir": "rancher-compose-v$version"
     }
 }

--- a/bucket/rg.json
+++ b/bucket/rg.json
@@ -13,8 +13,5 @@
         }
     },
     "bin": "rg.exe",
-    "checkver": {
-        "url": "https://github.com/BurntSushi/ripgrep/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
-    }
+    "checkver": "github"
 }

--- a/bucket/scriptcs.json
+++ b/bucket/scriptcs.json
@@ -7,7 +7,6 @@
     "extract_dir": "tools",
     "bin": "scriptcs.exe",
     "checkver": {
-        "url": "https://github.com/scriptcs/scriptcs/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/scriptcs/scriptcs"
     }
 }

--- a/bucket/syncany-cli.json
+++ b/bucket/syncany-cli.json
@@ -10,7 +10,6 @@
         "bin\\syncany.bat"
     ],
     "checkver": {
-        "url": "https://github.com/syncany/syncany/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/syncany/syncany"
     }
 }

--- a/bucket/upx.json
+++ b/bucket/upx.json
@@ -6,7 +6,6 @@
     "bin": "upx392w\\upx.exe",
     "license": "GPL2",
     "checkver": {
-        "url": "https://github.com/upx/upx/releases/latest",
-        "re": "\/releases\/tag\/v([\\d.]+)"
+        "github": "https://github.com/upx/upx"
     }
 }

--- a/bucket/vagrant.json
+++ b/bucket/vagrant.json
@@ -11,9 +11,6 @@
         "re": "vagrant_([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://releases.hashicorp.com/vagrant/$version/vagrant_$version.msi",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://releases.hashicorp.com/vagrant/$version/vagrant_$version.msi"
     }
 }

--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://yarnpkg.com/",
     "licence": "BSD",
-    "version": "0.17.10",
+    "version": "0.18.1",
     "depends": "nodejs",
-    "url": "https://github.com/yarnpkg/yarn/releases/download/v0.17.10/yarn-0.17.10.msi",
-    "hash": "5937c247697f43b305018438e2e4040842046402d264fb7a0863389d3776912e",
+    "url": "https://github.com/yarnpkg/yarn/releases/download/v0.18.1/yarn-0.18.1.msi",
+    "hash": "931405a771ec8f02e09aeea405a33bbde7b2d2610c42139397b22852a75cb786",
     "bin": "Yarn\\bin\\yarn.cmd",
     "checkver": {
         "url": "https://github.com/yarnpkg/yarn/releases/latest",

--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -11,9 +11,6 @@
         "re": "/releases/tag/v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/yarnpkg/yarn/releases/download/v$version/yarn-$version.msi",
-        "hash": {
-            "mode": "download"
-        }
+        "url": "https://github.com/yarnpkg/yarn/releases/download/v$version/yarn-$version.msi"
     }
 }

--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -9,7 +9,6 @@
         "ffmpeg"
     ],
     "checkver": {
-        "url": "https://github.com/rg3/youtube-dl/releases/latest",
-        "re": "\/releases\/tag\/([\\d.]+)"
+        "github": "https://github.com/rg3/youtube-dl"
     }
 }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -57,13 +57,17 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
         $hashfile_url = substitute $config.url @{'$version' = $version; '$url' = $url};
         $hashfile = (new-object net.webclient).downloadstring($hashfile_url)
 
-        $regex = substitute $config.find @{'$basename' = [regex]::Escape($basename)}
+        $regex = $config.find
+        if ($regex -eq $null) {
+            $regex = "([a-z0-9]+)"
+        }
+        $regex = substitute $regex @{'$basename' = [regex]::Escape($basename)}
 
         if ($hashfile -match $regex) {
             $hash = $matches[1]
 
-            if ($config.type -eq "sha1") {
-                $hash = "sha1:$hash"
+            if ($config.type -and !($config.type -eq "sha256")) {
+                $hash = $config.type + ":$hash"
             }
         }
     } elseif ($hashmode -eq "download") {

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -49,6 +49,7 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
     <#
     TODO implement more hashing types
     `extract` Should be able to extract from origin page source (checkver)
+    `rdf` Find hash from a RDF Xml file
     `download` Last resort, download the real file and hash it
     #>
     $hashmode = $config.mode
@@ -70,12 +71,12 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
                 $hash = $config.type + ":$hash"
             }
         }
+    } elseif ($hashmode -eq "rdf") {
+        return find_hash_in_rdf $config.url $basename
     } elseif ($hashmode -eq "download") {
         dl_with_cache $app $version $url $null $null $true
         $file = fullpath (cache_path $app $version $url)
         return compute_hash $file "sha256"
-    } elseif ($hashmode -eq "rdf") {
-        return find_hash_in_rdf $config.url $basename
     } else {
         Write-Host "Unknown hashmode $hashmode"
     }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -7,7 +7,7 @@ TODO
 
 function substitute([String] $str, [Hashtable] $params) {
     $params.GetEnumerator() | % {
-        $str = $str.Replace($_.Name, $_.Value);
+        $str = $str.Replace($_.Name, $_.Value)
     }
 
     return $str
@@ -17,7 +17,7 @@ function check_url([String] $url) {
     if ($url.Contains("github.com")) {
         # github does not allow HEAD requests
         warn "Unable to check github url (assuming it is ok)"
-        return $true;
+        return $true
     }
 
     $response = Invoke-WebRequest -Uri $url -Method HEAD
@@ -42,7 +42,7 @@ function find_hash_in_rdf([String] $url, [String] $filename)
     return $digest.sha256
 }
 
-function getHash([String] $app, $config, [String] $version, [String] $url)
+function get_hash_for_app([String] $app, $config, [String] $version, [String] $url)
 {
     $hash = $null
 
@@ -55,7 +55,7 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
     $hashmode = $config.mode
     $basename = fname($url)
     if ($hashmode -eq "extract") {
-        $hashfile_url = substitute $config.url @{'$version' = $version; '$url' = $url};
+        $hashfile_url = substitute $config.url @{'$version' = $version; '$url' = $url}
         $hashfile = (new-object net.webclient).downloadstring($hashfile_url)
 
         $regex = $config.find
@@ -84,7 +84,7 @@ function getHash([String] $app, $config, [String] $version, [String] $url)
     return $hash
 }
 
-function updateJsonFileWithNewVersion($json, [String] $version, [String] $url, [String] $hash, $architecture = $null)
+function update_manifest_with_new_version($json, [String] $version, [String] $url, [String] $hash, $architecture = $null)
 {
     $json.version = $version
 
@@ -112,7 +112,7 @@ function updateJsonFileWithNewVersion($json, [String] $version, [String] $url, [
     }
 }
 
-function prepareDownloadUrl([String] $template, [String] $version)
+function prepare_download_url([String] $template, [String] $version)
 {
     <#
     TODO There should be a second option to extract the url from the page
@@ -129,7 +129,7 @@ function autoupdate([String] $app, $json, [String] $version)
 
     if ($json.url) {
         # create new url
-        $url = prepareDownloadUrl $json.autoupdate.url $version
+        $url = prepare_download_url $json.autoupdate.url $version
 
         # check url
         if (!(check_url $url)) {
@@ -138,7 +138,7 @@ function autoupdate([String] $app, $json, [String] $version)
         }
 
         # create hash
-        $hash = getHash $app $json.autoupdate.hash $version $url
+        $hash = get_hash_for_app $app $json.autoupdate.hash $version $url
         if ($hash -eq $null) {
             $valid = $false
             Write-Host -f DarkRed "Could not find hash!"
@@ -147,7 +147,7 @@ function autoupdate([String] $app, $json, [String] $version)
         # write changes to the json object
         if ($valid) {
             $has_changes = $true
-            updateJsonFileWithNewVersion $json $version $url $hash
+            update_manifest_with_new_version $json $version $url $hash
         } else {
             $has_errors = $true
             Write-Host -f DarkRed "Could not update $app"
@@ -158,7 +158,7 @@ function autoupdate([String] $app, $json, [String] $version)
             $architecture = $_.Name
 
             # create new url
-            $url = prepareDownloadUrl $json.autoupdate.url.$architecture $version
+            $url = prepare_download_url $json.autoupdate.url.$architecture $version
 
             # check url
             if (!(check_url $url)) {
@@ -167,7 +167,7 @@ function autoupdate([String] $app, $json, [String] $version)
             }
 
             # create hash
-            $hash = getHash $app $json.autoupdate.hash $version $url
+            $hash = get_hash_for_app $app $json.autoupdate.hash $version $url
             if ($hash -eq $null) {
                 $valid = $false
                 Write-Host -f DarkRed "Could not find hash!"
@@ -176,7 +176,7 @@ function autoupdate([String] $app, $json, [String] $version)
             # write changes to the json object
             if ($valid) {
                 $has_changes = $true
-                updateJsonFileWithNewVersion $json $version $url $hash $architecture
+                update_manifest_with_new_version $json $version $url $hash $architecture
             } else {
                 $has_errors = $true
                 Write-Host -f DarkRed "Could not update $app $architecture"

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -116,7 +116,7 @@ function prepareDownloadUrl([String] $template, [String] $version)
     <#
     TODO There should be a second option to extract the url from the page
     #>
-    return substitute $template @{'$version' = $version}
+    return substitute $template @{'$version' = $version; '$underscoreVersion' = ($version -replace "\.", "_")}
 }
 
 function autoupdate([String] $app, $json, [String] $version)

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -73,15 +73,12 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         }
     } elseif ($hashmode -eq "rdf") {
         return find_hash_in_rdf $config.url $basename
-    } elseif ($hashmode -eq "download") {
+    } else {
+        Write-Host "Download files to compute hashes!" -f DarkYellow
         dl_with_cache $app $version $url $null $null $true
         $file = fullpath (cache_path $app $version $url)
         return compute_hash $file "sha256"
-    } else {
-        Write-Host "Unknown hashmode $hashmode"
     }
-
-    return $hash
 }
 
 function update_manifest_with_new_version($json, [String] $version, [String] $url, [String] $hash, $architecture = $null)

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -340,7 +340,7 @@ function check_hash($file, $url, $manifest, $arch) {
         $type, $expected = 'sha256', $type
     }
 
-    if(@('md5','sha1','sha256') -notcontains $type) {
+    if(@('md5','sha1','sha256', 'sha512') -notcontains $type) {
         return $false, "hash type $type isn't supported"
     }
 


### PR DESCRIPTION
_Sorry for the big pull request, I wanted to make multiple ones, but I ended up having dependencies between them_

## Autoupdate
 - [Breaking] I changed the `url` reference inside `autoupdate` to match the core logic ([commit](https://github.com/rrelmy/scoop/commit/68781a890ed84e3ee7646ded03ed1df98a29de7d))
 - Autoupdate can now extract hashes from RDF XML files. (The imagemagick already use it)
 - Option to update `extract_dir` with new version
 - Hash mode `download` is now the default if nothing is specified

_I also started to document the autoupdate pieces in the wiki_

@rasa 
I noticed you created your own [scoops](https://github.com/rasa/scoops) repo, nice work there.
You need to update your manifests if you have separate 32bit and 64bit URLs. (_Take a look at the breaking change_)
And you can remove `"hash": {"mode": "download"},` because it's the default behaviour now.

## Checkver
 - Added a [github helper](https://github.com/rrelmy/scoop/commit/98fba649fb6a87761c879006ae78ce482416c152)
 - New option `-forceUpdate` to force an autoupdate

## General
While updating `ant` I only found official sha1 and sha512 hashes, instead of using sha1 I added support for sha512 to scoop ([change](https://github.com/rrelmy/scoop/commit/5170cb9185dbdcada3855de41cbb5a0a9d03bd87#diff-c2a7e0e3e8869b7de54b5f172fc77009)).
@lukesampson Trying to install the updated `ant` manifest with an old version of scoop will fail, but this should never happen as `scoop update` will update scoop and the manifests. Am I right?

## Updated apps
I also added autoupdate if not already there

 - imagemagick
 - yarn
 - nodejs
 - ant
 - curl
 - caddy
 - pt
 - mariadb
 - rancher-compose
