### PR TITLE
Suggest Git instead of depending on it

### DIFF
--- a/bucket/git-lfs.json
+++ b/bucket/git-lfs.json
@@ -14,7 +14,12 @@
             "extract_dir": "git-lfs-windows-amd64-2.2.1"
         }
     },
-    "depends": "git",
+    "suggest": {
+        "Git": [
+            "git",
+            "git-with-openssh"
+        ]
+    },
     "bin": "git-lfs.exe",
     "checkver": {
         "github": "https://github.com/git-lfs/git-lfs"


### PR DESCRIPTION
That way, people using `git-with-openssh` won't end up with two versions of Git installed.