### PR TITLE
Update artifact bucket to use gnu abi and new version format.

### DIFF
--- a/bucket/artifact.json
+++ b/bucket/artifact.json
@@ -1,26 +1,26 @@
 {
-    "version": "0.9.0",
+    "version": "0.9.1",
     "homepage": "https://github.com/vitiral/artifact",
     "license": "LGPL",
     "bin": "art.exe",
     "checkver": "github",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vitiral/artifact/releases/download/v0.9.0/artifact-app-v0.9.0-x86_64-pc-windows-msvc.zip",
-            "hash": "943da3c632af2b1ab2fa78a45c546406ca4ea67e4cca3981fe228c30e8df56e8"
+            "url":  "https://github.com/vitiral/artifact/releases/download/0.9.1/artifact-app-0.9.1-x86_64-pc-windows-gnu.zip",
+            "hash": "2aff30bc89003e60c1998f6a4036928bab955c5e4ad47440282d8e10e215d738"
         },
         "32bit": {
-            "url": "https://github.com/vitiral/artifact/releases/download/v0.9.0/artifact-app-v0.9.0-i686-pc-windows-msvc.zip",
-            "hash": "4824e19cd48d83de0ff3896ef267074a28ae3fc8112194038de77e6e026420e2"
+            "url":  "https://github.com/vitiral/artifact/releases/download/0.9.1/artifact-app-0.9.1-i686-pc-windows-gnu.zip",
+            "hash": "c7af614e6787ad14f4a7a860dd855f24ab9a46219a98468101023e7d6af61900"
         }
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vitiral/artifact/releases/download/$version/artifact-app-$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/vitiral/artifact/releases/download/$version/artifact-app-$version-x86_64-pc-windows-gnu.zip"
             },
             "32bit": {
-                "url": "https://github.com/vitiral/artifact/releases/download/$version/artifact-app-$version-i686-pc-windows-msvc.zip"
+                "url": "https://github.com/vitiral/artifact/releases/download/$version/artifact-app-$version-i686-pc-windows-gnu.zip"
             }
         }
     }


### PR DESCRIPTION
For the artifact bucket, the windows ABI builds failed on appveyor so the releases didn't get posted to github but the gnu ABI builds consistently built correctly. It makes more sense to use these builds now in the bucket since they build more reliably.