### PR TITLE
Updates and new autoupdates

### DIFF
--- a/bucket/7zip.json
+++ b/bucket/7zip.json
@@ -14,5 +14,15 @@
     },
     "extract_dir": "Files/7-Zip",
     "bin": "7z.exe",
-    "checkver": "Download 7-zip ([^\\ ]+)"
+    "checkver": "Download 7-zip ([^\\ ]+)",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://7-zip.org/a/7z$cleanVersion-x64.msi"
+            },
+            "32bit": {
+                "url": "http://7-zip.org/a/7z$cleanVersion.msi"
+            }
+        }
+    }
 }

--- a/bucket/elixir.json
+++ b/bucket/elixir.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://elixir-lang.org/",
-    "version": "1.2.5",
+    "version": "1.4.0",
     "depends": "erlang",
-    "url": "https://github.com/elixir-lang/elixir/releases/download/v1.2.5/Precompiled.zip",
-    "hash": "4ab860707040e2dde4024cc8c0f74f1adc48aaae8d48293bf2b98fda3921a99c",
+    "url": "https://github.com/elixir-lang/elixir/releases/download/v1.4.0/Precompiled.zip",
+    "hash": "60d077bc242e65f4f430beb43c968b5632dfb07ec89a7d689da254ffdc791b98",
     "bin": [
         "bin\\elixir.bat",
         "bin\\elixirc.bat",
@@ -12,5 +12,8 @@
     ],
     "checkver": {
         "github": "https://github.com/elixir-lang/elixir"
+    },
+    "autoupdate": {
+        "url": "https://github.com/elixir-lang/elixir/releases/download/v$version/Precompiled.zip"
     }
 }

--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://www.erlang.org",
-    "version": "19.0",
+    "version": "19.2",
     "license": "http://www.apache.org/licenses/LICENSE-2.0",
     "architecture": {
         "64bit": {
-            "url": "http://erlang.org/download/otp_win64_19.0.exe",
-            "hash": "ab1811996cac1bff1248dbd3d840b012c9585ea6ee746862aa297e598a35ad3c"
+            "url": "http://erlang.org/download/otp_win64_19.2.exe",
+            "hash": "ce819d2936af1157aed27aed49719c64f4134f714322f096cb5538d9ad627814"
         },
         "32bit": {
-            "url": "http://erlang.org/download/otp_win32_19.0.exe",
-            "hash": "62ef79ef798434a6ad5828d2ad275d9c26d8a1c638db6860d2325c3e00b8a803"
+            "url": "http://erlang.org/download/otp_win32_19.2.exe",
+            "hash": "ab4e5e79448e24551cc752b09af9c76824695d41d73574cf990c633085c94213"
         }
     },
     "bin": [
@@ -21,14 +21,29 @@
         "ERLANG_HOME": "$dir"
     },
     "installer": {
-        "args": ["/S", "/D=$dir"]
+        "args": [
+            "/S",
+            "/D=$dir"
+        ]
     },
     "uninstaller": {
-        "file" : "Uninstall.exe",
-        "args" : ["/S"]
+        "file": "Uninstall.exe",
+        "args": [
+            "/S"
+        ]
     },
     "checkver": {
         "url": "http://www.erlang.org/downloads",
         "re": "DOWNLOAD\\s+OTP ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://erlang.org/download/otp_win64_$version.exe"
+            },
+            "32bit": {
+                "url": "http://erlang.org/download/otp_win32_$version.exe"
+            }
+        }
     }
 }

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -1,17 +1,17 @@
 {
-    "version": "20161230",
+    "version": "20170110-f48b6b8",
     "homepage": "https://ffmpeg.zeranoe.com/builds/",
     "license": "GPL3",
     "architecture": {
         "64bit": {
-            "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20161230-6993bb4-win64-static.zip",
-            "hash": "b4f35d18db6bb5b616162d2e261ed1a0fec47415793396ae517971d5fa750b0c",
-            "extract_dir": "ffmpeg-20161230-6993bb4-win64-static"
+            "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20170110-f48b6b8-win64-static.zip",
+            "hash": "7b122b3ce21d93ab94a35145c8b92fc34957f085e3d13a5aa254672e4bb6dc2b",
+            "extract_dir": "ffmpeg-20170110-f48b6b8-win64-static"
         },
         "32bit": {
-            "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-20161230-6993bb4-win32-static.zip",
-            "hash": "513e7a6adf770bff8df925cdb736c4755f825af5451a5ab6fcea0d2150ed2dc0",
-            "extract_dir": "ffmpeg-20161230-6993bb4-win32-static"
+            "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-20170110-f48b6b8-win32-static.zip",
+            "hash": "abc56f5209058f1f7b382ea0a2bc5792dd38f4f4da6b2a4bb3f5aa93ed7acc25",
+            "extract_dir": "ffmpeg-20170110-f48b6b8-win32-static"
         }
     },
     "bin": [
@@ -19,5 +19,17 @@
         "bin\\ffplay.exe",
         "bin\\ffprobe.exe"
     ],
-    "checkver": "value=\"([\\d]{8})-[\\d\\w]+\""
+    "checkver": "value=\"([\\d]{8}-[\\d\\w]+)\"",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-$version-win64-static.zip",
+                "extract_dir": "ffmpeg-$version-win64-static"
+            },
+            "32bit": {
+                "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-$version-win32-static.zip",
+                "extract_dir": "ffmpeg-$version-win32-static"
+            }
+        }
+    }
 }

