### PR TITLE
Improvements for schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -9,24 +9,27 @@
                 "bin": {
                     "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
                 },
+                "checkver": {
+                    "$ref": "#/definitions/checkver"
+                },
                 "extract_dir": {
-                    "$ref": "#/definitions/stringOrArrayOfOneOrMoreStrings"
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
                 "hash": {
-                    "$ref": "#/definitions/stringOrArrayOfOneOrMoreStrings"
+                    "$ref": "#/definitions/stringOrArrayOfUniqueStrings"
                 },
                 "installer": {
                     "$ref": "#/definitions/installer"
                 },
                 "msi": {
-                    "$ref": "#/definitions/stringOrArrayOfOneOrMoreStrings",
+                    "$ref": "#/definitions/stringOrArrayOfStrings",
                     "description": "Deprecated"
                 },
                 "post_install": {
-                    "$ref": "#/definitions/stringOrArrayOfOneOrMoreStrings"
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
                 "pre_install": {
-                    "$ref": "#/definitions/stringOrArrayOfOneOrMoreStrings"
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
                 "uninstaller": {
                     "$ref": "#/definitions/uninstaller"
@@ -42,8 +45,10 @@
                 "items": {
                     "type": "string"
                 },
+                "minItems": 1,
                 "type": "array"
             },
+            "minItems": 1,
             "type": "array"
         },
         "autoupdate": {
@@ -82,7 +87,7 @@
                     "type": "object"
                 },
                 "extract_dir": {
-                    "$ref": "#/definitions/stringOrArrayOfOneOrMoreStrings"
+                    "type": "string"
                 },
                 "hash": {
                     "additionalProperties": false,
@@ -185,19 +190,6 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
-                }
-            ]
-        },
-        "stringOrArrayOfOneOrMoreStrings": {
-            "anyOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "items": {
-                        "type": "string"
-                    },
                     "minItems": 1,
                     "type": "array"
                 }
@@ -210,19 +202,25 @@
                 },
                 {
                     "items": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            }
-                        ]
+                        "$ref": "#/definitions/stringOrArrayOfStrings"
                     },
+                    "minItems": 1,
                     "type": "array"
+                }
+            ]
+        },
+        "stringOrArrayOfUniqueStrings": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": true
                 }
             ]
         },
@@ -244,21 +242,22 @@
             "anyOf": [
                 {
                     "format": "uri",
-                    "type": "string",
                     "not": {
                         "pattern": "(\\$)"
-                    }
+                    },
+                    "type": "string"
                 },
                 {
                     "items": {
                         "format": "uri",
-                        "type": "string",
                         "not": {
                             "pattern": "(\\$)"
-                        }
+                        },
+                        "type": "string"
                     },
                     "minItems": 1,
-                    "type": "array"
+                    "type": "array",
+                    "uniqueItems": true
                 }
             ]
         }
@@ -272,78 +271,10 @@
             "additionalProperties": false,
             "properties": {
                 "32bit": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "bin": {
-                            "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
-                        },
-                        "checkver": {
-                            "$ref": "#/definitions/checkver"
-                        },
-                        "extract_dir": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "hash": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "installer": {
-                            "$ref": "#/definitions/installer"
-                        },
-                        "msi": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings",
-                            "description": "Deprecated"
-                        },
-                        "post_install": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "pre_install": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "uninstaller": {
-                            "$ref": "#/definitions/uninstaller"
-                        },
-                        "url": {
-                            "$ref": "#/definitions/uriOrArrayOfUris"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/architecture"
                 },
                 "64bit": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "bin": {
-                            "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
-                        },
-                        "checkver": {
-                            "$ref": "#/definitions/checkver"
-                        },
-                        "extract_dir": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "hash": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "installer": {
-                            "$ref": "#/definitions/installer"
-                        },
-                        "msi": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings",
-                            "description": "Deprecated"
-                        },
-                        "post_install": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "pre_install": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "uninstaller": {
-                            "$ref": "#/definitions/uninstaller"
-                        },
-                        "url": {
-                            "$ref": "#/definitions/uriOrArrayOfUris"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/architecture"
                 }
             },
             "type": "object"
@@ -382,7 +313,7 @@
             "description": "Undocumented: only found in scoop/ruby*"
         },
         "hash": {
-            "$ref": "#/definitions/stringOrArrayOfStrings"
+            "$ref": "#/definitions/stringOrArrayOfUniqueStrings"
         },
         "homepage": {
             "format": "uri",
@@ -411,8 +342,26 @@
         "pre_install": {
             "$ref": "#/definitions/stringOrArrayOfStrings"
         },
+        "psmodule": {
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "shortcuts": {
             "$ref": "#/definitions/arrayOfArrayOfStrings"
+        },
+        "suggest": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^(.*)$": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                }
+            },
+            "type": "object"
         },
         "travel_dirs": {
             "$ref": "#/definitions/stringOrArrayOfStrings",
@@ -425,30 +374,13 @@
             "$ref": "#/definitions/uriOrArrayOfUris"
         },
         "version": {
+            "pattern": "^[\\w\\.\\-_]+$",
             "type": "string"
-        },
-        "suggest": {
-            "additionalProperties": false,
-            "patternProperties": {
-                "^(.*)$": {
-                    "$ref": "#/definitions/stringOrArrayOfStrings"
-                }
-            },
-            "type": "object"
-        },
-        "psmodule": {
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
         }
     },
-    "title": "scoop app manifest schema",
-    "type": "object",
     "required": [
         "version"
-    ]
+    ],
+    "title": "scoop app manifest schema",
+    "type": "object"
 }


### PR DESCRIPTION
* Use architecture definition
* Arrays of string shouldn't be empty
* Add back uniqueItems directive
* match version against pattern from [lib/install.ps1#L21](https://github.com/lukesampson/scoop/blob/master/lib/install.ps1#L21))
* `extract_dir` in autoupdate only works with string (at the time)
* reindent