### PR TITLE
Add matching regex groups as url templates

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -108,12 +108,15 @@ while($in_progress -gt 0) {
     } else {
         if($page -match $regexp) {
             $ver = $matches[1]
+            if(!$ver) {
+                $ver = $matches['version']
+            }
             if($ver -eq $expected_ver) {
                 write-host "$ver" -f darkgreen
 
                 if ($forceUpdate -and $json.autoupdate) {
                     Write-Host "Forcing autoupdate!" -f DarkMagenta
-                    autoupdate $app $json $ver
+                    autoupdate $app $json $ver $matches
                 }
             } else {
                 write-host "$ver" -f darkred -nonewline
@@ -126,7 +129,7 @@ while($in_progress -gt 0) {
                 }
 
                 if($update -and $json.autoupdate) {
-                    autoupdate $app $json $ver
+                    autoupdate $app $json $ver $matches
                 }
             }
 


### PR DESCRIPTION
Now it's possible to use `$match1`, `$match2`, and so on in the url. Also named groups are supported.
A regex like `v(?<version>[\d\w.]+)\/PortableGit-(?<short>[\d.]+).*\.exe` will result in `$matchVersion` and `$matchShort`.

I wrote this change mainly for autoupdating git-for-windows, because of there strange versioning on github.

Example git bucket:
```
{
    "_comment": "Maintainers: when updating this manifest to a new version, you might like to also update git-with-openssh.json",
    "homepage": "https://git-for-windows.github.io/",
    "license": "GPL2",
    "version": "2.11.0.windows.3",
    "architecture": {
        "64bit": {
            "url": "https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.3/PortableGit-2.11.0.3-64-bit.7z.exe#/dl.7z",
            "hash": "41a4ab3a1f0c88a3254b5a30d49c0c6e4ef06c204ddce53e23fc15d6e56f8d24"
        },
        "32bit": {
            "url": "https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.3/PortableGit-2.11.0.3-32-bit.7z.exe#/dl.7z",
            "hash": "8bf3769c37945e991903dd1b988c6b1d97bbf0f3afc9851508974f38bf94dc01"
        }
    },
    "bin": [
        "cmd\\git.exe",
        "cmd\\gitk.exe",
        "cmd\\git-gui.exe",
        "git-bash.exe"
    ],
    "post_install": [
        "git config --global credential.helper manager"
    ],
    "notes": "To get Git to recognise OpenSSH, you will need to run

scoop install openssh
[environment]::setenvironmentvariable('GIT_SSH', (resolve-path (scoop which ssh)), 'USER')

and then restart powershell.",
    "checkver": {
        "url": "https://github.com/git-for-windows/git/releases/latest",
        "re": "v(?<version>[\\d\\w.]+)/PortableGit-(?<short>[\\d.]+).*\\.exe"
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://github.com/git-for-windows/git/releases/download/v$matchVersion/PortableGit-$matchShort-64-bit.7z.exe#/dl.7z"
            },
            "32bit": {
                "url": "https://github.com/git-for-windows/git/releases/download/v$matchVersion/PortableGit-$matchShort-32-bit.7z.exe#/dl.7z"
            }
        }
    }
}
```