--- a/bucket/flow.json
+++ b/bucket/flow.json
@@ -1,12 +1,15 @@
 {
-    "version":  "v0.33.0",
-    "license":  "BSD",
-    "url":  "https://github.com/facebook/flow/releases/download/v0.33.0/flow-win64-v0.33.0.zip",
-    "homepage":  "https://flowtype.org/",
-    "hash":  "5bcd5cab59c8c4406273a59df187473e9fd56e0e6a3a8b3de76a48b34412caac",
-    "bin":  "flow.exe",
-    "extract_dir":  "flow",
+    "version": "0.37.4",
+    "license": "BSD",
+    "url": "https://github.com/facebook/flow/releases/download/v0.37.4/flow-win64-v0.37.4.zip",
+    "homepage": "https://flowtype.org/",
+    "hash": "72ed4dc6a9807372bf79f718966190c6a6add8968aaa5d3b427de002ee918d10",
+    "bin": "flow.exe",
+    "extract_dir": "flow",
     "checkver": {
         "github": "https://github.com/facebook/flow"
+    },
+    "autoupdate": {
+        "url": "https://github.com/facebook/flow/releases/download/v$version/flow-win64-v$version.zip"
     }
 }

--- a/bucket/forge.json
+++ b/bucket/forge.json
@@ -8,5 +8,8 @@
     ],
     "checkver": {
         "github": "https://github.com/fsharp-editing/Forge"
+    },
+    "autoupdate": {
+        "url": "https://github.com/fsharp-editing/Forge/releases/download/$version/forge.zip"
     }
 }

--- a/bucket/grails.json
+++ b/bucket/grails.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://grails.org/",
-    "version": "3.0.9",
+    "version": "3.2.4",
     "license": "Apache 2.0",
-    "url": "https://github.com/grails/grails-core/releases/download/v3.0.9/grails-3.0.9.zip",
-    "hash": "f1bfdec6efd45283c810e29be4433f134118344d2eabea870ae553fb66c864b1",
-    "extract_dir": "grails-3.0.9",
+    "url": "https://github.com/grails/grails-core/releases/download/v3.2.4/grails-3.2.4.zip",
+    "hash": "9cc3f9620ba8261a845beca3a0d63936b7dc529b41ba1d29b0a9d84c212ac1c7",
+    "extract_dir": "grails-3.2.4",
     "bin": [
         "bin\\grails.bat"
     ],
@@ -14,5 +14,9 @@
     "depends": "openjdk",
     "checkver": {
         "github": "https://github.com/grails/grails-core"
+    },
+    "autoupdate": {
+        "url": "https://github.com/grails/grails-core/releases/download/v$version/grails-$version.zip",
+        "extract_dir": "grails-$version"
     }
 }

--- a/bucket/groovy.json
+++ b/bucket/groovy.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://www.groovy-lang.org/",
-    "version": "2.4.6",
+    "version": "2.4.7",
     "license": "Apache 2.0",
-    "url": "https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.6.zip",
-    "hash": "9b3fb5b51bc21342bba13f090a88ad6d89b20c4a7a166dd50df2ac763c278768",
+    "url": "https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip",
+    "hash": "438dd6098252647e88ff12ac5737d0d0f7e16a8e4e42e8be3e05a4c43abefbd5",
     "extract_dir": "groovy-2.4.6",
     "bin": [
         "bin\\grape.bat",
@@ -22,5 +22,8 @@
     "checkver": {
         "url": "http://www.groovy-lang.org/download.html",
         "re": "([\\d.]+) distributions"
+    },
+    "autoupdate": {
+        "url": "https://dl.bintray.com/groovy/maven/apache-groovy-binary-$version.zip"
     }
 }

--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "http://www.haskell.org",
+    "homepage": "https://www.haskell.org",
     "version": "7.10.2-a",
     "architecture": {
         "64bit": {

--- a/bucket/haxe.json
+++ b/bucket/haxe.json
@@ -1,10 +1,10 @@
 {
-    "homepage": "http://haxe.org/",
-    "version": "3.2.1",
-    "license": "http://haxe.org/foundation/open-source.html",
-    "url": "http://haxe.org/website-content/downloads/3.2.1/downloads/haxe-3.2.1-win.zip",
-    "hash": "af57d42ca474bba826426e9403b2cb21c210d56addc8bbc0e8fafa88b3660db3",
-    "extract_dir": "haxe-3.2.1",
+    "homepage": "https://haxe.org/",
+    "version": "3.4.0-rc.2",
+    "license": "https://haxe.org/foundation/open-source.html",
+    "url": "https://haxe.org/website-content/downloads/3.4.0-rc.2/downloads/haxe-3.4.0-rc.2-win.zip",
+    "hash": "6bc4a74b6738c270673a8033e91caf381120d0315c84072e94f9079e268048d0",
+    "extract_dir": "haxe-3.4.0-rc.2",
     "bin": [
         "haxe.exe",
         "haxelib.exe"
@@ -14,7 +14,11 @@
     },
     "depends": "neko",
     "checkver": {
-        "url": "http://haxe.org/download/list/",
+        "url": "https://haxe.org/download/list/",
         "re": "The current stable version is <a [^>]+>([\\d.\\-rc]+)"
+    },
+    "autoupdate": {
+        "url": "https://haxe.org/website-content/downloads/$version/downloads/haxe-$version-win.zip",
+        "extract_dir": "haxe-$version"
     }
 }

--- a/bucket/hub.json
+++ b/bucket/hub.json
@@ -17,5 +17,15 @@
     ],
     "checkver": {
         "github": "https://github.com/github/hub"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/github/hub/releases/download/v$version/hub-windows-amd64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/github/hub/releases/download/v$version/hub-windows-386-$version.zip"
+            }
+        }
     }
 }

