### PR TITLE
Update gcc version from version 6.3 to 7.1, gradle from 4.0 to 4.0.1

### DIFF
--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -4,13 +4,13 @@
     "license": "GPL3",
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/6.3.0/threads-posix/seh/x86_64-6.3.0-release-posix-seh-rt_v5-rev1.7z",
-            "hash": "2d0e72340ffa14916d4469db25c37889e477f8f1f49ba4f77155830ddc1dca89",
+            "url": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.1.0/threads-posix/seh/x86_64-7.1.0-release-posix-seh-rt_v5-rev0.7z",
+            "hash": "5391e8e733dcdab71e6ac71d6524e841be5ea980dc14f22a23af64e92af5dcd7",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.3.0/threads-posix/dwarf/i686-6.3.0-release-posix-dwarf-rt_v5-rev1.7z",
-            "hash": "8f7381e8ed61c438d36d33ae2f514a7ca8065c44dcf6801847fd425f71a9ee1d",
+            "url": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/7.1.0/threads-posix/dwarf/i686-7.1.0-release-posix-dwarf-rt_v5-rev0.7z",
+            "hash": "f92d3deea0816692398c41e925380083f717888c200ee2e5900652b80cae520c",
             "extract_dir": "mingw32"
         }
     },

--- a/bucket/gradle.json
+++ b/bucket/gradle.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://gradle.org",
-    "version": "4.0",
+    "version": "4.0.1",
     "license": "Apache 2.0",
-    "hash": "56bd2dde29ba2a93903c557da1745cafd72cdd8b6b0b83c05a40ed7896b79dfe",
-    "url": "https://services.gradle.org/distributions/gradle-4.0-bin.zip",
-    "extract_dir": "gradle-4.0",
+    "hash": "d717e46200d1359893f891dab047fdab98784143ac76861b53c50dbd03b44fd4",
+    "url": "https://services.gradle.org/distributions/gradle-4.0.1-bin.zip",
+    "extract_dir": "gradle-4.0.1",
     "bin": "bin\\gradle.bat",
     "suggest": {
         "JDK": [


### PR DESCRIPTION
The gcc in main bucket is quite old, I update it. I always use latest gradle and that in main bucket is a little old.