### PR TITLE
Add .NET SDK

### DIFF
--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.4",
+    "homepage": "https://www.microsoft.com/net/core#windows",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip",
+            "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"
+        },
+        "32bit": {
+            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip",
+            "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"
+        }
+    },
+    "bin": "dotnet.exe"
+}

--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -1,14 +1,14 @@
 {
-    "version": "1.0.4",
+    "version": "2.0.0",
     "homepage": "https://www.microsoft.com/net/core#windows",
     "architecture": {
         "64bit": {
-            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x64.1.0.4.zip",
-            "hash": "82869baef9e010415583174b0b0be95a2cb326dfd36bb32ec270803a9c8196ec"
+            "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x64.zip",
+            "hash": "541d4dd17023aff14a0aeb6505b200ccabffffc34ab2f629caeb994cedf8afd9"
         },
         "32bit": {
-            "url": "https://download.microsoft.com/download/E/7/8/E782433E-7737-4E6C-BFBF-290A0A81C3D7/dotnet-dev-win-x86.1.0.4.zip",
-            "hash": "648f74ec818f5969035afec3cd4c2a0d9579539710dd4ccdfec806727cf0f8a4"
+            "url": "https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-win-x86.zip",
+            "hash": "5eaa475a12843cfff9a97f4b7d3b205eb169fd372ddfc9ddde92225e9e4c1c7c"
         }
     },
     "bin": "dotnet.exe"

--- a/bucket/dotnet.json
+++ b/bucket/dotnet.json
@@ -11,5 +11,8 @@
             "hash": "3a8d7316dd774d54e27a332c5d1e73d7813fecd10b670249f480ae917226e444"
         }
     },
-    "bin": "dotnet.exe"
+    "bin": "dotnet.exe",
+    "notes": [
+        "This app is deprecated. Install `dotnet-sdk` instead."
+    ]
 }


### PR DESCRIPTION
The version number in the file name I mentioned in [#1396](https://github.com/lukesampson/scoop/pull/1396#issue-216351620) isn't correct anymore, they changed it from 1.1.1 to 1.0.1 at some point. So we can't update the old manifest to 1.0.4, because that would be lower than the old version.

I'm not sure about the deprecation note, I think we should rather remove the `dotnet` manifest for now. What do you think?