### PR TITLE
Better error handling for autoupdate and checkver

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -106,7 +106,8 @@ while($in_progress -gt 0) {
     write-host "$app`: " -nonewline
 
     if($err) {
-        write-host "ERROR: $err" -f darkyellow
+        write-host -f darkred $err.message
+        write-host -f darkred "URL $url is not valid"
     } else {
         if($page -match $regexp) {
             $ver = $matches[1]

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -142,7 +142,7 @@ function do_dl($url, $to, $cookies) {
     } catch {
         $e = $_.exception
         if($e.innerexception) { $e = $e.innerexception }
-        abort $e.message
+        throw $e
     } finally {
         set_https_protocols $original_protocols
     }
@@ -300,7 +300,12 @@ function dl_urls($app, $version, $manifest, $architecture, $dir, $use_cache = $t
         }
         $fname = $data.$url.fname
 
-        dl_with_cache $app $version $url "$dir\$fname" $cookies $use_cache
+        try {
+            dl_with_cache $app $version $url "$dir\$fname" $cookies $use_cache
+        } catch {
+            write-host -f darkred $_
+            abort "URL $url is not valid"
+        }
     }
 
     foreach($url in $urls) {


### PR DESCRIPTION
do_dl() now rethrows an exception instead of aborting. this prevents killing the autoupdate process prematurely and thus skipping queued updates.