### PR TITLE
Some updates and autoupdate fixes and improvements

### DIFF
--- a/bucket/far.json
+++ b/bucket/far.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://farmanager.com/",
-    "version": "3.0build4774",
+    "version": "3.0 build 4774",
     "architecture": {
         "64bit": {
             "url": "https://farmanager.com/files/Far30b4774.x64.20160902.7z",

--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -1,22 +1,34 @@
 {
-    "version": "1.5.3",
+    "homepage": "https://git-lfs.github.com/",
+    "version": "1.5.4",
     "license": "MIT",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/github/git-lfs/releases/download/v1.5.3/git-lfs-windows-386-1.5.3.zip",
-            "hash": "63017d38410e36d039e7a500f8aa2e8d80ca729f454de19a853b10ebf8920527",
-            "extract_dir": "git-lfs-windows-386-1.5.3"
+            "url": "https://github.com/github/git-lfs/releases/download/v1.5.4/git-lfs-windows-386-1.5.4.zip",
+            "hash": "5e320a40155ffe38d31a989c206bba7f1d581836851681aec58c9c893c3be098",
+            "extract_dir": "git-lfs-windows-386-1.5.4"
         },
         "64bit": {
-            "url": "https://github.com/github/git-lfs/releases/download/v1.5.3/git-lfs-windows-amd64-1.5.3.zip",
-            "hash": "75266d8798f7bb16dc163a7fef7f6145f53a7f740f098e10c8a8bdef56b4fc78",
-            "extract_dir": "git-lfs-windows-amd64-1.5.3"
+            "url": "https://github.com/github/git-lfs/releases/download/v1.5.4/git-lfs-windows-amd64-1.5.4.zip",
+            "hash": "173f0a6dc067d994abcc752bc99e983d996f9151597c3131c730af6da5caffd6",
+            "extract_dir": "git-lfs-windows-amd64-1.5.4"
         }
     },
     "depends": "git",
-    "homepage": "https://git-lfs.github.com/",
     "bin": "git-lfs.exe",
     "checkver": {
         "github": "https://github.com/github/git-lfs"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-386-$version.zip",
+                "extract_dir": "git-lfs-windows-386-$version"
+            },
+            "64bit": {
+                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-amd64-$version.zip",
+                "extract_dir": "git-lfs-windows-amd64-$version"
+            }
+        }
     }
 }

--- a/bucket/git-up.json
+++ b/bucket/git-up.json
@@ -1,12 +1,12 @@
 {
-    "version":  "1.4.0",
-    "license":  "https://github.com/msiemens/PyGitUp/blob/master/LICENCE",
-    "url":  "https://github.com/msiemens/PyGitUp/archive/v1.4.0.zip",
-    "hash":  "ed4c873b473e76e942089e17481db390809f4bbd906433e1d6373f9521c5640e",
-    "depends":  "python",
-    "extract_dir":  "PyGitUp-1.4.0",
-    "homepage":  "https://github.com/msiemens/PyGitUp",
-    "post_install":  "
+    "homepage": "https://github.com/msiemens/PyGitUp",
+    "license": "https://github.com/msiemens/PyGitUp/blob/master/LICENCE",
+    "version": "1.4.1",
+    "url": "https://github.com/msiemens/PyGitUp/archive/v1.4.1.zip",
+    "hash": "6e673c873d8d7fdb81537ae25ae57462f868e4a4348c9c5d12fb17d5f7a7a4a8",
+    "extract_dir": "PyGitUp-1.4.1",
+    "depends": "python",
+    "post_install": "
         pushd $dir
         try {
             scoop reset python
@@ -15,5 +15,9 @@
         finally {
             popd
         }",
-    "checkver": "github"
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/msiemens/PyGitUp/archive/v$version.zip",
+        "extract_dir": "PyGitUp-$version"
+    }
 }

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -12,6 +12,7 @@
             "hash": "30fd5bbb2ae0897eb015e37075b89d79c031a98bc2b41d929a66555c8b9606ea"
         }
     },
