### PR TITLE
Repaired the axel app manifest 

### DIFF
--- a/bucket/axel.json
+++ b/bucket/axel.json
@@ -1,7 +1,7 @@
 {
     "version":  "2.4",
-    "url":  "https://dl.dropbox.com/u/23114384/builds/Axel2.4.zip",
-    "homepage":  "https://st0rage.org/~n2j3/?page_id=225717166",
-    "hash":  "65d36c69ca060a84ffdf542cc26dbae2e800811217382d2b1a9b6156a7b79b43",
+    "url":  "https://github.com/ghuntley/cygwin-axel/raw/master/release/axel-2.4.zip",
+    "homepage":  "https://github.com/ghuntley/cygwin-axel/",
+    "hash":  "3cce621da5f17ea03e4fcf51916dd4f8928759766f88b4ca5643131d2dd3fed2",
     "bin":  "axel.exe"
 }


### PR DESCRIPTION
Repaired the axel app manifest to use maintainer release (https://github.com/ghuntley/cygwin-axel) instead of dropbox