### PR TITLE
Set GIT_INSTALL_ROOT variable on installation

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -32,6 +32,9 @@ and then restart powershell.",
         "url": "https://github.com/git-for-windows/git/releases/latest",
         "re": "v(?<version>[\\d\\w.]+)/PortableGit-(?<short>[\\d.]+).*\\.exe"
     },
+    "env_set": {
+        "GIT_INSTALL_ROOT": "$dir"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
The GIT_INSTALL_ROOT env is required by cmder, otherwise it starts giving "Found old git at C:\Users\<name>\scoop\apps, but not using..."