### PR TITLE
Remove extract_dir from git-lfs

### DIFF
--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -5,13 +5,11 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/github/git-lfs/releases/download/v1.5.6/git-lfs-windows-386-1.5.6.zip",
-            "hash": "70558921e7a405ede45e9441d247af741c5e82030f60bfdea9fe974f473ebc59",
-            "extract_dir": "git-lfs-windows-386-1.5.6"
+            "hash": "70558921e7a405ede45e9441d247af741c5e82030f60bfdea9fe974f473ebc59"
         },
         "64bit": {
             "url": "https://github.com/github/git-lfs/releases/download/v1.5.6/git-lfs-windows-amd64-1.5.6.zip",
-            "hash": "cc72164f5ba54fad85c67c19e507cb4da001039d84132d101a7c8eab98b28aa2",
-            "extract_dir": "git-lfs-windows-amd64-1.5.6"
+            "hash": "cc72164f5ba54fad85c67c19e507cb4da001039d84132d101a7c8eab98b28aa2"
         }
     },
     "depends": "git",
@@ -22,12 +20,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-386-$version.zip",
-                "extract_dir": "git-lfs-windows-386-$version"
+                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-386-$version.zip"
             },
             "64bit": {
-                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-amd64-$version.zip",
-                "extract_dir": "git-lfs-windows-amd64-$version"
+                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-amd64-$version.zip"
             }
         }
     }


### PR DESCRIPTION
Fixes:
````
Extracting... Error moving directory:
 -------------------------------------------------------------------------------    ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------    Started : Thu Feb 16 16:22:35 2017     Source :
C:\Users\ross\scoop\apps\git-lfs\1.5.6\_scoop_extract\git-lfs-windows-amd64-1.5.6\      Dest : C:\Users\ross\scoop\apps\git-lfs\1.5.6\      Files : *.*                Options : *.* /S /E

/COPY:DAT /MOVE /R:1000000 /W:30   ------------------------------------------------------------------------------  2017/02/16 16:22:35 ERROR 2 (0x00000002) Accessing Source Directory
C:\Users\ross\scoop\apps\git-lfs\1.5.6\_scoop_extract\git-lfs-windows-amd64-1.5.6\ The system cannot find the file specified.
At C:\Users\ross\scoop\apps\scoop\current\lib\core.ps1:131 char:9
+         throw "Error moving directory: `n$out"
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Error moving di...ile specified. :String) [], RuntimeException
    + FullyQualifiedErrorId : Error moving directory:
     -------------------------------------------------------------------------------    ROBOCOPY     ::     Robust File Copy for Windows                               ------------------
   -------------------------------------------------------------    Started : Thu Feb 16 16:22:35 2017     Source : C:\Users\ross\scoop\apps\git-lfs\1.5.6\_scoop_extract\git-lfs-window
  s-amd64-1.5.6\      Dest : C:\Users\ross\scoop\apps\git-lfs\1.5.6\      Files : *.*          Options : *.* /S /E /COPY:DAT /MOVE /R:1000000 /W:30   ----------------------------------

 --------------------------------------------  2017/02/16 16:22:35 ERROR 2 (0x00000002) Accessing Source Directory C:\Users\ross\scoop\apps\git-lfs\1.5.6\_scoop_extract\git-lfs-windo
ws-amd64-1.5.6\ The system cannot find the file specified.
````