+    "depends": ["ffmpeg"],
     "env_add_path": ".",
     "bin": [
         "compare.exe",
@@ -19,10 +20,6 @@
         "conjure.exe",
         "convert.exe",
         "dcraw.exe",
-        [
-            "ffmpeg.exe",
-            "iffmpeg"
-        ],
         "hp2xx.exe",
         "identify.exe",
         "IMDisplay.exe",

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,18 +1,15 @@
 {
     "homepage": "https://www.imagemagick.org/script/index.php",
     "license": "https://www.imagemagick.org/script/license.php",
-    "version": "7.0.4-2",
+    "version": "7.0.4-3",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-2-portable-Q16-x64.zip",
-            "hash": "8d0115f4faf11565aaa618c37e995b7c01ee5bf29acb1353c88aa56835d2660b"
-
-
-
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-3-portable-Q16-x64.zip",
+            "hash": "a3cec661f432a62dcf64ab7037b7464e04ea9c67c6da24e608e3b50a00c09dc0"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-2-portable-Q16-x86.zip",
-            "hash": "d04bd324ce72d028f234cea4ed82547507d2f1fdbceddb647fccabd494dece73"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.4-3-portable-Q16-x86.zip",
+            "hash": "30fd5bbb2ae0897eb015e37075b89d79c031a98bc2b41d929a66555c8b9606ea"
         }
     },
     "env_add_path": ".",
@@ -22,7 +19,10 @@
         "conjure.exe",
         "convert.exe",
         "dcraw.exe",
-        ["ffmpeg.exe", "iffmpeg"],
+        [
+            "ffmpeg.exe",
+            "iffmpeg"
+        ],
         "hp2xx.exe",
         "identify.exe",
         "IMDisplay.exe",

--- a/bucket/kotlin.json
+++ b/bucket/kotlin.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://kotlinlang.org/",
-    "version": "1.0.3",
+    "version": "1.0.6",
     "license": "Apache 2.0",
-    "url": "https://github.com/JetBrains/kotlin/releases/download/v1.0.3/kotlin-compiler-1.0.3.zip",
-    "hash": "37615f1d63e8500cd33c7f3e60b715263f65189d6d8f25defba78968c896dc97",
+    "url": "https://github.com/JetBrains/kotlin/releases/download/v1.0.6/kotlin-compiler-1.0.6.zip",
+    "hash": "42a20b72d1e90f9efa9d13aab97559f478cc32b7c2e6da8569cdc3741a8e14b6",
     "extract_dir": "kotlinc",
     "bin": [
         "bin\\kotlin.bat",
@@ -17,5 +17,8 @@
     "depends": "openjdk",
     "checkver": {
         "github": "https://github.com/JetBrains/kotlin"
+    },
+    "autoupdate": {
+        "url": "https://github.com/JetBrains/kotlin/releases/download/v$version/kotlin-compiler-$version.zip"
     }
 }

--- a/bucket/mercurial.json
+++ b/bucket/mercurial.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.mercurial-scm.org/",
-    "version": "4.0",
+    "version": "4.0.2",
     "license": "http://www.gnu.org/licenses/gpl-2.0.txt",
     "architecture": {
         "64bit": {
-            "url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.0-x64.exe",
-            "hash": "88ed2fdabe8e8d48d3ac88d7aafb5a3a766e39d163444aa72aaeec962339fd9b"
+            "url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.0.2-x64.exe",
+            "hash": "c9f56f034844cd2318eb92cfb6e92a28da8c6fcfa193d989bf8f57e86e5ddba0"
         },
         "32bit": {
-            "url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.0.exe",
-            "hash": "7ddb974ecd327fd9a355ab4dc94de3c6b39f99dd5d456b27ccda8ac76d19bfe4"
+            "url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.0.2.exe",
+            "hash": "fe40952522c725c8decab7812f5b1c5310026dca52b5b17a94fb0bbbafee18cd"
         }
     },
     "innosetup": true,
@@ -17,5 +17,15 @@
     "checkver": {
         "url": "https://www.mercurial-scm.org/wiki/WhatsNew",
         "re": "Mercurial\\s+([\\d.]+)\\s+\\([0-9\\-]+\\)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.mercurial-scm.org/release/windows/Mercurial-$version-x64.exe"
+            },
+            "32bit": {
+                "url": "https://www.mercurial-scm.org/release/windows/Mercurial-$version.exe"
+            }
+        }
     }
 }