--- a/bucket/hugo.json
+++ b/bucket/hugo.json
@@ -1,20 +1,30 @@
 {
-    "version":  "0.18",
-    "license":  "https://github.com/spf13/hugo/blob/master/LICENSE.md",
+    "version": "0.18.1",
+    "license": "https://github.com/spf13/hugo/blob/master/LICENSE.md",
     "architecture": {
-      "64bit": {
-        "url":  "https://github.com/spf13/hugo/releases/download/v0.18/hugo_0.18_windows-64bit.zip",
-        "hash": "9C6094196524A9F8CBB2A3FD83A309C7FF42E62CE24DECF10222FA9D0B0EAA16",
-        "bin": [ "hugo_0.18_windows_amd64.exe" ]
-      },
-      "32bit": {
-        "url":  "https://github.com/spf13/hugo/releases/download/v0.18/hugo_0.18_windows-32bit.zip",
-        "hash":  "12FAB36D0492E90B1004227D6FC62683682C3D19369C3A8166D0158A89D9DFFA",
-        "bin": [ "hugo_0.18_windows_386.exe" ]
-      }
+        "64bit": {
+            "url": "https://github.com/spf13/hugo/releases/download/v0.18.1/hugo_0.18.1_windows-64bit.zip",
+            "hash": "8269b0fbd54a8548692fe994625ed99bada53807d172f29f00b8c66be676a922"
+        },
+        "32bit": {
+            "url": "https://github.com/spf13/hugo/releases/download/v0.18.1/hugo_0.18.1_windows-32bit.zip",
+            "hash": "2703ac22f0421031d2008f1cf85836280e2e5fa01a41efb06e72b202f8f4ac5f"
+        }
     },
-    "homepage": "http://gohugo.io",
+    "bin": "hugo.exe",
+    "pre_install": "Rename-Item @(Get-ChildItem $dir\\hugo_*.exe)[0] $dir\\hugo.exe",
+    "homepage": "https://gohugo.io",
     "checkver": {
         "github": "https://github.com/spf13/hugo"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/spf13/hugo/releases/download/v$version/hugo_$version_windows-64bit.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/spf13/hugo/releases/download/v$version/hugo_$version_windows-32bit.zip"
+            }
+        }
     }
 }

--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -1,12 +1,15 @@
 {
     "homepage": "https://miktex.org",
-    "version": "2.9.5987",
+    "version": "2.9.6161",
     "license": "https://miktex.org/copying",
-    "url": "http://wbc.upm.edu.my/tex-archive/systems/win32/miktex/setup/miktex-portable-2.9.5987.exe#/dl.7z",
-    "hash": "b6773ba988007a88c361f63d27833e63fefdb8011238f0ca843135a3c4ffded9",
+    "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/miktex-portable-2.9.6161.exe#/dl.7z",
+    "hash": "cc7d67f481e009e5eece8b531b9a86c1f47c7dd107cf8bc36b7ee1689c5b3811",
     "env_add_path": "texmfs\\install\\miktex\\bin",
     "checkver": {
         "url": "https://miktex.org/portable",
         "re": "miktex-portable-([\\d.]+).exe"
+    },
+    "autoupdate": {
+        "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/miktex-portable-$version.exe#/dl.7z"
     }
 }

--- a/bucket/lessmsi.json
+++ b/bucket/lessmsi.json
@@ -1,9 +1,14 @@
 {
     "homepage": "https://github.com/activescott/lessmsi/",
-    "version": "1.4",
+    "version": "1.5.1",
     "license": "https://github.com/activescott/lessmsi/raw/master/LICENSE",
-    "hash": "ea16da35477aff1ab63d71e0f1c08ca697cad6f7211ccdf7fb8fa2c7206a1ffa",
-    "url": "https://github.com/activescott/lessmsi/releases/download/v1.4/lessmsi-v1.4.zip",
+    "hash": "478564a8430cc74c3fb727175e4bbb46ce6d9c8874e7c1555f719dcff9ee91af",
+    "url": "https://github.com/activescott/lessmsi/releases/download/v1.5.1/lessmsi-v1.5.1.zip",
     "bin": "lessmsi.exe",
-    "checkver": "github"
+    "checkver": {
+        "github": "https://github.com/activescott/lessmsi"
+    },
+    "autoupdate": {
+        "url": "https://github.com/activescott/lessmsi/releases/download/v$version/lessmsi-v$version.zip"
+    }
 }

--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -1,19 +1,34 @@
 {
     "homepage": "http://www.llvm.org",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "license": "University of Illinois/NCSA Open Source License",
     "architecture": {
         "32bit": {
-            "url": "http://llvm.org/releases/3.9.0/LLVM-3.9.0-win32.exe",
-            "hash": "b4eaa1fa9872e2c76268f32fc597148cfa14c57b7d13e1edd9b9b6496cdf7de8"
+            "url": "http://releases.llvm.org/3.9.1/LLVM-3.9.1-win32.exe",
+            "hash": "f5cdf134e27a215a18515e2dcd100902dcf539f487c2028a817ffe7d3091f32a"
         },
         "64bit": {
-            "url": "http://llvm.org/releases/3.9.0/LLVM-3.9.0-win64.exe",
-            "hash": "3e5b53a79266d3f7f1d5cb4d94283fe2bc61f9689e55f39e3939364f4076b0c9"
+            "url": "http://releases.llvm.org/3.9.1/LLVM-3.9.1-win64.exe",
+            "hash": "7ea2b7bc0de6b96a6ce11e6cfece7b84a31fb0c86c977f42ee178cba41517606"
         }
     },
-    "installer": {"args": "/S /D=$dir"},
-    "uninstaller": {"file": "Uninstall.exe", "args": "/S"},
+    "installer": {
+        "args": "/S /D=$dir"
+    },
+    "uninstaller": {
+        "file": "Uninstall.exe",
+        "args": "/S"
+    },
     "env_add_path": "bin",
-    "checkver": "\\/releases\\/download.html#([\\d.]+)"
+    "checkver": "\\/releases\\/download.html#([\\d.]+)",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://releases.llvm.org/$version/LLVM-$version-win64.exe"
+            },
+            "32bit": {
+                "url": "http://releases.llvm.org/$version/LLVM-$version-win32.exe"
+            }
+        }
+    }
 }

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://dev.mysql.com/downloads/mysql/",
-    "version": "5.7.14",
+    "version": "5.7.17",
     "license": "GPLv2",
     "architecture": {
         "64bit": {
-            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.14-winx64.zip",
-            "hash": "md5:dac7a16845da1dd3f789ca27972cca65",
-            "extract_dir": "mysql-5.7.14-winx64"
+            "url": "https://dev.mysql.com/get/mysql-5.7.17-winx64.zip",
+            "hash": "53b2e9eec6d7c986444926dd59ae264d156cea21a1566d37547f3e444c0b80c8",
+            "extract_dir": "mysql-5.7.17-winx64"
         },
         "32bit": {
-            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.14-win32.zip",
-            "hash": "md5:5b88f3e3724122f1fbd2fac26f8a7bd8",
-            "extract_dir": "mysql-5.7.14-win32"
+            "url": "https://dev.mysql.com/get/mysql-5.7.17-win32.zip",
+            "hash": "5fd863bbe76e306989ec2ba43fb4b7e9d72240ac1e058c590cf6ea72cc9454df",
+            "extract_dir": "mysql-5.7.17-win32"
         }
     },
     "bin": [
@@ -25,7 +25,7 @@
         "bin\\mysqlshow.exe",
         "bin\\mysqlslap.exe",
         "bin\\my_print_defaults.exe"
-        ],
+    ],
     "post_install": "
 #Initialize data directory (without generating root password)
 mysqld --initialize-insecure
