### PR TITLE
Add script to un/installer property

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -523,6 +523,11 @@ function run_installer($fname, $manifest, $architecture, $dir, $global) {
     # MSI or other installer
     $msi = msi $manifest $architecture
     $installer = installer $manifest $architecture
+    if($installer.script) {
+        write-output "Running installer script..."
+        iex $installer.script
+        return
+    }
 
     if($msi) {
         install_msi $fname $dir $msi
@@ -608,6 +613,11 @@ function install_prog($fname, $dir, $installer, $global) {
 function run_uninstaller($manifest, $architecture, $dir) {
     $msi = msi $manifest $architecture
     $uninstaller = uninstaller $manifest $architecture
+    if($uninstaller.script) {
+        write-output "Running uninstaller script..."
+        iex $uninstaller.script
+        return
+    }
 
     if($msi -or $uninstaller) {
         $exe = $null; $arg = $null; $continue_exit_codes = @{}

--- a/schema.json
+++ b/schema.json
@@ -220,6 +220,9 @@
                 "file": {
                     "type": "string"
                 },
+                "script": {
+                    "type": "string"
+                },
                 "keep": {
                     "type": "string"
                 }
@@ -260,6 +263,9 @@
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
                 "file": {
+                    "type": "string"
+                },
+                "script": {
                     "type": "string"
                 }
             },


### PR DESCRIPTION
Allow custom un/installer scripts without creating/downloading *.ps1 files (could also be used to clean-up `post_install` and `pre_install` scripts)

This idea came to me because of @matthewjberger's recent pull requests (https://github.com/lukesampson/scoop-extras/pull/501, https://github.com/lukesampson/scoop-extras/pull/503), where he creates un/installers with `pre_install`.