### PR TITLE
remove unncessary setting of $HOME env var which causes other issues

### DIFF
--- a/bucket/openssh.json
+++ b/bucket/openssh.json
@@ -26,6 +26,5 @@
         "bin\\ssh-keygen.exe",
         "bin\\ssh-keyscan.exe",
         "bin\\ssh.exe"
-    ],
-    "env_set": { "home": "$home" }
+    ]
 }


### PR DESCRIPTION
I've been experiencing quite a bit of issues with the setting of $HOME env var causing failures in building Unreal Engine HTML5 WebGL: https://answers.unrealengine.com/questions/457972/could-not-find-file-epic-games412engineintermediat.html

Follow their support team's suggestions, I look around in my `scoop` installations for where $HOME was being set. And I noticed that `env_ensure_home` is commented out and the general direction in scoop is not to set $HOME:

https://github.com/lukesampson/scoop/blob/a6f6e5425f873098a565b4e85b7639053d0c894e/lib/install.ps1#L840

However I did find $HOME still being set in `openssh` which I have installed in my system. So that's what this PR is about.