@@ -38,5 +38,17 @@ echo \"\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
 echo \"[client]\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
 echo \"user=root\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
 ",
-    "checkver": "<h1>MySQL Community Server ([\\d.]+)"
+    "checkver": "<h1>MySQL Community Server ([\\d.]+)",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dev.mysql.com/get/mysql-$version-winx64.zip",
+                "extract_dir": "mysql-$version-winx64"
+            },
+            "32bit": {
+                "url": "https://dev.mysql.com/get/mysql-$version-win32.zip",
+                "extract_dir": "mysql-$version-win32"
+            }
+        }
+    }
 }

--- a/bucket/nginx.json
+++ b/bucket/nginx.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "http://nginx.org",
+    "homepage": "https://nginx.org",
     "version": "1.11.8",
     "license": "BSD",
-    "url": "http://nginx.org/download/nginx-1.11.8.zip",
+    "url": "https://nginx.org/download/nginx-1.11.8.zip",
     "hash": "0f06c91e86322a7658fcd4c210e1af69512ae9ff974df5e2beb4e4952e678016",
     "extract_dir": "nginx-1.11.8",
     "bin": "nginx.exe",
@@ -11,7 +11,7 @@
         "re": "Changes with nginx ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://nginx.org/download/nginx-$version.zip",
+        "url": "https://nginx.org/download/nginx-$version.zip",
         "extract_dir": "nginx-$version"
     }
 }

--- a/bucket/nuget.json
+++ b/bucket/nuget.json
@@ -3,10 +3,13 @@
     "version": "3.5.0",
     "license": "Apache 2.0",
     "url": "https://dist.nuget.org/win-x86-commandline/v3.5.0/NuGet.exe",
-    "hash": "399EC24C26ED54D6887CDE61994BB3D1CADA7956C1B19FF880F06F060C039918",
+    "hash": "399ec24c26ed54d6887cde61994bb3d1cada7956c1b19ff880f06f060c039918",
     "bin": "NuGet.exe",
     "checkver": {
         "url": "https://dist.nuget.org/index.json",
         "re": "latest\", \"version\": \"([\\d.]+)\""
+    },
+    "autoupdate": {
+        "url": "https://dist.nuget.org/win-x86-commandline/v$version/NuGet.exe"
     }
 }

--- a/bucket/nvm.json
+++ b/bucket/nvm.json
@@ -3,8 +3,12 @@
     "version": "1.1.1",
     "url": "https://github.com/coreybutler/nvm-windows/releases/download/1.1.1/nvm-noinstall.zip",
     "extract_dir": "\\",
-    "bin": ["nvm.exe", "elevate.cmd","elevate.vbs"],
-    "env_add_path":"nodejs",
+    "bin": [
+        "nvm.exe",
+        "elevate.cmd",
+        "elevate.vbs"
+    ],
+    "env_add_path": "nodejs",
     "env_set": {
         "NVM_HOME": "$dir",
         "NVM_SYMLINK": "$dir\\nodejs"
@@ -12,12 +16,15 @@
     "hash": "ca733ab612709080cea2f46a9baabbd475014c49a95ee7dc60c0575201852bce",
     "architecture": {
         "64bit": {
-            "post_install": "\"root: $dir `r`narch: 64`r`nproxy: none `r`noriginalpath: `r`noriginalversion: `r`n\" | Out-File -encoding \"ASCII\" $dir\\settings.txt"
+            "post_install": "\"root: $dir `r`narch: 64 `r`nproxy: none `r`noriginalpath: `r`noriginalversion: `r`n\" | Out-File -encoding \"ASCII\" $dir\\settings.txt"
         },
         "32bit": {
             "post_install": "\"root: $dir `r`narch: 32 `r`nproxy: none `r`noriginalpath: `r`noriginalversion: `r`n\" | Out-File -encoding \"ASCII\" $dir\\settings.txt"
         }
     },
-    "notes":"You'll need to restart powershell/cmd to have it reload Environment Variables so nvm will work correctly",
-    "checkver": "github"
+    "notes": "You'll need to restart powershell/cmd to have it reload Environment Variables so nvm will work correctly",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/coreybutler/nvm-windows/releases/download/$version/nvm-noinstall.zip"
+    }
 }

