### PR TITLE
php 7.1.1

### DIFF
--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,25 +1,25 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.1.0",
+    "version": "7.1.1",
     "license": "https://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.1.0-Win32-VC14-x64.zip",
+                "http://windows.php.net/downloads/releases/php-7.1.1-Win32-VC14-x64.zip",
                 "https://raw.githubusercontent.com/madbub/scoop-php/master/64-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:48b99e4aae06b6ca4933689277bd3ff836398eb8",
+                "sha1:84aefb5b1f4148a1895e8ae88726279a57850629",
                 "acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
             ]
         },
         "32bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.1.0-Win32-VC14-x86.zip",
+                "http://windows.php.net/downloads/releases/php-7.1.1-Win32-VC14-x86.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:afb042692d01848016c64246672601a28efffead",
+                "sha1:5f80a93f4fcdc3caa2faae182e39a0b69be3397f",
                 "b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
             ]
         }


### PR DESCRIPTION
while 7.1.1 havent been announced yet, the previous release 404's on their servers atm:

```
installing php (7.1.0)
downloading http://windows.php.net/downloads/releases/php-7.1.0-Win32-VC14-x64.zip...The remote server returned an error: (404) Not Found.
```