### PR TITLE
remotesigned in README fixes #1221

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Scoop is a command-line installer for Windows.
 Requirements:
 
 * [PowerShell 3](https://www.microsoft.com/en-us/download/details.aspx?id=34595)
-* PowerShell must be enabled for your user account e.g. `set-executionpolicy unrestricted -s cu`
+* PowerShell must be enabled for your user account e.g. `set-executionpolicy remotesigned -s cu`
 
 To install:
 


### PR DESCRIPTION
http://scoop.sh/ was updated to recommend `remotesigned` vs `unrestricted` but the README wasn't
Fixes #1221 - Change installation instructions to recommend RemoteSigned instead of Unrestricted