--- a/bucket/octave.json
+++ b/bucket/octave.json
@@ -1,11 +1,20 @@
 {
-    "homepage":  "https://www.gnu.org/software/octave/",
-    "version":  "4.0.3",
-    "license":  "GNU GPL",
-    "url":  "https://ftp.gnu.org/gnu/octave/windows/octave-4.0.3.zip",
-    "extract_dir":  "octave-4.0.3",
-    "hash":  "dd00d2b33b0b89cb5339de347b0e48c8cbc44d5cab2b23de8e3102fdb55c1286",
-    "bin":  [
+    "homepage": "https://www.gnu.org/software/octave/",
+    "version": "4.2.0",
+    "license": "GNU GPL",
+    "architecture": {
+        "64bit": {
+            "url": "https://ftp.gnu.org/gnu/octave/windows/octave-4.2.0-w64.zip",
+            "hash": "58ac8da90984bfb241dbab68b9857776ceee32b01176085bd6e4f01ca5a3d91f",
+            "extract_dir": "octave-4.2.0-w64"
+        },
+        "32bit": {
+            "url": "https://ftp.gnu.org/gnu/octave/windows/octave-4.2.0-w32.zip",
+            "hash": "c2162d330232f14060d539014e5b7b785dec0c4501af0f3a9d690ef0ea4c9f6d",
+            "extract_dir": "octave-4.2.0-w32"
+        }
+    },
+    "bin": [
         "bin\\octave.exe",
         "bin\\octave-gui.exe",
         "bin\\octave-cli.exe",
@@ -14,5 +23,17 @@
     "checkver": {
         "url": "http://wiki.octave.org/GNU_Octave_Wiki",
         "re": "GNU Octave ([\\d.]+) is the current stable release"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://ftp.gnu.org/gnu/octave/windows/octave-$version-w64.zip",
+                "extract_dir": "octave-$version-w64"
+            },
+            "32bit": {
+                "url": "https://ftp.gnu.org/gnu/octave/windows/octave-$version-w32.zip",
+                "extract_dir": "octave-$version-w32"
+            }
+        }
     }
 }

--- a/bucket/pester.json
+++ b/bucket/pester.json
@@ -1,10 +1,10 @@
 {
-    "version":  "3.3.6",
-    "license":  "https://raw.githubusercontent.com/pester/Pester/master/LICENSE",
-    "url":  "https://github.com/pester/pester/archive/3.3.6.tar.gz",
-    "homepage":  "https://github.com/pester/Pester",
-    "hash":  "38a9ae3c829b02fe90fb8acbed564ffb883fb0175a6a00b501ac3663f03d6b9a",
-    "extract_dir": "pester-3.3.6",
+    "version": "3.4.3",
+    "license": "https://raw.githubusercontent.com/pester/Pester/master/LICENSE",
+    "url": "https://github.com/pester/pester/archive/3.4.3.tar.gz",
+    "homepage": "https://github.com/pester/Pester",
+    "hash": "8690283baf3e03e6e9e9188008e3d219c3db5dc6da866a26bae11f5a9016826d",
+    "extract_dir": "pester-3.4.3",
     "bin": "bin\\pester.bat",
     "post_install": "
         $import = \"try { `$null = gcm pester -ea stop; import-module `\"$dir\\pester.psm1`\" } catch { }\"
@@ -29,5 +29,9 @@
         'importing pester for current session...'
         iex \"$import\"
     ",
-    "checkver": "github"
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/pester/pester/archive/$version.tar.gz",
+        "extract_dir": "pester-$version"
+    }
 }

--- a/bucket/phantomjs.json
+++ b/bucket/phantomjs.json
@@ -9,5 +9,8 @@
     "checkver": {
         "url": "http://phantomjs.org/download.html",
         "re": "phantomjs-([\\d.]+)-windows.zip"
+    },
+    "autoupdate": {
+        "url": "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$version-windows.zip"
     }
 }

--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.postgresql.org/",
-    "version": "9.5.3",
+    "version": "9.6.1",
     "license": "https://www.postgresql.org/about/licence/",
     "architecture": {
         "64bit": {
-            "url": "http://get.enterprisedb.com/postgresql/postgresql-9.5.3-1-windows-x64-binaries.zip",
-            "hash": "38c150d0fd0907b7f535a060420bb4d1233b24b78a291d4b9eb11ea0eff37b44"
+            "url": "https://get.enterprisedb.com/postgresql/postgresql-9.6.1-1-windows-x64-binaries.zip",
+            "hash": "8362c5c445370b67ec7684a9312776793e165011362619af0197729fd50b997a"
         },
         "32bit": {
-            "url": "http://get.enterprisedb.com/postgresql/postgresql-9.5.3-1-windows-binaries.zip",
-            "hash": "936d5fc139d5a5be30896c0dd506c4d06ee4ac133e2b7f151653ef700a39ada7"
+            "url": "https://get.enterprisedb.com/postgresql/postgresql-9.6.1-1-windows-binaries.zip",
+            "hash": "ad5364ce2c0fa9a489dd907516f9116243c278d7b887fb7d5f469b0d060ba4a9"
         }
     },
     "extract_dir": "pgsql",
@@ -56,7 +56,17 @@
         "bin\\zic.exe"
     ],
     "checkver": {
-        "url": "http://www.enterprisedb.com/products-services-training/pgbindownload",
+        "url": "https://www.enterprisedb.com/products-services-training/pgbindownload",
         "re": "<b>Version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://get.enterprisedb.com/postgresql/postgresql-$version-1-windows-x64-binaries.zip"
+            },
+            "32bit": {
+                "url": "https://get.enterprisedb.com/postgresql/postgresql-$version-1-windows-binaries.zip"
+            }
+        }
     }
 }

--- a/bucket/puppet.json
+++ b/bucket/puppet.json
@@ -12,12 +12,22 @@
         }
     },
     "bin": [
-            "Puppet Labs/Puppet/bin\\facter.bat",
-            "Puppet Labs/Puppet/bin\\hiera.bat",
-            "Puppet Labs/Puppet/bin\\puppet.bat"
+        "Puppet Labs/Puppet/bin\\facter.bat",
+        "Puppet Labs/Puppet/bin\\hiera.bat",
+        "Puppet Labs/Puppet/bin\\puppet.bat"
     ],
     "checkver": {
         "url": "https://downloads.puppetlabs.com/windows/?C=N;O=D",
         "re": "puppet-([\\d.]+)-x64.msi</a>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.puppetlabs.com/windows/puppet-$version-x64.msi"
+            },
+            "32bit": {
+                "url": "https://downloads.puppetlabs.com/windows/puppet-$version.msi"
+            }
+        }
     }
 }

