### PR TITLE
modify the bucket manifest to allow persist

### DIFF
--- a/bucket/nvm.json
+++ b/bucket/nvm.json
@@ -8,24 +8,25 @@
         "elevate.vbs"
     ],
     "persist": [
-        "nodejs",
-        "settings.txt"
+        "settings.txt",
+        "elevate.cmd",
+        "elevate.vbs"
     ],
     "env_add_path": "nodejs",
     "env_set": {
-        "NVM_HOME": "$dir",
-        "NVM_SYMLINK": "$persist_dir\\nodejs"
+        "NVM_HOME": "$persist_dir",
+        "NVM_SYMLINK": "$dir\\nodejs"
     },
     "hash": "cbe1b6d71cc420f2d4428e4b7d41b8eb409232706385b2e97f2b749228e370bc",
     "architecture": {
         "64bit": {
             "pre_install": "if(!(test-path \"$dir\\settings.txt\")) {
-                write-output \"root: $persist_dir\\nodejs`r`narch: 64`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
+                write-output \"root: $persist_dir`r`narch: 64`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
             }"
         },
         "32bit": {
             "pre_install": "if(!(test-path \"$dir\\settings.txt\")) {
-                write-output \"root: $persist_dir\\nodejs`r`narch: 32`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
+                write-output \"root: $persist_dir`r`narch: 32`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
             }"
         }
     },

--- a/bucket/nvm.json
+++ b/bucket/nvm.json
@@ -3,30 +3,29 @@
     "version": "1.1.5",
     "url": "https://github.com/coreybutler/nvm-windows/releases/download/1.1.5/nvm-noinstall.zip",
     "bin": [
-        "nvm.exe",
-        "elevate.cmd",
-        "elevate.vbs"
+        "nvm.exe"
     ],
     "persist": [
-        "settings.txt",
-        "elevate.cmd",
-        "elevate.vbs"
+       "nodejs",
+        ["elevate.cmd", "nodejs\\elevate.cmd"],
+        ["elevate.vbs", "nodejs\\elevate.vbs"],
+        "settings.txt"
     ],
-    "env_add_path": "nodejs",
+    "env_add_path": "nodejs\\nodejs",
     "env_set": {
-        "NVM_HOME": "$persist_dir",
-        "NVM_SYMLINK": "$dir\\nodejs"
+        "NVM_HOME": "$dir",
+        "NVM_SYMLINK": "$persist_dir\\nodejs\\nodejs"
     },
     "hash": "cbe1b6d71cc420f2d4428e4b7d41b8eb409232706385b2e97f2b749228e370bc",
     "architecture": {
         "64bit": {
             "pre_install": "if(!(test-path \"$dir\\settings.txt\")) {
-                write-output \"root: $persist_dir`r`narch: 64`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
+                write-output \"root: $persist_dir\\nodejs`r`narch: 64`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
             }"
         },
         "32bit": {
             "pre_install": "if(!(test-path \"$dir\\settings.txt\")) {
-                write-output \"root: $persist_dir`r`narch: 32`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
+                write-output \"root: $persist_dir\\nodejs`r`narch: 32`r`nproxy: none\" | Out-File -encoding \"ASCII\" $dir\\settings.txt
             }"
         }
     },


### PR DESCRIPTION
#1546 

I've tested with this update manifest. 
1. The downloaded node versions will be persisted properly. 
2. The nvm created symlink lives in apps folder and is not persisted. 
3. This symlink seems to prevent scoop uninstall to delete the nvm folder in apps. It'll always say that the folder is in use. But after manually remove the symlink, uninstall will work fine.
4. I tried to put the symlink in the persist folder, but I am not sure how to properly add that symlink to path. ```"env_add_path": "$persist_dir\\nodejs"``` doesn't seem to work.

Please advise if more change is needed.