### PR TITLE
Fix: Haxe 3.4.0-rc.2 bucket error moving dir

### DIFF
--- a/bucket/haxe.json
+++ b/bucket/haxe.json
@@ -4,7 +4,7 @@
     "license": "https://haxe.org/foundation/open-source.html",
     "url": "https://haxe.org/website-content/downloads/3.4.0-rc.2/downloads/haxe-3.4.0-rc.2-win.zip",
     "hash": "6bc4a74b6738c270673a8033e91caf381120d0315c84072e94f9079e268048d0",
-    "extract_dir": "haxe-3.4.0-rc.2",
+    "extract_dir": "haxe-3.4.0-rc2",
     "bin": [
         "haxe.exe",
         "haxelib.exe"


### PR DESCRIPTION
Haxe 3.4.0-rc.2 config typo

Error:
```
installing haxe (3.4.0-rc.2)
loading https://haxe.org/website-content/downloads/3.4.0-rc.2/downloads/haxe-3.4.0-rc.2-win.zip from cache...
checking hash...ok
extracting...error moving directory:
-------------------------------------------------------------------------------
    ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------
    Started : Saturday, 21 January, 2017 19:35:27
    Source : C:\Users\Zweimal\AppData\Local\scoop\apps\haxe\3.4.0-rc.2\_scoop_extract\haxe-3.4.0-rc.2\
    Dest : C:\Users\Zweimal\AppData\Local\scoop\apps\haxe\3.4.0-rc.2\
    Files : *.*
    Options : *.* /S /E /DCOPY:DA /COPY:DAT /MOVE /R:1000000 /W:30
------------------------------------------------------------------------------ 
 2017/01/21 19:35:27 ERROR 2 (0x00000002) Accessing Source Directory C:\Users\Zweimal\AppData\Local\scoop\apps\haxe\3.4.0-rc.2\_scoop_extract\haxe-3.4.0-rc.2\ The system cannot find the file specified.
At C:\Users\Zweimal\AppData\Local\scoop\apps\scoop\current\lib\core.ps1:131 char:9
+         throw "error moving directory: `n$out"
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : OperationStopped: (error moving di...ile specified. :String) [], RuntimeException
+ FullyQualifiedErrorId : error moving directory:
  
  
-------------------------------------------------------------------------------
    ROBOCOPY     ::     Robust File Copy for Windows                           
-------------------------------------------------------------------------------
    Started : Saturday, 21 January, 2017 19:35:27
    Source : C:\Users\Zweimal\AppData\Local\scoop\apps\haxe\3.4.0-rc.2\_scoop_extract\haxe-3.4.0-rc.2\
    Dest : C:\Users\Zweimal\AppData\Local\scoop\apps\haxe\3.4.0-rc.2\
    Files : *.*
    Options : *.* /S /E /DCOPY:DA /COPY:DAT /MOVE /R:1000000 /W:30   
------------------------------------------------------------------------------
  2017/01/21 19:35:27 ERROR 2 (0x00000002) Accessing Source Directory C:\Users\Zweimal\AppData\Local\scoop\apps\haxe\3.4.0-rc.2\_scoop_extract\haxe-3.4.0-rc.2\ The system cannot find the file specified.
```