### PR TITLE
Assume that nuget.org URLs are valid

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -14,9 +14,9 @@ function substitute([String] $str, [Hashtable] $params) {
 }
 
 function check_url([String] $url) {
-    if ($url.Contains("github.com") -or $url.Contains("chocolatey.org")) {
+    if ($url.Contains("github.com") -or $url.Contains("nuget.org") -or $url.Contains("chocolatey.org")) {
         # github does not allow HEAD requests
-        warn "Unable to check github/chocolatey url (assuming it is ok)"
+        warn "Unable to check github/nuget/chocolatey url (assuming it is ok)"
         return $true
     }
 


### PR DESCRIPTION
NuGet-Galleries (such as nuget.org or chocolatey.org) don't seem to support `HEAD` requests.