### PR TITLE
Add support for lzh format. (with 7zip)

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -16,7 +16,7 @@ function requires_lessmsi ($manifest, $architecture) {
 }
 
 function file_requires_7zip($fname) {
-    $fname -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(7z)|(rar)|(iso)|(xz))$'
+    $fname -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(7z)|(rar)|(iso)|(xz)|(lzh))$'
 }
 
 function extract_7zip($path, $to, $recurse) {


### PR DESCRIPTION
Thank you for really great software!
I like scoop so much.

Please add support for extracting .lzh format.
Because in Japan, some softwares is provided this legacy format...
ex)  http://ftp.vector.co.jp/43/51/2176/SoftTilt111.lzh

7zip can extract .lzh format.