### PR TITLE
Make scoop home agnostic

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -102,7 +102,7 @@ function fullpath($path) { # should be ~ rooted
 }
 function relpath($path) { "$($myinvocation.psscriptroot)\$path" } # relative to calling script
 function friendly_path($path) {
-    $h = "$home"; if(!$h.endswith('\')) { $h += '\' }
+    $h = (Get-PsProvider 'FileSystem').home; if(!$h.endswith('\')) { $h += '\' }
     if($h -eq '\') { return $path }
     return "$path" -replace ([regex]::escape($h)), "~\"
 }


### PR DESCRIPTION
Rather use (Get-PsProvider 'FileSystem').home, in case the user
~ is not pointing to $home.
This can happen if the user wants to keep $home on $Env:USERPROFILE
but is working in a different folder and want it to be ~ (for simplicity).

I'm actually in this case:
* I'm working daily in C:\nicolas
* $home is in C:\USers\nicolas (with all dot files, ssh...)

And when I'm in powershell, I like that `cd ~` change to C:\nicolas