### PR TITLE
Ensure shortcut set explicit working directory

### DIFF
--- a/lib/shortcuts.ps1
+++ b/lib/shortcuts.ps1
@@ -22,6 +22,7 @@ function startmenu_shortcut($target, $shortcutName) {
     $wsShell = New-Object -ComObject WScript.Shell
     $wsShell = $wsShell.CreateShortcut("$scoop_startmenu_folder\$shortcutName.lnk")
     $wsShell.TargetPath = "$target"
+    $wsShell.WorkingDirectory = Split-Path $target
     $wsShell.Save()
 }
 


### PR DESCRIPTION
Ideally we should let the manifest specify a working directory, but for now let's at least make sure it is by default set to the directory of the shortcut's target.