### PR TITLE
Cygwin manifest fixes

### DIFF
--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -1,5 +1,5 @@
 {
-    "version": ".",
+    "version": "2.8.2",
     "homepage": "https://cygwin.com/",
     "architecture": {
         "64bit": {
@@ -29,18 +29,19 @@
         ]
     ],
     "checkver": {
-        "re": "The most recent version of the Cygwin DLL is[^>]*([\\d\\.]+)"
+        "re": "The most recent version of the Cygwin DLL is[^>]*>([\\d\\.]+)<"
     },
     "installer": {
         "args": [
             "--no-admin",
             "--no-desktop",
             "--local-package-dir $dir\\packages",
-            "--packages default",
+            "--packages default,lynx,wget",
             "--quiet-mode",
             "--root $dir\\root",
             "--site http://mirrors.kernel.org/sourceware/cygwin/"
-        ]
+        ],
+        "keep": "true"
     },
     "notes": "To start a Cygwin shell, type \"cygwin\"",
     "persist": [


### PR DESCRIPTION
This pull request addresses some issues with cygwin manifest:

* The autoupdate regex was incorrect, which caused the version to be updated to '.' instead of the latest version. 
* The installer isn't kept after installation, so a user couldn't run the installer to download packages without downloading the installer manually.
* Lynx and wget are not installed by default, so [apt-cyg](https://github.com/transcode-open/apt-cyg) installation instructions wouldn't work. This means you would have to download the installer, re-run it, then install lynx and wget before you could use apt-cyg.

I corrected the regex, added the proper latest version of cygwin to the version tag, and told the manifest to keep the installer after installation as well as install lynx and wget along with the default packages.
