### PR TITLE
Version substitution for license property

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -263,6 +263,9 @@ function autoupdate([String] $app, $dir, $json, [String] $version, [Hashtable] $
     # update properties
     update_manifest_prop "extract_dir" $json $substitutions
 
+    # update license
+    update_manifest_prop "license" $json $substitutions
+
     if ($has_changes -and !$has_errors) {
         # write file
         Write-Host -f DarkGreen "Writing updated $app manifest"


### PR DESCRIPTION
To allow something like this:
```
"license": "https://<some-site>/1.0.0/license/en.html",
"autoupdate": {
     "url": "https://<some-site>/$version/<software>-$version.zip",
     "license": "https://<some-site>/$version/license/en.html"
}
```