### PR TITLE
Remove extract_dir from git-lfs

### DIFF
--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -5,13 +5,11 @@
     "architecture": {
         "32bit": {
             "url": "https://github.com/github/git-lfs/releases/download/v2.2.0/git-lfs-windows-386-2.2.0.zip",
-            "hash": "2f486f7552ce11662646fdb799a0b52770a669d690984e15fc7c17ceacb722f0",
-            "extract_dir": "git-lfs-windows-386-2.2.0"
+            "hash": "2f486f7552ce11662646fdb799a0b52770a669d690984e15fc7c17ceacb722f0"
         },
         "64bit": {
             "url": "https://github.com/github/git-lfs/releases/download/v2.2.0/git-lfs-windows-amd64-2.2.0.zip",
-            "hash": "e548660fa7546b133b63c08910a1b8c223df042a1b616b331e226f0542a7b4aa",
-            "extract_dir": "git-lfs-windows-amd64-2.2.0"
+            "hash": "e548660fa7546b133b63c08910a1b8c223df042a1b616b331e226f0542a7b4aa"
         }
     },
     "depends": "git",
@@ -22,12 +20,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-386-$version.zip",
-                "extract_dir": "git-lfs-windows-386-$version"
+                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-386-$version.zip"
             },
             "64bit": {
-                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-amd64-$version.zip",
-                "extract_dir": "git-lfs-windows-amd64-$version"
+                "url": "https://github.com/github/git-lfs/releases/download/v$version/git-lfs-windows-amd64-$version.zip"
             }
         }
     }


### PR DESCRIPTION
extract_dir was added 4 months ago in https://github.com/lukesampson/scoop/commit/48441508dd81412a35a88a32119b90ea29809fb0