### PR TITLE
Remove -SkipLast to restore Powershell 3 compatibility (fixes #1278)

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -141,7 +141,8 @@ function get_version_substitutions([String] $version, [Hashtable] $matches)
         '$buildVersion' = $firstPart.Split('.') | Select-Object -skip 3 -first 1;
         '$preReleaseVersion' = $lastPart;
     }
-    $matches.GetEnumerator() | Select -SkipLast 1 | % {
+    $matches.Remove(0)
+    $matches.GetEnumerator() | % {
         $versionVariables.Add('$match' + (Get-Culture).TextInfo.ToTitleCase($_.Name), $_.Value)
     }
     return $versionVariables


### PR DESCRIPTION
Fix for #1278