### PR TITLE
fix #1628 (scoop update --ignore-cache option broken)

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -9,10 +9,9 @@ function nightly_version($date, $quiet = $false) {
     "nightly-$date_str"
 }
 
-function install_app($app, $architecture, $global, $suggested) {
+function install_app($app, $architecture, $global, $suggested, $use_cache = $true) {
     $app, $bucket = app $app
     $app, $manifest, $bucket, $url = locate $app $bucket
-    $use_cache = $true
     $check_hash = $true
 
     if(!$manifest) {

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -14,6 +14,7 @@
 # Options:
 #   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 #   -i, --independent         Don't install dependencies automatically
+#   -k, --no-cache            Don't use the download cache
 #   -g, --global              Install the app globally
 
 . "$psscriptroot\..\lib\core.ps1"
@@ -44,11 +45,12 @@ function ensure_not_installed($app, $global) {
     }
 }
 
-$opt, $apps, $err = getopt $args 'gia:' 'global', 'independent', 'arch='
+$opt, $apps, $err = getopt $args 'gika:' 'global', 'independent', 'no-cache', 'arch='
 if($err) { "scoop install: $err"; exit 1 }
 
 $global = $opt.g -or $opt.global
 $independent = $opt.i -or $opt.independent
+$use_cache = !($opt.k -or $opt.'no-cache')
 $architecture = ensure_architecture ($opt.a + $opt.arch)
 
 if(!$apps) { 'ERROR: <app> missing'; my_usage; exit 1 }
@@ -102,7 +104,7 @@ $apps, $skip = prune_installed $apps $global
 $skip | ? { $explicit_apps -contains $_} | % { warn "$_ is already installed. Skipping." }
 
 $suggested = @{};
-$apps | % { install_app $_ $architecture $global $suggested }
+$apps | % { install_app $_ $architecture $global $suggested $use_cache }
 
 show_suggestions $suggested
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -93,7 +93,7 @@ function update_scoop() {
     success 'Scoop was updated successfully!'
 }
 
-function update($app, $global, $quiet = $false, $independent, $suggested) {
+function update($app, $global, $quiet = $false, $independent, $suggested, $use_cache = $true) {
     $old_version = current_version $app $global
     $old_manifest = installed_manifest $app $old_version $global
     $install = install_info $app $old_version $global
@@ -107,7 +107,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested) {
     if(!$independent) {
         # check dependencies
         $deps = @(deps $app $architecture) | ? { !(installed $_) }
-        $deps | % { install_app $_ $architecture $global $suggested }
+        $deps | % { install_app $_ $architecture $global $suggested $use_cache }
     }
 
     $version = latest_version $app $bucket $url
@@ -197,7 +197,7 @@ if(!$apps) {
 
     $suggested = @{};
     # # $outdated is a list of ($app, $global) tuples
-    $outdated | % { update @_ $quiet $independent $suggested }
+    $outdated | % { update @_ $quiet $independent $suggested $use_cache }
 }
 
 exit 0

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -132,7 +132,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested) {
     $manifest = manifest $app $bucket $url
 
     write-host "Updating '$app' ($old_version -> $version)"
-update
+
     $dir = versiondir $app $old_version $global
 
     write-host "Uninstalling '$app' ($old_version)"

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -147,7 +147,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested) {
 
     # note: keep the old dir in case it contains user files
 
-    install_app $app $architecture $global $suggested
+    install_app $app $architecture $global $suggested $use_cache
 <#
     "Installing '$app' ($version)"
     $dir = ensure (versiondir $app $version $global)


### PR DESCRIPTION
This adds the $use_cache parameter to the install function. Hopefully that is an acceptable change.