--- a/bucket/modd.json
+++ b/bucket/modd.json
@@ -1,12 +1,16 @@
 {
-    "version":  "0.3",
-    "license":  "https://github.com/cortesi/modd/blob/master/LICENSE",
-    "url":  "https://github.com/cortesi/modd/releases/download/v0.3/modd-0.3-windows64.zip",
-    "homepage":  "https://corte.si/posts/modd/announce/index.html",
-    "hash":  "91be7051e8fd7893192688ff4cc3daec887dc05fc6fa0a6565dd5b5bce374e44",
-    "extract_dir":  "modd-0.3-windows64",
-    "bin":  "modd.exe",
+    "homepage": "https://corte.si/posts/modd/announce/index.html",
+    "license": "https://github.com/cortesi/modd/blob/master/LICENSE",
+    "version": "0.4",
+    "url": "https://github.com/cortesi/modd/releases/download/v0.4/modd-0.4-windows64.zip",
+    "hash": "9d2f314a2fe8cfbc64a6e3657575e9de7d0410ff4cd12522b72663605ea2b03f",
+    "extract_dir": "modd-0.4-windows64",
+    "bin": "modd.exe",
     "checkver": {
         "github": "https://github.com/cortesi/modd"
+    },
+    "autoupdate": {
+        "url": "https://github.com/cortesi/modd/releases/download/v$version/modd-$version-windows64.zip",
+        "extract_dir": "modd-$version-windows64"
     }
 }

--- a/bucket/ninja.json
+++ b/bucket/ninja.json
@@ -1,13 +1,16 @@
 {
     "homepage": "https://ninja-build.org/",
-    "version": "1.7.1",
     "license": "Apache 2.0",
-    "url": "https://github.com/ninja-build/ninja/releases/download/v1.7.1/ninja-win.zip",
-    "hash": "4221b2cef768de64799077ba83ca9ca28e197415a34257ed8d54f93e899afc4e",
+    "version": "1.7.2",
+    "url": "https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-win.zip",
+    "hash": "95b36a597d33c1fe672829cfe47b5ab34b3a1a4c6bf628e5d150b6075df4ef50",
     "bin": [
         "ninja.exe"
     ],
     "checkver": {
         "github": "https://github.com/ninja-build/ninja"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ninja-build/ninja/releases/download/v$version/ninja-win.zip"
     }
 }

--- a/bucket/nodejs-lts.json
+++ b/bucket/nodejs-lts.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://nodejs.org",
-    "version": "6.9.2",
+    "version": "6.9.4",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/dist/v6.9.2/node-v6.9.2-x64.msi",
-            "hash": "9b2fcdd0d81e69a9764c3ce5a33087e02e94e8e23ea2b8c9efceebe79d49936e"
+            "url": "https://nodejs.org/dist/v6.9.4/node-v6.9.4-x64.msi",
+            "hash": "bbc2b045bb2b8e6f4822920e8b2956287639b476cded4620ca33ff1d7dbef195"
         },
         "32bit": {
-            "url": "https://nodejs.org/dist/v6.9.2/node-v6.9.2-x86.msi",
-            "hash": "f8b911a249d45358464135c41e7b16fe4abef8d047efb6183f043bc965632aea"
+            "url": "https://nodejs.org/dist/v6.9.4/node-v6.9.4-x86.msi",
+            "hash": "1de0ea5e6b699a650b921f14fb3fb13958ba0ced6a63fe49bac3a20b6e2b09f9"
         }
     },
     "env_add_path": "nodejs",

--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://github.com/ojdkbuild/ojdkbuild",
-    "version": "1.8.0_102-2",
+    "version": "1.8.0.111-3",
     "license": "GPL2",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ojdkbuild/ojdkbuild/releases/download/1.8.0.102-2/java-1.8.0-openjdk-1.8.0.102-2.b14.ojdkbuild.windows.x86_64.zip",
-            "hash": "8103db54f94d7379e8866a9b2eaec17d38f9164ee1159806e826a61be4905cc2",
-            "extract_dir": "java-1.8.0-openjdk-1.8.0.102-2.b14.ojdkbuild.windows.x86_64"
+            "url": "https://github.com/ojdkbuild/ojdkbuild/releases/download/1.8.0.111-3/java-1.8.0-openjdk-1.8.0.111-3.b15.ojdkbuild.windows.x86_64.zip",
+            "hash": "e080371bf57536668416157660e05d95fe04db15da36234d32bda8e301bb0454",
+            "extract_dir": "java-1.8.0-openjdk-1.8.0.111-3.b15.ojdkbuild.windows.x86_64"
         }
     },
     "env_add_path": "bin",
@@ -15,6 +15,15 @@
     },
     "checkver": {
         "url": "https://github.com/ojdkbuild/ojdkbuild/releases/latest",
-        "re": "\/releases\/tag\/([\\d.\\-]+)"
+        "re": "/releases/tag/([\\d.\\-]+)"
+    },
+    "autoupdate": {
+        "note": "Please check if the generated URL is correct. Sometime the b15 after the version can change too!",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ojdkbuild/ojdkbuild/releases/download/$version/java-1.8.0-openjdk-$version.b15.ojdkbuild.windows.x86_64.zip",
+                "extract_dir": "java-1.8.0-openjdk-$version.b15.ojdkbuild.windows.x86_64"
+            }
+        }
     }
 }

