### PR TITLE
use diffutils from msys2

### DIFF
--- a/bucket/diffutils.json
+++ b/bucket/diffutils.json
@@ -1,22 +1,40 @@
 {
-    "homepage": "http://www.mingw.org/wiki/MSYS",
-    "version": "2.8.7",
-    "url": [
-        "https://sourceforge.net/projects/mingw/files/MSYS/Base/diffutils/diffutils-2.8.7.20071206cvs-3/diffutils-2.8.7.20071206cvs-3-msys-1.0.13-bin.tar.lzma",
-        "https://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.18-1/msysCORE-1.0.18-1-msys-1.0.18-bin.tar.lzma",
-        "https://sourceforge.net/projects/mingw/files/MSYS/Base/gettext/gettext-0.18.1.1-1/libintl-0.18.1.1-1-msys-1.0.17-dll-8.tar.lzma",
-        "https://sourceforge.net/projects/mingw/files/MSYS/Base/libiconv/libiconv-1.14-1/libiconv-1.14-1-msys-1.0.17-dll-2.tar.lzma"
-    ],
-    "hash": [
-        "522889b044492dd2337c4752ba6262995a11f352ca5fb8a8660349413ea9b864",
-        "4e262a414f238773b311c8bb55a52e62743c06e0e55b319ca5b47e3e306464d5",
-        "29db8c969661c511fbe2a341ab25c993c5f9c555842a75d6ddbcfa70dec16910",
-        "196921e8c232259c8e6a6852b9ee8d9ab2d29a91419f0c8dc27ba6f034231683"
-    ],
+    "homepage": "http://www.msys2.org",
+    "version": "3.5",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "http://repo.msys2.org/msys/x86_64/diffutils-3.5-1-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/msys2-runtime-2.7.0-1-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/libiconv-1.14-2-x86_64.pkg.tar.xz",
+                "http://repo.msys2.org/msys/x86_64/libintl-0.19.7-3-x86_64.pkg.tar.xz"
+            ],
+            "hash": [
+                "6feba4594fe39180752213673510041d322be87977b573fc933141ddc8cb7f01",
+                "13921128ec52d0cf14b5b5c518c21c7b937020075607c0b5d96fa49f8eea0bd2",
+                "de1a5b4974b10ddcf35389c9ede615ed4ab93f86854e7355e66d1f39723ca3c8",
+                "8bde823a82608b577c31c82759a8410bd503c5f7ae62843385310b2e4c24b48c"
+            ]
+        },
+        "32bit": {
+            "url": [
+                "http://repo.msys2.org/msys/i686/diffutils-3.5-1-i686.pkg.tar.xz",
+                "http://repo.msys2.org/msys/i686/msys2-runtime-2.7.0-1-i686.pkg.tar.xz",
+                "http://repo.msys2.org/msys/i686/libiconv-1.14-2-i686.pkg.tar.xz",
+                "http://repo.msys2.org/msys/i686/libintl-0.19.7-3-i686.pkg.tar.xz"
+            ],
+            "hash": [
+                "3b60c994dfcf8fb8e3a61d1c4aab4b23102e16c5d9c5e080761d969bec414ebe",
+                "86574f2e9afe9d295f329fb23feb35ec18505070b3682e76961d9c5910764388",
+                "90502f67f38eb7d709498b9fb4a0e68f2afafafa1fad005e0dec8315d8191b79",
+                "1285d5788987052e133e18b537d9825a7a3cd4ecb738d8cfd5feddc9886ba58a"
+            ]
+        }
+    },
     "bin": [
-        "bin\\cmp.exe",
-        "bin\\diff.exe",
-        "bin\\diff3.exe",
-        "bin\\sdiff.exe"
+        "usr\\bin\\cmp.exe",
+        "usr\\bin\\diff.exe",
+        "usr\\bin\\diff3.exe",
+        "usr\\bin\\sdiff.exe"
     ]
 }


### PR DESCRIPTION
because diff utils from msys crash under win10