### PR TITLE
Add reverse property to checkver

### DIFF
--- a/bucket/x264-10bit.json
+++ b/bucket/x264-10bit.json
@@ -1,23 +1,32 @@
 {
-    "architecture": {
-        "32bit": {
-            "hash": "5f3b00b570f386d53d4b8595de2691c26bb0100c0f84b5629e72576185578b6a",
-            "url": "https://download.videolan.org/pub/x264/binaries/win32/x264-10b-r2833-df79067.exe"
-        },
-        "64bit": {
-            "hash": "f84e50446971f449fa9e67d5bf73a7c23b68e53d957586e3a369ef21a043889e",
-            "url": "https://download.videolan.org/pub/x264/binaries/win64/x264-10b-r2833-df79067.exe"
-        }
-    },
-    "bin": [
-        [
-            "x264-10b-r2833-df79067.exe",
-            "x264-10b"
-        ]
-    ],
     "description": "H.264/MPEG-4 AVC video encoder (10 bit)",
     "homepage": "https://www.videolan.org/developers/x264.html",
     "license": "GPL-2.0",
-    "notes": "Version 0.150.2833 (df79067) was released on 2017-05-30",
-    "version": "17.05.30"
+    "version": "2851",
+    "architecture": {
+        "64bit": {
+            "hash": "6dab3cfd5d5685206160f5a31b951ce6a9712d7694f7c0cefd8c3e8ad9c24f00",
+            "url": "https://download.videolan.org/pub/x264/binaries/win64/x264-10b-r2851-ba24899.exe#/x264-10b.exe"
+        },
+        "32bit": {
+            "hash": "7c233457a6f23a475877c4ff0061f3f52bf02e8f19b1ba92c73dd37df5b37d68",
+            "url": "https://download.videolan.org/pub/x264/binaries/win32/x264-10b-r2851-ba24899.exe#/x264-10b.exe"
+        }
+    },
+    "bin": "x264-10b.exe",
+    "checkver": {
+        "url": "https://download.videolan.org/pub/videolan/x264/binaries/win64/",
+        "re": "x264-10b-r(?<version>[\\d]+)-(?<commit>[a-fA-F0-9]{7}).exe",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.videolan.org/pub/x264/binaries/win64/x264-10b-r$version-$matchCommit.exe#/x264-10b.exe"
+            },
+            "32bit": {
+                "url": "https://download.videolan.org/pub/x264/binaries/win32/x264-10b-r$version-$matchCommit.exe#/x264-10b.exe"
+            }
+        }
+    }
 }

--- a/bucket/x264.json
+++ b/bucket/x264.json
@@ -1,27 +1,38 @@
 {
-    "architecture": {
-        "32bit": {
-            "hash": "3849129365adf956f47a35eef2ba5615a9d00040362397f94e13e69da0407fc0",
-            "url": "https://download.videolan.org/pub/x264/binaries/win32/x264-r2833-df79067.exe"
-        },
-        "64bit": {
-            "hash": "2834b1bf50fffffb0d9b7cc03db9a95b7f51e288338494a1311de1e7bfb3f3c4",
-            "url": "https://download.videolan.org/pub/x264/binaries/win64/x264-r2833-df79067.exe"
-        }
-    },
-    "bin": [
-        [
-            "x264-r2833-df79067.exe",
-            "x264-8b"
-        ],
-        [
-            "x264-r2833-df79067.exe",
-            "x264"
-        ]
-    ],
     "description": "H.264/MPEG-4 AVC video encoder (8 bit)",
     "homepage": "https://www.videolan.org/developers/x264.html",
     "license": "GPL-2.0",
-    "notes": "Version 0.150.2833 (df79067) was released on 2017-05-30",
-    "version": "17.05.30"
+    "version": "2851",
+    "architecture": {
+        "64bit": {
+            "hash": "92844f1b9694fb55bfaaf5bd06e89a0b9bec1f1c4a904fc18b9f6b17b6cbdedc",
+            "url": "https://download.videolan.org/pub/x264/binaries/win64/x264-r2851-ba24899.exe#/x264.exe"
+        },
+        "32bit": {
+            "hash": "ca0b4bb694cc63c08ee7cd56a96b94bdc5551ecce2f1d113bd6a41da1a4c4e15",
+            "url": "https://download.videolan.org/pub/x264/binaries/win32/x264-r2851-ba24899.exe#/x264.exe"
+        }
+    },
+    "bin": [
+        "x264.exe",
+        [
+            "x264.exe",
+            "x264-8b"
+        ]
+    ],
+    "checkver": {
+        "url": "https://download.videolan.org/pub/videolan/x264/binaries/win64/",
+        "re": "x264-r(?<version>[\\d]+)-(?<commit>[a-fA-F0-9]{7}).exe",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.videolan.org/pub/x264/binaries/win64/x264-r$version-$matchCommit.exe#/x264.exe"
+            },
+            "32bit": {
+                "url": "https://download.videolan.org/pub/x264/binaries/win32/x264-r$version-$matchCommit.exe#/x264.exe"
+            }
+        }
+    }
 }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -195,9 +195,10 @@ function get_version_substitutions([String] $version, [Hashtable] $matches) {
         '$preReleaseVersion' = $lastPart;
     }
     if($matches) {
-        $matches.Remove(0)
         $matches.GetEnumerator() | % {
-            $versionVariables.Add('$match' + (Get-Culture).TextInfo.ToTitleCase($_.Name), $_.Value)
+            if($_.Name -ne "0") {
+                $versionVariables.Add('$match' + (Get-Culture).TextInfo.ToTitleCase($_.Name), $_.Value)
+            }
         }
     }
     return $versionVariables

--- a/schema.json
+++ b/schema.json
@@ -201,6 +201,10 @@
                         "jp": {
                             "pattern": "^\\$\\..*$",
                             "type": "string"
+                        },
+                        "reverse": {
+                            "description": "Reverse the order of regex matches",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
Add a reverse property to checkver.
If set to true, the regex matches get reversed.
This helps to find new versions in directory listings. (see x264)

Like: https://download.videolan.org/pub/x264/binaries/win64/

I know there are other programs with the same problem, but I can't remember them right now :grin:

**Needs testing on Unix!**