--- a/bucket/rg.json
+++ b/bucket/rg.json
@@ -1,17 +1,27 @@
 {
     "homepage": "https://github.com/BurntSushi/ripgrep",
     "licence": "MIT",
-    "version": "0.2.9",
+    "version": "0.3.2",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/BurntSushi/ripgrep/releases/download/0.2.9/ripgrep-0.2.9-x86_64-pc-windows-msvc.zip",
-            "hash": "22ba4ba70142f3d8fe575058e3a1ecb128b9dfdd037ae737fed5531857fa59ed"
+            "url": "https://github.com/BurntSushi/ripgrep/releases/download/0.3.2/ripgrep-0.3.2-x86_64-pc-windows-msvc.zip",
+            "hash": "bf5d8896078e9f2d5b50dd38f370269169cb723f2009ae5ae3a879f601570ff1"
         },
         "32bit": {
-            "url": "https://github.com/BurntSushi/ripgrep/releases/download/0.2.9/ripgrep-0.2.9-i686-pc-windows-msvc.zip",
-            "hash": "d1110d07500d3d68ead8af7801e650ee6b7cc207a9679093fd905cc015a9b811"
+            "url": "https://github.com/BurntSushi/ripgrep/releases/download/0.3.2/ripgrep-0.3.2-i686-pc-windows-msvc.zip",
+            "hash": "4949565197b3bcea0a4cd2f4fb978718b0fb0509bc1dad57d1691c5528c15ad4"
         }
     },
     "bin": "rg.exe",
-    "checkver": "github"
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/BurntSushi/ripgrep/releases/download/$version/ripgrep-$version-x86_64-pc-windows-msvc.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/BurntSushi/ripgrep/releases/download/$version/ripgrep-$version-i686-pc-windows-msvc.zip"
+            }
+        }
+    }
 }

--- a/bucket/scriptcs.json
+++ b/bucket/scriptcs.json
@@ -1,12 +1,15 @@
 {
     "homepage": "http://scriptcs.net/",
-    "version": "0.13.2",
+    "version": "0.16.1",
     "license": "Apache 2.0",
-    "url": "http://chocolatey.org/api/v2/package/ScriptCs/0.13.2?fn=/dl.zip",
-    "hash": "b0e24268e5e5258cd2f26bacfccb75427884cb00435358b724fbf15d5fb38083",
+    "url": "http://chocolatey.org/api/v2/package/ScriptCs/0.16.1?fn=/dl.zip",
+    "hash": "b5b4d7a080cf6354f9dc03c11f0100d2407910e5bcd87a8061315cc116510ce9",
     "extract_dir": "tools",
     "bin": "scriptcs.exe",
     "checkver": {
         "github": "https://github.com/scriptcs/scriptcs"
+    },
+    "autoupdate": {
+        "url": "http://chocolatey.org/api/v2/package/ScriptCs/$version?fn=/dl.zip"
     }
 }

--- a/bucket/syncany-cli.json
+++ b/bucket/syncany-cli.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://www.syncany.org/",
     "license": "https://raw.githubusercontent.com/syncany/syncany/develop/LICENSE.md",
-    "version": "0.4.0",
-    "url": "https://www.syncany.org/dist/releases/syncany-cli-0.4.0-alpha.exe",
-    "hash": "386365f99ea985a9abedab58439980500b3b62592531cd44af32e30f63df232d",
+    "version": "0.4.7",
+    "url": "https://www.syncany.org/dist/releases/syncany-cli-0.4.7-alpha.exe",
+    "hash": "2db6e8f77d39fb0094c48e7b5e434ba2014c4bf67f0632f2f065998e23e6fd23",
     "innosetup": true,
     "bin": [
         "bin\\sy.bat",
@@ -11,5 +11,8 @@
     ],
     "checkver": {
         "github": "https://github.com/syncany/syncany"
+    },
+    "autoupdate": {
+        "url": "https://www.syncany.org/dist/releases/syncany-cli-$version-alpha.exe"
     }
 }

--- a/bucket/xz.json
+++ b/bucket/xz.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://tukaani.org/xz/",
-    "version": "5.2.1",
     "license": "http://tukaani.org/xz/#licensing",
