### PR TITLE
Improve feedback when Scoop is outdated and updated

### DIFF
--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -102,8 +102,4 @@ if(!$old -and !$removed -and !$failed -and !$missing_deps -and !$needs_update) {
     success "Everything is ok!"
 }
 
-if ($needs_update) {
-    warn "Cannot check for app updates while Scoop is out of date."
-}
-
 exit 0

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -98,8 +98,12 @@ if($missing_deps) {
     }
 }
 
-if(!$old -and !$removed -and !$failed -and !$missing_deps) {
+if(!$old -and !$removed -and !$failed -and !$missing_deps -and !$needs_update) {
     success "Everything is ok!"
+}
+
+if ($needs_update) {
+    warn "Cannot check for app updates while Scoop is out of date."
 }
 
 exit 0

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -89,6 +89,7 @@ function update_scoop() {
         popd
     }
     success 'Scoop was updated successfully!'
+    "Run 'scoop status' to check for updates to installed apps."
 }
 
 function update($app, $global, $quiet = $false, $independent, $suggested) {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -89,7 +89,6 @@ function update_scoop() {
         popd
     }
     success 'Scoop was updated successfully!'
-    "Run 'scoop status' to check for updates to installed apps."
 }
 
 function update($app, $global, $quiet = $false, $independent, $suggested) {


### PR DESCRIPTION
When there is an update to Scoop and `scoop status` is run, the output is
```
Scoop is out of date. Run 'scoop update' to get the latest changes.
Everything is ok!
```
This is not ideal, because "Everything is ok!" is what it says when it has checked for package updates and there are none - but in this case it apparently doesn't even check.

The next step if I want to do anything is `scoop update`:
```
Updating Scoop...
Scoop was updated successfully!
```
Now to find out if there are updates to the installed packages, as was the original intention, `scoop status` needs to be run a second time, but I might not think of that, because it said "Everything is ok" earlier.

This PR improves the feedback in two places:
- Don't say "Everything is ok!" when Scoop is out of date; instead warn with "Cannot check for app updates while Scoop is out of date."
- Additionally say "Run 'scoop status' to check for updates to installed apps." after updating Scoop as an additional reminder to the user.