### PR TITLE
Add glslangValidator version Overload400-PrecQual.1817.

### DIFF
--- a/bucket/glslang.json
+++ b/bucket/glslang.json
@@ -1,0 +1,7 @@
+{
+    "homepage": "https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/",
+    "version": "Overload400-PrecQual.1817",
+    "url": "https://cvs.khronos.org/svn/repos/ogl/trunk/ecosystem/public/sdk/tools/glslang/Install/Windows/glslangValidator.exe",
+    "hash": "6d7c6b88472aaa904f07367dbb54fdcb89d4c95e4d22ec8a9a8069aa138c0077",
+    "bin": "glslangValidator.exe"
+}


### PR DESCRIPTION
This pull request adds the glslang shader validation tool. Glslang is the official reference compiler front end for the OpenGL ES and OpenGL shading languages. It's a standalone executable, and it is often used by editor plugins to validate shader code.