### PR TITLE
Update URLs for Yarn

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -11,14 +11,14 @@
             "nvm"
         ]
     },
-    "url": "https://github.com/yarnpkg/yarn/releases/download/v0.21.3/yarn-0.21.3.msi",
+    "url": "https://yarnpkg.com/downloads/0.21.3/yarn-0.21.3.msi",
     "hash": "3b4e34f8a3b3c4cb63f2da5411fe7a7977f35e65679b45b68773de4ed24a0d1c",
     "bin": "Yarn\\bin\\yarn.cmd",
     "checkver": {
-        "url": "https://github.com/yarnpkg/yarn/releases/latest",
-        "re": "/releases/tag/v([\\d.]+)"
+        "url": "https://yarnpkg.com/latest-version",
+        "re": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/yarnpkg/yarn/releases/download/v$version/yarn-$version.msi"
+        "url": "https://yarnpkg.com/downloads/$version/yarn-$version.msi"
     }
 }


### PR DESCRIPTION
The Yarn package should use the official download URLs rather than the GitHub URLs 😃 