--- a/bucket/racket.json
+++ b/bucket/racket.json
@@ -1,15 +1,15 @@
 {
-    "version": "6.6",
+    "version": "6.7",
     "homepage": "https://racket-lang.org",
     "license": "LGPL",
     "architecture": {
         "64bit": {
-            "url": "https://mirror.racket-lang.org/installers/6.6/racket-6.6-x86_64-win32.exe#/dl.7z",
-            "hash": "ce1c4e3db1c43b3a13c9db30a1ed787d403a0cff6cd5210d8c3a4a7d36887656"
+            "url": "https://mirror.racket-lang.org/installers/6.7/racket-6.7-x86_64-win32.exe#/dl.7z",
+            "hash": "43454d88b8ec6bd341c8fb6c983c61c7fa5cd4d3cb122fe4f8537e46606d3579"
         },
         "32bit": {
-            "url": "https://mirror.racket-lang.org/installers/6.6/racket-6.6-i386-win32.exe#/dl.7z",
-            "hash": "cde3c64349624ac483ecb757814884275171e144b31670ef8bc018b90c6c1f70"
+            "url": "https://mirror.racket-lang.org/installers/6.7/racket-6.7-i386-win32.exe#/dl.7z",
+            "hash": "fb20224cbe1756ae64752dc70806b0b8dccd5f5b0c14666b056dfe74feaa5bb5"
         }
     },
     "bin": [
@@ -17,11 +17,27 @@
         "raco.exe"
     ],
     "shortcuts": [
-        [ "GRacket.exe", "GRacket" ],
-        [ "DrRacket.exe", "DrRacket" ]
+        [
+            "GRacket.exe",
+            "GRacket"
+        ],
+        [
+            "DrRacket.exe",
+            "DrRacket"
+        ]
     ],
     "checkver": {
         "url": "https://download.racket-lang.org/",
         "re": "Version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://mirror.racket-lang.org/installers/$version/racket-$version-x86_64-win32.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://mirror.racket-lang.org/installers/$version/racket-$version-i386-win32.exe#/dl.7z"
+            }
+        }
     }
 }

--- a/bucket/rancher-compose.json
+++ b/bucket/rancher-compose.json
@@ -1,18 +1,18 @@
 {
     "homepage": "https://rancher.com/",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.12.0/rancher-compose-windows-386-v0.12.0.zip",
-            "hash": "64af3942c7327a2aab8dc07c961b78e7cbeced3c83cb8a072eb4f2532b09df12"
+            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.12.1/rancher-compose-windows-386-v0.12.1.zip",
+            "hash": "74e7e7af63b0e3cca7a9458f4c10183291faa019f63ad33b0d5fe306ca80be9b"
         },
         "64bit": {
-            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.12.0/rancher-compose-windows-amd64-v0.12.0.zip",
-            "hash": "825a7024e749c6beaab3294f5ae3f426eeb1f68afada348b00301822dce7617e"
+            "url": "https://github.com/rancher/rancher-compose/releases/download/v0.12.1/rancher-compose-windows-amd64-v0.12.1.zip",
+            "hash": "ff3b49a7b679764e13a449c46dda81c13080e0d4bfebdfe146f6667bf6f20e82"
         }
     },
     "license": "Apache 2.0",
-    "extract_dir": "rancher-compose-v0.12.0",
+    "extract_dir": "rancher-compose-v0.12.1",
     "bin": [
         "rancher-compose.exe"
     ],

--- a/bucket/rethinkdb.json
+++ b/bucket/rethinkdb.json
@@ -5,12 +5,15 @@
     "architecture": {
         "64bit": {
             "url": "https://download.rethinkdb.com/windows/rethinkdb-2.3.5.zip",
-            "hash": "AFC431C0AAA6D8B05090F4C33BC527BAB6D889555A9817789F155AC45BC51573"
+            "hash": "afc431c0aaa6d8b05090f4c33bc527bab6d889555a9817789f155ac45bc51573"
         }
     },
     "bin": "rethinkdb.exe",
     "checkver": {
-      "url": "https://rethinkdb.com/docs/install/windows/",
-      "re": "<a href=\"https://download\\.rethinkdb\\.com/windows/rethinkdb-([\\d.]+)\\.zip\">"
+        "url": "https://rethinkdb.com/docs/install/windows/",
+        "re": "<a href=\"https://download\\.rethinkdb\\.com/windows/rethinkdb-([\\d.]+)\\.zip\">"
+    },
+    "autoupdate": {
+        "url": "https://download.rethinkdb.com/windows/rethinkdb-$version.zip"
     }
 }

--- a/bucket/rsync.json
+++ b/bucket/rsync.json
@@ -1,13 +1,17 @@
 {
     "homepage": "https://www.itefix.net/cwrsync",
-    "version": "3.1.1",
-    "license": "",
-    "url": "https://www.itefix.net/dl/cwRsync_5.4.1_x86_Free.zip",
-    "hash": "a200c7f269311cdaf68610a15d0e4891b80a6e21e8e981ac7afad44df79596f6",
-    "extract_dir": "cwRsync_5.4.1_x86_Free",
-    "bin": "rsync.exe",
+    "version": "5.5.0",
+    "license": "https://www.itefix.net/content/cwrsync-licenseversion",
+    "url": "https://www.itefix.net/dl/cwRsync_5.5.0_x86_Free.zip",
+    "hash": "37e8ef21ac975d4ee86c9d3be40c8935e8b9d0ba84e9302fc106b9452296cb85",
+    "extract_dir": "cwRsync_5.5.0_x86_Free",
+    "bin": "bin\\rsync.exe",
     "checkver": {
         "url": "https://www.itefix.net/content/cwrsync-free-edition",
         "re": "cwRsync_([\\d.]+)_x86"
+    },
+    "autoupdate": {
+        "url": "https://www.itefix.net/dl/cwRsync_$version_x86_Free.zip",
+        "extract_dir": "cwRsync_$version_x86_Free"
     }
 }

