### PR TITLE
Fix scoop-reset's undefined `get_config` error

### DIFF
--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -10,6 +10,7 @@ param($app)
 . "$psscriptroot\..\lib\help.ps1"
 . "$psscriptroot\..\lib\install.ps1"
 . "$psscriptroot\..\lib\versions.ps1"
+. "$psscriptroot\..\lib\config.ps1"
 
 reset_aliases
 


### PR DESCRIPTION
`scoop reset` is currently erroring at an undefined `get_config` call:

```
$ scoop reset $app
resetting $app ($version)
get_config : The term 'get_config' is not recognized as the name of a cmdlet, function, script
file, or operable program. Check the spelling of the name, or if a path was included, verify that
the path is correct and try again.
At $path\scoop\apps\scoop\current\lib\install.ps1:638 char:8
+     if(get_config NO_JUNCTIONS) { return $versiondir }
+        ~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (get_config:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

In this PR I just followed the other commands' structure and sourced `lib/config.ps1` from `scoop-reset.ps1`. Feel free to close this if it's not the correct approach -- I just thought it was a small enough change to risk it.

As you can see, however, the problem actually comes from `lib/install.ps1`. Perhaps we should consider moving dependencies to the actual usage file? I'm not familiar enough with Powershell to know if that'd be better or how to "dot source guard" double inclusions.