-    "url": "http://tukaani.org/xz/xz-5.2.1-windows.zip",
-    "hash": "2447f5e70dd105900a2957d6c2fad2b5872a6482ba59c1fa0513d03e8b2d10f4",
+    "version": "5.2.3",
+    "url": "http://tukaani.org/xz/xz-5.2.3-windows.zip",
+    "hash": "afe73c260e38fdebdd14c9eaab71c19b206ff74cebbdc744b0fa35b77b243220",
     "architecture": {
         "64bit": {
             "bin": [
@@ -22,5 +22,8 @@
             ]
         }
     },
-    "checkver": "<h3>Stable<\\/h3>\\s+<p>\\s+([\\d.]+) was released"
+    "checkver": "<h3>Stable<\\/h3>\\s+<p>\\s+([\\d.]+) was released",
+    "autoupdate": {
+        "url": "http://tukaani.org/xz/xz-$version-windows.zip"
+    }
 }

--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -1,14 +1,17 @@
 {
     "homepage": "https://rg3.github.io/youtube-dl/",
     "license": "Public Domain",
-    "version": "2016.11.08.1",
-    "url": "https://github.com/rg3/youtube-dl/releases/download/2016.11.08.1/youtube-dl.exe",
-    "hash": "aaf519d78c8aca2678ccf748458d6e21d559daa9a17ce2ac05d79910b94d8b67",
+    "version": "2017.01.05",
+    "url": "https://github.com/rg3/youtube-dl/releases/download/2017.01.05/youtube-dl.exe",
+    "hash": "f49311e938821f1f5d45c13c63492994ca30bdbdd5e5db3274bfe35cfb6272ec",
     "bin": "youtube-dl.exe",
     "depends": [
         "ffmpeg"
     ],
     "checkver": {
         "github": "https://github.com/rg3/youtube-dl"
+    },
+    "autoupdate": {
+        "url": "https://github.com/rg3/youtube-dl/releases/download/$version/youtube-dl.exe"
     }
 }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -115,11 +115,13 @@ function update_manifest_prop([String] $prop, $json)
     }
 
     # check if there are architecture specific variants
-    $json.architecture | Get-Member -MemberType NoteProperty | % {
-        $architecture = $_.Name
+    if ($json.architecture) {
+        $json.architecture | Get-Member -MemberType NoteProperty | % {
+            $architecture = $_.Name
 
-        if ($json.architecture.$architecture.$prop) {
-            $json.architecture.$architecture.$prop = substitute (arch_specific $prop $json.autoupdate $architecture) @{'$version' = $json.version}
+            if ($json.architecture.$architecture.$prop) {
+                $json.architecture.$architecture.$prop = substitute (arch_specific $prop $json.autoupdate $architecture) @{'$version' = $json.version}
+            }
         }
     }
 }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -207,6 +207,12 @@ function autoupdate([String] $app, $json, [String] $version)
 
         $file_content = $json | ConvertToPrettyJson
         [System.IO.File]::WriteAllLines($path, $file_content)
+
+        # notes
+        if ($json.autoupdate.note) {
+            Write-Host ""
+            Write-Host -f DarkYellow $json.autoupdate.note
+        }
     } else {
         Write-Host -f DarkGray "No updates for $app"
     }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -14,9 +14,9 @@ function substitute([String] $str, [Hashtable] $params) {
 }
 
 function check_url([String] $url) {
-    if ($url.Contains("github.com")) {
+    if ($url.Contains("github.com") -or $url.Contains("chocolatey.org")) {
         # github does not allow HEAD requests
-        warn "Unable to check github url (assuming it is ok)"
+        warn "Unable to check github/chocolatey url (assuming it is ok)"
         return $true
     }
 

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -70,6 +70,8 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
             if ($config.type -and !($config.type -eq "sha256")) {
                 $hash = $config.type + ":$hash"
             }
+
+            return $hash
         }
     } elseif ($hashmode -eq "rdf") {
         return find_hash_in_rdf $config.url $basename


### PR DESCRIPTION
Updated apps
 - nodejs-lts
 - mercurial
 - git-lfs
 - youtube-dl
 - syncany-cli
 - _more following …_

Fixes
 - autoupdate regression on hashing type `extract`
 - autoupdate error when no `architecture` option was set
 - far version number used another notation as checkver would report
 - do not check chocolatey urls with HEAD request

New features
 - `autoupdate.note` to show a message when autoupdate is run