### PR TITLE
Add bucket and arch to list/export output

### DIFF
--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -8,6 +8,7 @@
 . "$psscriptroot\..\lib\buckets.ps1"
 
 reset_aliases
+$def_arch = default_architecture
 
 $local = installed_apps $false | % { @{ name = $_; global = $false } }
 $global = installed_apps $true | % { @{ name = $_; global = $true } }
@@ -23,7 +24,20 @@ if($apps) {
         $app = $_.name
         $global = $_.global
         $ver = current_version $app $global
-        $global_display = $null; if($global) { $global_display = '*global*'}
+        $global_display = $null; if($global) { $global_display = ' *global*'}
+
+        $install_info = install_info $app $ver $global
+        $bucket = ''
+        if ($install_info.bucket) {
+            $bucket = ' [' + $install_info.bucket + ']'
+        } elseif ($install_info.url) {
+            $bucket = ' [' + $install_info.url + ']'
+        }
+        if ($install_info.architecture -and $def_arch -ne $install_info.architecture) {
+            $arch = ' {' + $install_info.architecture + '}'
+        } else {
+            $arch = ''
+        }
 
         # json
         # $val = "{ 'name': '$app', 'version': '$ver', 'global': $($global.toString().tolower()) }"
@@ -34,7 +48,7 @@ if($apps) {
         # }
 
         # "$app (v:$ver) global:$($global.toString().tolower())"
-        "$app (v:$ver) $global_display"
+        "$app (v:$ver)$global_display$bucket$arch"
 
         $count++
     }

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -17,8 +17,7 @@ $global = installed_apps $true | % { @{ name = $_; global = $true } }
 $apps = @($local) + @($global)
 
 if($apps) {
-    echo "Installed apps$(if($query) { `" matching '$query'`"}):
-"
+    write-host "Installed apps$(if($query) { `" matching '$query'`"}): `n"
     $apps | sort { $_.name } | ? { !$query -or ($_.name -match $query) } | % {
         $app = $_.name
         $global = $_.global
@@ -37,11 +36,11 @@ if($apps) {
         } else {
             $arch = ''
         }
-        "  $app ($ver)$global_display$bucket$arch"
+        write-host "  $app ($ver)$global_display$bucket$arch"
     }
-    ""
+    write-host ''
     exit 0
 } else {
-    "There aren't any apps installed."
+    write-host "There aren't any apps installed."
     exit 1
 }

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -22,21 +22,22 @@ if($apps) {
         $app = $_.name
         $global = $_.global
         $ver = current_version $app $global
-        $global_display = $null; if($global) { $global_display = ' *global*'}
 
         $install_info = install_info $app $ver $global
-        $bucket = ''
+        write-host "  $app " -NoNewline
+        write-host -f DarkCyan $ver -NoNewline
+        if($global) {
+            write-host -f DarkRed ' *global*' -NoNewline
+        }
         if ($install_info.bucket) {
-            $bucket = ' [' + $install_info.bucket + ']'
+            write-host -f Yellow " [$($install_info.bucket)]" -NoNewline
         } elseif ($install_info.url) {
-            $bucket = ' [' + $install_info.url + ']'
+            write-host -f Yellow " [$($install_info.url)]" -NoNewline
         }
         if ($install_info.architecture -and $def_arch -ne $install_info.architecture) {
-            $arch = ' {' + $install_info.architecture + '}'
-        } else {
-            $arch = ''
+            write-host -f DarkRed " {$($install_info.architecture)}" -NoNewline
         }
-        write-host "  $app ($ver)$global_display$bucket$arch"
+        write-host ''
     }
     write-host ''
     exit 0

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -9,6 +9,7 @@ param($query)
 . "$psscriptroot\..\lib\buckets.ps1"
 
 reset_aliases
+$def_arch = default_architecture
 
 $local = installed_apps $false | % { @{ name = $_ } }
 $global = installed_apps $true | % { @{ name = $_; global = $true } }
@@ -22,9 +23,21 @@ if($apps) {
         $app = $_.name
         $global = $_.global
         $ver = current_version $app $global
-        $global_display = $null; if($global) { $global_display = '*global*'}
+        $global_display = $null; if($global) { $global_display = ' *global*'}
 
-        "  $app ($ver) $global_display"
+        $install_info = install_info $app $ver $global
+        $bucket = ''
+        if ($install_info.bucket) {
+            $bucket = ' [' + $install_info.bucket + ']'
+        } elseif ($install_info.url) {
+            $bucket = ' [' + $install_info.url + ']'
+        }
+        if ($install_info.architecture -and $def_arch -ne $install_info.architecture) {
+            $arch = ' {' + $install_info.architecture + '}'
+        } else {
+            $arch = ''
+        }
+        "  $app ($ver)$global_display$bucket$arch"
     }
     ""
     exit 0


### PR DESCRIPTION
Transforms `scoop list` from:
````
  netcat (1.12)
  notepadplusplus (7.4.2)
  openssl10x (1.0.2L)
  pciutils (3.5.5)
````
to:
````
  netcat (1.12)
  notepadplusplus (7.4.2) [extras] {32bit}
  openssl10x (1.0.2L) [versions]
  pciutils (3.5.5) {32bit}
````
I originally changed it to
````
  netcat (1.12)
  extras/notepadplusplus (7.4.2) {32bit}
  versions/openssl10x (1.0.2L)
  pciutils (3.5.5) {32bit}
````
but it didn't feel alphabetical any more.
