### PR TITLE
Added Cmder env variables

### DIFF
--- a/bucket/cmder.json
+++ b/bucket/cmder.json
@@ -14,6 +14,10 @@
             "Cmder"
         ]
     ],
+    "env_set": {
+       "CMDER_ROOT": "$dir",
+       "ConEmuDir": "$dir\\vendor\\conemu-maximus5"
+    },
     "checkver": {
         "github": "https://github.com/cmderdev/cmder"
     },


### PR DESCRIPTION
Cmder starts complaining if these are not available.

I did not have to set them when I was using the full installation; this must just be an issue with the mini client.