--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -3,13 +3,13 @@
     "version": "1.14.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
-        "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.14.0-i686-pc-windows-msvc.msi",
-            "hash": "ede76354e87b383594754024c38de7e6a6884ee10468cfa627709a9994d2088f"
-        },
         "64bit": {
             "url": "https://static.rust-lang.org/dist/rust-1.14.0-x86_64-pc-windows-msvc.msi",
             "hash": "af9d1e2d7804f5c75b694bc87f924d75d7e3b34776755eba277793a070ea3799"
+        },
+        "32bit": {
+            "url": "https://static.rust-lang.org/dist/rust-1.14.0-i686-pc-windows-msvc.msi",
+            "hash": "ede76354e87b383594754024c38de7e6a6884ee10468cfa627709a9994d2088f"
         }
     },
     "bin": [
@@ -18,7 +18,17 @@
         "Rust\\bin\\cargo.exe"
     ],
     "checkver": {
-      "url": "https://github.com/rust-lang/rust/releases",
-      "re": "<span class=\"tag-name\">([\\d.]+)</span>"
+        "url": "https://github.com/rust-lang/rust/releases",
+        "re": "<span class=\"tag-name\">([\\d.]+)</span>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://static.rust-lang.org/dist/rust-$version-x86_64-pc-windows-msvc.msi"
+            },
+            "32bit": {
+                "url": "https://static.rust-lang.org/dist/rust-$version-i686-pc-windows-msvc.msi"
+            }
+        }
     }
 }

--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -3,13 +3,13 @@
     "version": "1.14.0",
     "license": "MIT/Apache 2.0",
     "architecture": {
-        "32bit": {
-            "url": "https://static.rust-lang.org/dist/rust-1.14.0-i686-pc-windows-gnu.msi",
-            "hash": "29670cbcbadf95abc98183d75988b57532dba177db5ae3faf27344af182f0441"
-        },
         "64bit": {
             "url": "https://static.rust-lang.org/dist/rust-1.14.0-x86_64-pc-windows-gnu.msi",
             "hash": "cde3e673288ee65f92b287994b83c64f69d9fb0fdd0c52b16c0f45e253afc96a"
+        },
+        "32bit": {
+            "url": "https://static.rust-lang.org/dist/rust-1.14.0-i686-pc-windows-gnu.msi",
+            "hash": "29670cbcbadf95abc98183d75988b57532dba177db5ae3faf27344af182f0441"
         }
     },
     "bin": [
@@ -18,7 +18,17 @@
         "Rust\\bin\\cargo.exe"
     ],
     "checkver": {
-      "url": "https://github.com/rust-lang/rust/releases",
-      "re": "<span class=\"tag-name\">([\\d.]+)</span>"
+        "url": "https://github.com/rust-lang/rust/releases",
+        "re": "<span class=\"tag-name\">([\\d.]+)</span>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://static.rust-lang.org/dist/rust-$version-x86_64-pc-windows-gnu.msi"
+            },
+            "32bit": {
+                "url": "https://static.rust-lang.org/dist/rust-$version-i686-pc-windows-gnu.msi"
+            }
+        }
     }
 }

--- a/bucket/sbt.json
+++ b/bucket/sbt.json
@@ -1,15 +1,19 @@
 {
     "homepage": "http://www.scala-sbt.org/",
-    "version": "0.13.9",
+    "version": "0.13.13",
     "license": "BSD",
-    "url": "https://dl.bintray.com/sbt/native-packages/sbt/0.13.9/sbt-0.13.9.zip",
-    "hash": "2e2deaf059d906026a0b63598df5a4cb679eb3ffd6b51ada02130d72730a039c",
-    "extract_dir": "sbt",
+    "url": "https://dl.bintray.com/sbt/native-packages/sbt/0.13.13/sbt-0.13.13.zip",
+    "hash": "701ac8873b9f91c591c86cbd74b2b7057f9cfeeee374cc9bc07303243b6fb5e7",
+    "extract_dir": "sbt-launcher-packaging-0.13.13",
     "bin": [
         "bin\\sbt.bat"
     ],
     "checkver": {
         "url": "http://www.scala-sbt.org/download.html",
-        "re": "\\/sbt/([\\d.]+)\\/"
+        "re": "/sbt-([\\d.]+).zip"
+    },
+    "autoupdate": {
+        "url": "https://dl.bintray.com/sbt/native-packages/sbt/$version/sbt-$version.zip",
+        "extract_dir": "sbt-launcher-packaging-$version"
     }
 }

--- a/bucket/scala.json
+++ b/bucket/scala.json
@@ -1,10 +1,10 @@
 {
-    "homepage": "http://www.scala-lang.org/",
-    "version": "2.11.8",
+    "homepage": "https://www.scala-lang.org/",
+    "version": "2.12.1",
     "license": "BSD 3-Clause",
-    "url": "http://downloads.typesafe.com/scala/2.11.8/scala-2.11.8.zip",
-    "hash": "40dc5d92444d6b0e06f751adb4f100faaf8f849be6806c922c88909d8474eefa",
-    "extract_dir": "scala-2.11.8",
+    "url": "https://downloads.typesafe.com/scala/2.12.1/scala-2.12.1.zip",
+    "hash": "bc71d2b6650c5617d248f3ffbbea54aef25e2899b96408bd3a043854e54f0a36",
+    "extract_dir": "scala-2.12.1",
     "bin": [
         "bin\\fsc.bat",
         "bin\\scala.bat",
@@ -17,7 +17,11 @@
     },
     "depends": "openjdk",
     "checkver": {
-        "url": "http://www.scala-lang.org/download/",
+        "url": "https://www.scala-lang.org/download/",
         "re": "Download Scala ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://downloads.typesafe.com/scala/$version/scala-$version.zip",
+        "extract_dir": "scala-$version"
     }
 }

