### PR TITLE
Fixed bug where $home doesn't support .endswith

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -87,7 +87,8 @@ function fullpath($path) { # should be ~ rooted
 }
 function relpath($path) { "$($myinvocation.psscriptroot)\$path" } # relative to calling script
 function friendly_path($path) {
-    $h = $home; if(!$h.endswith('\')) { $h += '\' }
+    $h = $home.ToString()
+    if(!$h.endswith('\')) { $h += '\' }
     if($h -eq '\') { return $path }
     return "$path" -replace ([regex]::escape($h)), "~\"
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -87,8 +87,7 @@ function fullpath($path) { # should be ~ rooted
 }
 function relpath($path) { "$($myinvocation.psscriptroot)\$path" } # relative to calling script
 function friendly_path($path) {
-    $h = $home.ToString()
-    if(!$h.endswith('\')) { $h += '\' }
+    $h = "$env:userprofile"; if(!$h.endswith('\')) { $h += '\' }
     if($h -eq '\') { return $path }
     return "$path" -replace ([regex]::escape($h)), "~\"
 }


### PR DESCRIPTION
In Windows 10, at least after the Creators update, $h is of type
PathInfo, which does not support String operations.  By toStringing it,
we turn it into a String and enable the expected String operations.

see https://github.com/lukesampson/scoop/issues/1440