### PR TITLE
Use manager credential helper for git

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -28,7 +28,7 @@
         "usr\\bin\\ssh-keyscan.exe"
     ],
     "post_install": [
-        "git config --global credential.helper wincred"
+        "git config --global credential.helper manager"
     ],
     "checkver": {
         "url": "https://github.com/git-for-windows/git/releases/latest",

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -20,7 +20,7 @@
         "git-bash.exe"
     ],
     "post_install": [
-        "git config --global credential.helper wincred"
+        "git config --global credential.helper manager"
     ],
     "notes": "To get Git to recognise OpenSSH, you will need to run\n\nscoop install openssh\n[environment]::setenvironmentvariable('GIT_SSH', (resolve-path (scoop which ssh)), 'USER')\n\nand then restart powershell.",
     "checkver": {


### PR DESCRIPTION
Manager has apparently replaced the wincred helper as of 2.x.