--- a/bucket/sqlite.json
+++ b/bucket/sqlite.json
@@ -1,14 +1,21 @@
 {
     "homepage": "https://www.sqlite.org/",
-    "version": "3.15.1",
+    "version": "3160200",
     "license": "Public Domain",
-    "url": "https://www.sqlite.org/2016/sqlite-tools-win32-x86-3150100.zip",
-    "hash": "sha1:6f6a93dd3a79aae994109bcf07e8e9706a33956c",
-    "extract_dir": "sqlite-tools-win32-x86-3150100",
+    "url": "https://www.sqlite.org/2017/sqlite-tools-win32-x86-3160200.zip",
+    "hash": "ddacfbedf3fb54480f8f338eb4c65d3aff5a0d2f0bc1c98486c7a23807772e1f",
+    "extract_dir": "sqlite-tools-win32-x86-3160200",
     "bin": [
         "sqlite3.exe",
         "sqldiff.exe",
         "sqlite3_analyzer.exe"
     ],
-    "checkver": "<a.*>Version ([\\d.]+)</a>"
+    "checkver": {
+        "url": "https://www.sqlite.org/download.html",
+        "re": "sqlite-tools-win32-x86-(\\d+).zip"
+    },
+    "autoupdate": {
+        "url": "https://www.sqlite.org/2017/sqlite-tools-win32-x86-$version.zip",
+        "extract_dir": "sqlite-tools-win32-x86-$version"
+    }
 }

--- a/bucket/thrift.json
+++ b/bucket/thrift.json
@@ -1,9 +1,13 @@
 {
     "homepage": "https://thrift.apache.org/",
-    "version": "0.9.3",
+    "version": "0.10.0",
     "licence": "Apache License v2.0",
-    "url": "https://www-us.apache.org/dist/thrift/0.9.3/thrift-0.9.3.exe",
-    "hash": "md5:d373614a4fac5cf0aff1340dfe630acb",
-    "bin": [["thrift-0.9.3.exe", "thrift"]],
-    "checkver": "Apache\\s+Thrift\\s+v([0-99\\.]+)"
+    "url": "https://www-us.apache.org/dist/thrift/0.10.0/thrift-0.10.0.exe",
+    "hash": "85aca25c5193c48ec6cc1c0a4c40fac5ea3fde2192c2ffaaad92a9b56d7a8f9a",
+    "bin": "thrift.exe",
+    "pre_install": "Rename-Item @(Get-ChildItem $dir\\thrift-*.exe)[0] $dir\\thrift.exe",
+    "checkver": "Apache\\s+Thrift\\s+v([\\d.]+)",
+    "autoupdate": {
+        "url": "https://www-us.apache.org/dist/thrift/$version/thrift-$version.exe"
+    }
 }

--- a/bucket/youtube-dl.json
+++ b/bucket/youtube-dl.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://rg3.github.io/youtube-dl/",
     "license": "Public Domain",
-    "version": "2017.01.05",
-    "url": "https://github.com/rg3/youtube-dl/releases/download/2017.01.05/youtube-dl.exe",
-    "hash": "f49311e938821f1f5d45c13c63492994ca30bdbdd5e5db3274bfe35cfb6272ec",
+    "version": "2017.01.10",
+    "url": "https://github.com/rg3/youtube-dl/releases/download/2017.01.10/youtube-dl.exe",
+    "hash": "cad77c4e14016e0573661979c929e20c38a275de037d8121403615efb8948c09",
     "bin": "youtube-dl.exe",
     "depends": [
         "ffmpeg"

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -131,7 +131,14 @@ function prepare_download_url([String] $template, [String] $version)
     <#
     TODO There should be a second option to extract the url from the page
     #>
-    return substitute $template @{'$version' = $version; '$underscoreVersion' = ($version -replace "\.", "_")}
+    return substitute $template @{
+        '$version' = $version;
+        '$underscoreVersion' = ($version -replace "\.", "_");
+        '$cleanVersion' = ($version -replace "\.", "");
+        '$majorVersion' = ($version.Split('.') | Select-Object -first 1) -join('.');
+        '$minorVersion' = ($version.Split('.') | Select-Object -first 2) -join('.');
+        '$patchVersion' = ($version.Split('.') | Select-Object -first 3) -join('.')
+    }
 }
 
 function autoupdate([String] $app, $json, [String] $version)


### PR DESCRIPTION
  * add more version substitutions for urls (e.g. used for 7zip)
  * 7zip add autoupdate
  * update exlixr 1.4.0 and add autoupdate
  * update erlang 19.2 and add autoupdate
  * update ffmpeg 20170110 and add autoupdate
  * update flow 0.37.4 and add autoupdate
  * forge add autoupdate
  * update grails 3.2.4 and add autoupdate
  * update groovy 2.4.7 and add autoupdate
  * fix haskell url
  * update haxe 3.4.0-rc.2 and add autoupdate
  * hub add autoupdate
  * update hugo 0.18.1 and add autoupdate
  * update latex 2.9.6161 and add autoupdate
  * update lessmsi 1.5.1 and add autoupdate
  * update llvm 3.9.1 and add autoupdate
  * update mysql 5.7.17 and add autoupdate
  * fix nginx urls
  * nuget add autoupdate
  * nvm add autoupdate
  * update octave 4.2.0 and add autoupdate
  * update pester 3.4.3 and add autoupdate
  * phantomjs add autoupdate
  * update postgresql 9.6.1 and add autoupdate
  * puppet add autoupdate
  * update racket 6.7 and add autoupdate
  * update rancher 0.12.1
  * rethinkdb add autoupdate
  * update rsync 5.5.0 and add autoupdate
  * rust-msvc add autoupdate
  * rust add autoupdate
  * update sbt 0.13.13 and add autoupdate
  * update scala 2.12.1 and add autoupdate
  * update sqlite 3160200 and add autoupdate
  * update thrift 0.10.0 and add autoupdate
  * update youtube-dl 2017.01.10