### PR TITLE
[WIP] Add Unix compatibility (for maintenance jobs and manifest testing)

### DIFF
--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -22,9 +22,16 @@ $dir = resolve-path $dir
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\json.ps1"
 
-if (!(scoop which hub)) {
-    Write-Host -f yellow "Please install hub (scoop install hub)"
-    exit 1
+if([environment]::OSVersion.Platform -eq "Unix") {
+    if (!(which hub)) {
+        Write-Host -f yellow "Please install hub ('brew install hub' or visit: https://hub.github.com/)"
+        exit 1
+    }
+} else {
+    if (!(scoop which hub)) {
+        Write-Host -f yellow "Please install hub 'scoop install hub'"
+        exit 1
+    }
 }
 
 if ((!$push -and !$request) -or $help) {

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -22,7 +22,7 @@ $dir = resolve-path $dir
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\json.ps1"
 
-if([environment]::OSVersion.Platform -eq "Unix") {
+if(isUnix) {
     if (!(which hub)) {
         Write-Host -f yellow "Please install hub ('brew install hub' or visit: https://hub.github.com/)"
         exit 1

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -21,8 +21,9 @@ $dir = resolve-path $dir
 
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\json.ps1"
+. "$psscriptroot\..\lib\unix.ps1"
 
-if(isUnix) {
+if(is_unix) {
     if (!(which hub)) {
         Write-Host -f yellow "Please install hub ('brew install hub' or visit: https://hub.github.com/)"
         exit 1

--- a/bin/checkurls.ps1
+++ b/bin/checkurls.ps1
@@ -48,17 +48,18 @@ function test_dl($url, $cookies) {
             $wreq.headers.add('Cookie', (cookie_header $cookies))
         }
     }
+    $wres = $null
     try {
         $wres = $wreq.getresponse()
-        if($wres -isnot [net.ftpwebresponse]) {
-            $wres.close()
-        }
         return $url, $wres.statuscode, $null
     } catch {
         $e = $_.exception
         if($e.innerexception) { $e = $e.innerexception }
         return $url, "Error", $e.message
     } finally {
+        if($wres -ne $null -and $wres -isnot [net.ftpwebresponse]) {
+            $wres.close()
+        }
     }
 }
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -21,6 +21,7 @@ if (!$app -and $update) {
 . "$psscriptroot\..\lib\json.ps1"
 . "$psscriptroot\..\lib\versions.ps1"
 . "$psscriptroot\..\lib\install.ps1" # needed for hash generation
+. "$psscriptroot\..\lib\unix.ps1"
 
 if(!$dir) { $dir = "$psscriptroot\..\bucket" }
 $dir = resolve-path $dir

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -270,7 +270,7 @@ function autoupdate([String] $app, $dir, $json, [String] $version, [Hashtable] $
         # write file
         Write-Host -f DarkGreen "Writing updated $app manifest"
 
-        $path = "$dir\$app.json"
+        $path = join-path $dir "$app.json"
 
         $file_content = $json | ConvertToPrettyJson
         [System.IO.File]::WriteAllLines($path, $file_content)

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -195,23 +195,23 @@ function shim($path, $global, $name, $arg) {
 
     # if $path points to another drive resolve-path prepends .\ which could break shims
     if($relpath -match "^(.\\[\w]:).*$") {
-        echo "`$path = `"$path`"" | out-file $shim -encoding utf8
+        write-output "`$path = `"$path`"" | out-file $shim -encoding utf8
     } else {
-        echo "`$path = join-path `"`$psscriptroot`" `"$relpath`"" | out-file $shim -encoding utf8
+        write-output "`$path = join-path `"`$psscriptroot`" `"$relpath`"" | out-file $shim -encoding utf8
     }
 
     if($arg) {
-        echo "`$args = '$($arg -join "', '")', `$args" | out-file $shim -encoding utf8 -append
+        write-output "`$args = '$($arg -join "', '")', `$args" | out-file $shim -encoding utf8 -append
     }
-    echo 'if($myinvocation.expectingInput) { $input | & $path @args } else { & $path @args }' | out-file $shim -encoding utf8 -append
+    write-output 'if($myinvocation.expectingInput) { $input | & $path @args } else { & $path @args }' | out-file $shim -encoding utf8 -append
 
     if($path -match '\.exe$') {
         # for programs with no awareness of any shell
         $shim_exe = "$(strip_ext($shim)).shim"
         cp "$(versiondir 'scoop' 'current')\supporting\shimexe\shim.exe" "$(strip_ext($shim)).exe" -force
-        echo "path = $(resolve-path $path)" | out-file $shim_exe -encoding utf8
+        write-output "path = $(resolve-path $path)" | out-file $shim_exe -encoding utf8
         if($arg) {
-            echo "args = $arg" | out-file $shim_exe -encoding utf8 -append
+            write-output "args = $arg" | out-file $shim_exe -encoding utf8 -append
         }
     } elseif($path -match '\.((bat)|(cmd))$') {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH
@@ -232,7 +232,7 @@ function ensure_in_path($dir, $global) {
     $path = env 'path' $global
     $dir = fullpath $dir
     if($path -notmatch [regex]::escape($dir)) {
-        echo "Adding $(friendly_path $dir) to $(if($global){'global'}else{'your'}) path."
+        write-output "Adding $(friendly_path $dir) to $(if($global){'global'}else{'your'}) path."
 
         env 'path' $global "$dir;$path" # for future sessions...
         $env:path = "$dir;$env:path" # for this session
@@ -258,7 +258,7 @@ function remove_from_path($dir,$global) {
     # future sessions
     $was_in_path, $newpath = strip_path (env 'path' $global) $dir
     if($was_in_path) {
-        echo "Removing $(friendly_path $dir) from your path."
+        write-output "Removing $(friendly_path $dir) from your path."
         env 'path' $global $newpath
     }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -18,8 +18,12 @@ $globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | select -first 1
 #       Use at your own risk.
 $cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | select -first 1
 
+function isUnix() { $PSVersionTable.Platform -eq 'Unix' }
+function isMacOS() { $PSVersionTable.OS.ToLower().StartsWith('darwin') }
+function isLinux() { $PSVersionTable.OS.ToLower().StartsWith('linux') }
+
 # Overwrite $scoopdir, $globaldir and $cachedir on unix systems
-if([environment]::OSVersion.Platform -eq "Unix") {
+if(isUnix) {
     $scoopdir = $env:SCOOP, (Join-Path $env:HOME "scoop") | select -first 1
     $globaldir = $env:SCOOP_GLOBAL, "/usr/local/scoop" | select -first 1
     $cachedir = $env:SCOOP_CACHE, (Join-Path $scoopdir "cache") | select -first 1
@@ -104,7 +108,7 @@ function url_remote_filename($url) {
 }
 
 function ensure($dir) {
-    if([environment]::OSVersion.Platform -eq "Unix") {
+    if(isUnix) {
         mkdir -p $dir > $null
     } else {
         if(!(test-path $dir)) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -10,7 +10,7 @@ if((test-path $oldscoopdir) -and !$env:SCOOP) {
     $scoopdir = $oldscoopdir
 }
 
-$globaldir = $env:SCOOP_GLOBAL, "$($env:programdata.tolower())\scoop" | select -first 1
+$globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | select -first 1
 
 # Note: Setting the SCOOP_CACHE environment variable to use a shared directory
 #       is experimental and untested. There may be concurrency issues when

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -18,19 +18,11 @@ $globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | select -first 1
 #       Use at your own risk.
 $cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | select -first 1
 
-function isUnix() { $PSVersionTable.Platform -eq 'Unix' }
-function isMacOS() { $PSVersionTable.OS.ToLower().StartsWith('darwin') }
-function isLinux() { $PSVersionTable.OS.ToLower().StartsWith('linux') }
-
-# Overwrite $scoopdir, $globaldir and $cachedir on unix systems
-if(isUnix) {
-    $scoopdir = $env:SCOOP, (Join-Path $env:HOME "scoop") | select -first 1
-    $globaldir = $env:SCOOP_GLOBAL, "/usr/local/scoop" | select -first 1
-    $cachedir = $env:SCOOP_CACHE, (Join-Path $scoopdir "cache") | select -first 1
-    $env:TEMP = "/tmp"
-}
-
 # helper functions
+function is_unix() { $PSVersionTable.Platform -eq 'Unix' }
+function is_mac() { $PSVersionTable.OS.ToLower().StartsWith('darwin') }
+function is_linux() { $PSVersionTable.OS.ToLower().StartsWith('linux') }
+
 function coalesce($a, $b) { if($a) { return $a } $b }
 
 function format($str, $hash) {
@@ -108,16 +100,7 @@ function url_remote_filename($url) {
     split-path (new-object uri $url).absolutePath -leaf
 }
 
-function ensure($dir) {
-    if(isUnix) {
-        mkdir -p $dir > $null
-    } else {
-        if(!(test-path $dir)) {
-            mkdir $dir > $null
-        }
-    }
-    return resolve-path $dir
-}
+function ensure($dir) { if(!(test-path $dir)) { mkdir $dir > $null }; resolve-path $dir }
 function fullpath($path) { # should be ~ rooted
     $executionContext.sessionState.path.getUnresolvedProviderPathFromPSPath($path)
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -19,10 +19,6 @@ $globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | select -first 1
 $cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | select -first 1
 
 # helper functions
-function is_unix() { $PSVersionTable.Platform -eq 'Unix' }
-function is_mac() { $PSVersionTable.OS.ToLower().StartsWith('darwin') }
-function is_linux() { $PSVersionTable.OS.ToLower().StartsWith('linux') }
-
 function coalesce($a, $b) { if($a) { return $a } $b }
 
 function format($str, $hash) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -27,6 +27,7 @@ if(isUnix) {
     $scoopdir = $env:SCOOP, (Join-Path $env:HOME "scoop") | select -first 1
     $globaldir = $env:SCOOP_GLOBAL, "/usr/local/scoop" | select -first 1
     $cachedir = $env:SCOOP_CACHE, (Join-Path $scoopdir "cache") | select -first 1
+    $env:TEMP = "/tmp"
 }
 
 # helper functions

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -18,6 +18,13 @@ $globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | select -first 1
 #       Use at your own risk.
 $cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | select -first 1
 
+# Overwrite $scoopdir, $globaldir and $cachedir on unix systems
+if([environment]::OSVersion.Platform -eq "Unix") {
+    $scoopdir = $env:SCOOP, (Join-Path $env:HOME "scoop") | select -first 1
+    $globaldir = $env:SCOOP_GLOBAL, "/usr/local/scoop" | select -first 1
+    $cachedir = $env:SCOOP_CACHE, (Join-Path $scoopdir "cache") | select -first 1
+}
+
 # helper functions
 function coalesce($a, $b) { if($a) { return $a } $b }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -103,7 +103,16 @@ function url_remote_filename($url) {
     split-path (new-object uri $url).absolutePath -leaf
 }
 
-function ensure($dir) { if(!(test-path $dir)) { mkdir $dir > $null }; resolve-path $dir }
+function ensure($dir) {
+    if([environment]::OSVersion.Platform -eq "Unix") {
+        mkdir -p $dir > $null
+    } else {
+        if(!(test-path $dir)) {
+            mkdir $dir > $null
+        }
+    }
+    return resolve-path $dir
+}
 function fullpath($path) { # should be ~ rooted
     $executionContext.sessionState.path.getUnresolvedProviderPathFromPSPath($path)
 }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -452,7 +452,6 @@ function check_hash($file, $url, $manifest, $arch) {
 }
 
 function compute_hash($file, $algname) {
-    if([environment]::OSVersion.Platform -eq "Unix") {
         switch ($algname)
         {
             "md5" { $result = (md5sum -b $file) }
@@ -460,6 +459,7 @@ function compute_hash($file, $algname) {
             "sha256" { $result = (sha256sum -b $file) }
             "sha512" { $result = (sha512sum -b $file) }
             default { $result = (sha256sum -b $file) }
+    if(isUnix) {
         }
         return $result.split(" ") | select -first 1
     }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -452,28 +452,6 @@ function check_hash($file, $url, $manifest, $arch) {
 }
 
 function compute_hash($file, $algname) {
-    if(isUnix) {
-        if(isMacOS) {
-            switch ($algname)
-            {
-                "md5" { $result = (md5 -q $file) }
-                "sha1" { $result = (shasum -ba 1 $file) }
-                "sha256" { $result = (shasum -ba 256 $file) }
-                "sha512" { $result = (shasum -ba 512 $file) }
-                default { $result = (shasum -ba 256 $file) }
-            }
-        } else {
-            switch ($algname)
-            {
-                "md5" { $result = (md5sum -b $file) }
-                "sha1" { $result = (sha1sum -b $file) }
-                "sha256" { $result = (sha256sum -b $file) }
-                "sha512" { $result = (sha512sum -b $file) }
-                default { $result = (sha256sum -b $file) }
-            }
-        }
-        return $result.split(' ') | select -first 1
-    }
     $alg = [system.security.cryptography.hashalgorithm]::create($algname)
     $fs = [system.io.file]::openread($file)
     try {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -112,8 +112,7 @@ function dl_with_cache($app, $version, $url, $to, $cookies = $null, $use_cache =
 
 function use_any_https_protocol() {
     $original = "$([System.Net.ServicePointManager]::SecurityProtocol)"
-    $available = [string]::join(', ', `
-        [Enum]::GetNames([System.Net.SecurityProtocolType]))
+    $available = [string]::join(', ', [Enum]::GetNames([System.Net.SecurityProtocolType]))
 
     # use whatever protocols are available that the server supports
     set_https_protocols $available
@@ -122,8 +121,11 @@ function use_any_https_protocol() {
 }
 
 function set_https_protocols($protocols) {
-    [System.Net.ServicePointManager]::SecurityProtocol = `
-        [System.Net.SecurityProtocolType] $protocols
+    try {
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType] $available
+    } catch {
+        [System.Net.ServicePointManager]::SecurityProtocol = "Tls,Tls11,Tls12"
+    }
 }
 
 function do_dl($url, $to, $cookies) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -31,7 +31,7 @@ function install_app($app, $architecture, $global, $suggested) {
         $check_hash = $false
     }
 
-    echo "Installing '$app' ($version)."
+    write-output "Installing '$app' ($version)."
 
     $dir = ensure (versiondir $app $version $global)
     $original_dir = $dir # keep reference to real (not linked) directory
@@ -668,7 +668,7 @@ function create_shims($manifest, $dir, $global, $arch) {
     $shims = @(arch_specific 'bin' $manifest $arch)
     $shims | ?{ $_ -ne $null } | % {
         $target, $name, $arg = shim_def $_
-        echo "Creating shim for '$name'."
+        write-output "Creating shim for '$name'."
 
         # check valid bin
         $bin = "$dir\$target"
@@ -687,7 +687,7 @@ function rm_shim($name, $shimdir) {
     if(!(test-path $shim)) { # handle no shim from failed install
         warn "Shim for '$name' is missing. Skipping."
     } else {
-        echo "Removing shim for '$name'."
+        write-output "Removing shim for '$name'."
         rm $shim
     }
 
@@ -873,7 +873,7 @@ function env_ensure_home($manifest, $global) {
 function pre_install($manifest, $arch) {
     $pre_install = arch_specific 'pre_install' $manifest $arch
     if($pre_install) {
-        echo "Running pre-install script..."
+        write-output "Running pre-install script..."
         iex $pre_install
     }
 }
@@ -881,16 +881,16 @@ function pre_install($manifest, $arch) {
 function post_install($manifest, $arch) {
     $post_install = arch_specific 'post_install' $manifest $arch
     if($post_install) {
-        echo "Running post-install script..."
+        write-output "Running post-install script..."
         iex $post_install
     }
 }
 
 function show_notes($manifest, $dir, $original_dir, $persist_dir) {
     if($manifest.notes) {
-        echo "Notes"
-        echo "-----"
-        echo (wraptext (substitute $manifest.notes @{ '$dir' = $dir; '$original_dir' = $original_dir; '$persist_dir' = $persist_dir}))
+        write-output "Notes"
+        write-output "-----"
+        write-output (wraptext (substitute $manifest.notes @{ '$dir' = $dir; '$original_dir' = $original_dir; '$persist_dir' = $persist_dir}))
     }
 }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -452,6 +452,17 @@ function check_hash($file, $url, $manifest, $arch) {
 }
 
 function compute_hash($file, $algname) {
+    if([environment]::OSVersion.Platform -eq "Unix") {
+        switch ($algname)
+        {
+            "md5" { $result = (md5sum -b $file) }
+            "sha1" { $result = (sha1sum -b $file) }
+            "sha256" { $result = (sha256sum -b $file) }
+            "sha512" { $result = (sha512sum -b $file) }
+            default { $result = (sha256sum -b $file) }
+        }
+        return $result.split(" ") | select -first 1
+    }
     $alg = [system.security.cryptography.hashalgorithm]::create($algname)
     $fs = [system.io.file]::openread($file)
     try {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -452,16 +452,27 @@ function check_hash($file, $url, $manifest, $arch) {
 }
 
 function compute_hash($file, $algname) {
-        switch ($algname)
-        {
-            "md5" { $result = (md5sum -b $file) }
-            "sha1" { $result = (sha1sum -b $file) }
-            "sha256" { $result = (sha256sum -b $file) }
-            "sha512" { $result = (sha512sum -b $file) }
-            default { $result = (sha256sum -b $file) }
     if(isUnix) {
+        if(isMacOS) {
+            switch ($algname)
+            {
+                "md5" { $result = (md5 -q $file) }
+                "sha1" { $result = (shasum -ba 1 $file) }
+                "sha256" { $result = (shasum -ba 256 $file) }
+                "sha512" { $result = (shasum -ba 512 $file) }
+                default { $result = (shasum -ba 256 $file) }
+            }
+        } else {
+            switch ($algname)
+            {
+                "md5" { $result = (md5sum -b $file) }
+                "sha1" { $result = (sha1sum -b $file) }
+                "sha256" { $result = (sha256sum -b $file) }
+                "sha512" { $result = (sha512sum -b $file) }
+                default { $result = (sha256sum -b $file) }
+            }
         }
-        return $result.split(" ") | select -first 1
+        return $result.split(' ') | select -first 1
     }
     $alg = [system.security.cryptography.hashalgorithm]::create($algname)
     $fs = [system.io.file]::openread($file)

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -122,7 +122,7 @@ function use_any_https_protocol() {
 
 function set_https_protocols($protocols) {
     try {
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType] $available
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType] $protocols
     } catch {
         [System.Net.ServicePointManager]::SecurityProtocol = "Tls,Tls11,Tls12"
     }

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -49,7 +49,7 @@ function ensure_in_psmodulepath($dir, $global) {
     $path = env 'psmodulepath' $global
     $dir = fullpath $dir
     if($path -notmatch [regex]::escape($dir)) {
-        echo "Adding $(friendly_path $dir) to $(if($global){'global'}else{'your'}) PowerShell module path."
+        write-output "Adding $(friendly_path $dir) to $(if($global){'global'}else{'your'}) PowerShell module path."
 
         env 'psmodulepath' $global "$dir;$path" # for future sessions...
         $env:psmodulepath = "$dir;$env:psmodulepath" # for this session

--- a/lib/unix.ps1
+++ b/lib/unix.ps1
@@ -1,0 +1,43 @@
+# Note: This fill should only be included after core.ps1 and install.ps1
+#       It will overwrite some global variables and functions to make
+#       them unix compatible.
+
+if(!(is_unix)) {
+    return # get the hell outta here
+}
+
+# core.ps1
+$scoopdir = $env:SCOOP, (Join-Path $env:HOME "scoop") | select -first 1
+$globaldir = $env:SCOOP_GLOBAL, "/usr/local/scoop" | select -first 1
+$cachedir = $env:SCOOP_CACHE, (Join-Path $scoopdir "cache") | select -first 1
+$env:TEMP = "/tmp"
+
+# core.ps1
+function ensure($dir) {
+    mkdir -p $dir > $null
+    return resolve-path $dir
+}
+
+# install.ps1
+function compute_hash($file, $algname) {
+    if(is_mac) {
+        switch ($algname)
+        {
+            "md5" { $result = (md5 -q $file) }
+            "sha1" { $result = (shasum -ba 1 $file) }
+            "sha256" { $result = (shasum -ba 256 $file) }
+            "sha512" { $result = (shasum -ba 512 $file) }
+            default { $result = (shasum -ba 256 $file) }
+        }
+    } else {
+        switch ($algname)
+        {
+            "md5" { $result = (md5sum -b $file) }
+            "sha1" { $result = (sha1sum -b $file) }
+            "sha256" { $result = (sha256sum -b $file) }
+            "sha512" { $result = (sha512sum -b $file) }
+            default { $result = (sha256sum -b $file) }
+        }
+    }
+    return $result.split(' ') | select -first 1
+}

--- a/lib/unix.ps1
+++ b/lib/unix.ps1
@@ -1,6 +1,9 @@
-# Note: This fill should only be included after core.ps1 and install.ps1
-#       It will overwrite some global variables and functions to make
-#       them unix compatible.
+# Note: This file is for overwriting global variables and functions to make
+#       them unix compatible. It has to be imported after everything else!
+
+function is_unix() { $PSVersionTable.Platform -eq 'Unix' }
+function is_mac() { $PSVersionTable.OS.ToLower().StartsWith('darwin') }
+function is_linux() { $PSVersionTable.OS.ToLower().StartsWith('linux') }
 
 if(!(is_unix)) {
     return # get the hell outta here

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -13,7 +13,7 @@ function versions($app, $global) {
 }
 
 function version($ver) {
-    $ver.split('.-') | % {
+    $ver -split '[\.-]' | % {
         $num = $_ -as [int]
         if($num) { $num } else { $_ }
     }

--- a/test/00-Project.Tests.ps1
+++ b/test/00-Project.Tests.ps1
@@ -3,9 +3,9 @@ $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
 $repo_files = @( Get-ChildItem $repo_dir -file -recurse -force )
 
 $project_file_exclusions = @(
-    $([regex]::Escape($repo_dir)+'\\.git\\.*$'),
+    $([regex]::Escape($repo_dir)+'(\\|/).git(\\|/).*$'),
     '.sublime-workspace$',
-    'supporting\\validator\\packages\\*'
+    'supporting(\\|/)validator(\\|/)packages(\\|/)*'
 )
 
 describe 'Project code' {

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -3,6 +3,7 @@
 . "$psscriptroot\Scoop-TestLib.ps1"
 
 $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
+$isUnix = isUnix
 
 describe "is_directory" {
     beforeall {
@@ -29,7 +30,7 @@ describe "movedir" {
         $working_dir = setup_working "movedir"
     }
 
-    it "moves directories with no spaces in path" {
+    it "moves directories with no spaces in path" -skip:$isUnix {
         $dir = "$working_dir\user"
         movedir "$dir\_scoop_extract\$extract_dir" "$dir\$extract_to"
 
@@ -37,7 +38,7 @@ describe "movedir" {
         "$dir\_scoop_extract\$extract_dir" | should not exist
     }
 
-    it "moves directories with spaces in path" {
+    it "moves directories with spaces in path" -skip:$isUnix {
         $dir = "$working_dir\user with space"
         movedir "$dir\_scoop_extract\$extract_dir" "$dir\$extract_to"
 
@@ -50,7 +51,7 @@ describe "movedir" {
         "$dir\_scoop_extract" | should not exist
     }
 
-    it "moves directories with quotes in path" {
+    it "moves directories with quotes in path" -skip:$isUnix {
         $dir = "$working_dir\user with 'quote"
         movedir "$dir\_scoop_extract\$extract_dir" "$dir\$extract_to"
 
@@ -76,7 +77,7 @@ describe "unzip_old" {
         $zerobyte = "$working_dir\zerobyte.zip"
         $zerobyte | should exist
 
-        it "unzips file with zero bytes without error" {
+        it "unzips file with zero bytes without error" -skip:$isUnix {
             # some combination of pester, COM (used within unzip_old), and Win10 causes a bugged return value from test-unzip
             # `$to = test-unzip $zerobyte` * RETURN_VAL has a leading space and complains of $null usage when used in PoSH functions
             $to = ([string](test-unzip $zerobyte)).trimStart()
@@ -94,7 +95,7 @@ describe "unzip_old" {
         $small = "$working_dir\small.zip"
         $small | should exist
 
-        it "unzips file which is small in size" {
+        it "unzips file which is small in size" -skip:$isUnix {
             # some combination of pester, COM (used within unzip_old), and Win10 causes a bugged return value from test-unzip
             # `$to = test-unzip $small` * RETURN_VAL has a leading space and complains of $null usage when used in PoSH functions
             $to = ([string](test-unzip $small)).trimStart()
@@ -118,7 +119,7 @@ describe "shim" {
         $(ensure_in_path $shimdir) | out-null
     }
 
-    it "links a file onto the user's path" {
+    it "links a file onto the user's path" -skip:$isUnix {
         { get-command "shim-test" -ea stop } | should throw
         { get-command "shim-test.ps1" -ea stop } | should throw
         { get-command "shim-test.cmd" -ea stop } | should throw
@@ -132,7 +133,7 @@ describe "shim" {
     }
 
     context "user with quote" {
-        it "shims a file with quote in path" {
+        it "shims a file with quote in path" -skip:$isUnix {
             { get-command "shim-test" -ea stop } | should throw
             { shim-test } | should throw
 
@@ -154,7 +155,7 @@ describe "rm_shim" {
         $(ensure_in_path $shimdir) | out-null
     }
 
-    it "removes shim from path" {
+    it "removes shim from path" -skip:$isUnix {
         shim "$working_dir\shim-test.ps1" $false "shim-test"
 
         rm_shim "shim-test" $shimdir
@@ -175,7 +176,7 @@ describe "ensure_robocopy_in_path" {
     }
 
     context "robocopy is not in path" {
-        it "shims robocopy when not on path" {
+        it "shims robocopy when not on path" -skip:$isUnix {
             mock gcm { $false }
             gcm robocopy | should be $false
 
@@ -190,7 +191,7 @@ describe "ensure_robocopy_in_path" {
     }
 
     context "robocopy is in path" {
-        it "does not shim robocopy when it is in path" {
+        it "does not shim robocopy when it is in path" -skip:$isUnix {
             mock gcm { $true }
             ensure_robocopy_in_path
 

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -1,9 +1,10 @@
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\install.ps1"
+. "$psscriptroot\..\lib\unix.ps1"
 . "$psscriptroot\Scoop-TestLib.ps1"
 
 $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
-$isUnix = isUnix
+$isUnix = is_unix
 
 describe "is_directory" {
     beforeall {

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -3,6 +3,8 @@
 . "$psscriptroot\..\lib\install.ps1"
 . "$psscriptroot\Scoop-TestLib.ps1"
 
+$isUnix = isUnix
+
 describe "ensure_architecture" {
     it "should keep correct architectures" {
         ensure_architecture "32bit" | Should be "32bit"
@@ -51,7 +53,7 @@ describe "url_remote_filename" {
 }
 
 describe "is_in_dir" {
-    it "should work correctly" {
+    it "should work correctly" -skip:$isUnix {
         is_in_dir "C:\test" "C:\foo" | Should be $false
         is_in_dir "C:\test" "C:\test\foo\baz.zip" | Should be $true
 
@@ -71,7 +73,7 @@ describe "env add and remove path" {
     # store the original path to prevent leakage of tests
     $origPath = $env:PATH
 
-    it "should concat the correct path" {
+    it "should concat the correct path" -skip:$isUnix {
         mock add_first_in_path {}
         mock remove_from_path {}
 

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -1,9 +1,10 @@
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\install.ps1"
+. "$psscriptroot\..\lib\unix.ps1"
 . "$psscriptroot\Scoop-TestLib.ps1"
 
-$isUnix = isUnix
+$isUnix = is_unix
 
 describe "ensure_architecture" {
     it "should keep correct architectures" {

--- a/test/Scoop-Manifest.Tests.ps1
+++ b/test/Scoop-Manifest.Tests.ps1
@@ -5,7 +5,7 @@
 describe "manifest-validation" {
     beforeall {
         $working_dir = setup_working "manifest"
-        $schema = "$psscriptroot\..\schema.json"
+        $schema = "$psscriptroot/../schema.json"
         Add-Type -Path "$psscriptroot\..\supporting\validator\Newtonsoft.Json.dll"
         Add-Type -Path "$psscriptroot\..\supporting\validator\Newtonsoft.Json.Schema.dll"
         Add-Type -Path "$psscriptroot\..\supporting\validator\Scoop.Validator.dll"

--- a/test/Scoop-TestLib.ps1
+++ b/test/Scoop-TestLib.ps1
@@ -75,11 +75,11 @@ function setup_working($name) {
     # reset working dir
     $working_dir = "$env:temp\ScoopTestFixtures\$name"
     if(test-path $working_dir) {
-        rm -r -force $working_dir
+        Remove-Item -Recurse -Force $working_dir
     }
 
     # set up
-    cp $fixtures $working_dir -r
+    Copy-Item $fixtures -Destination $working_dir -Recurse
 
     return $working_dir
 }

--- a/test/Scoop-TestLib.ps1
+++ b/test/Scoop-TestLib.ps1
@@ -73,7 +73,7 @@ function setup_working($name) {
     }
 
     # reset working dir
-    $working_dir = "$env:temp\ScoopTestFixtures\$name"
+    $working_dir = "$env:TEMP\ScoopTestFixtures\$name"
     if(test-path $working_dir) {
         Remove-Item -Recurse -Force $working_dir
     }


### PR DESCRIPTION
These changes allow running maintenance jobs like `checkver.ps1` and `auto-pr.ps1` on Ubuntu or MacOS.
My main goals are to run these jobs on my Ubuntu server instead of using a Windows VM.

This includes:
- Fixing an error with Ssl3 which is no longer supported in Powershell 6
- Detecting `hub` correctly
- Setting up the correct paths for `$scoopdir`, `$globaldir` and `$cachedir`
- Using `sha256sum` on Linux and `shasum` on MacOS, because `system.security.cryptography.hashalgorithm::create` doesn't work
- Skipping some robocopy based tests
- Use write-output/remove-item/copy-item instead of aliases, because they run into problems with their build in counterparts
- Some path fixes for Unix

## TODO
**checkver**
- [x] downloads files
- [x] calculates correct hash sums
- [x] updates manifest correctly

**auto-pr**
- [x] detect `hub`
- [x] run `checkver`
- [ ] needs testing for creating pull requests
- [ ] needs testing for pushs to master branch