### PR TITLE
Improve manifest validation tests for url and extract_dir

### DIFF
--- a/test/Scoop-Manifest.Tests.ps1
+++ b/test/Scoop-Manifest.Tests.ps1
@@ -11,11 +11,19 @@ describe "manifest-validation" {
             $manifest = parse_json $_.fullname
 
             $url = arch_specific "url" $manifest "32bit"
+            $url | should not match "\$"
+            $url64 = arch_specific "url" $manifest "64bit"
+            $url64 | should not match "\$"
             if(!$url) {
-                $url = arch_specific "url" $manifest "64bit"
+                $url = $url64
             }
-
             $url | should not benullorempty
+
+            $extract_dir32 = arch_specific "extract_dir" $manifest "32bit"
+            $extract_dir32 | should not match "\$"
+            $extract_dir64 = arch_specific "extract_dir" $manifest "64bit"
+            $extract_dir64 | should not match "\$"
+
             $manifest | should not benullorempty
             $manifest.version | should not benullorempty
         }


### PR DESCRIPTION
Manifest validation should fail if there are untranslated variables left over in url or extract_dir