### PR TITLE
Add gource version 0.42.

### DIFF
--- a/bucket/gource.json
+++ b/bucket/gource.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.42",
+    "license": "GPL",
+    "url": "https://github.com/acaudwell/Gource/releases/download/gource-0.42/gource-0.42.win32.zip",
+    "homepage": "http://gource.io",
+    "checkver": {
+        "re": "([\\d\\.]+).win32.zip"
+    },
+    "autoupdate": {
+        "url": "https://github.com/acaudwell/Gource/releases/download/gource-$version/gource-$version.win32.zip"
+    },
+    "hash": "865e43418ae826ff69eea97246e95ec7c2b005ba070b1a7f5834ceb5fc0c6093",
+    "bin": "gource.exe"
+}


### PR DESCRIPTION
Adds [gource](http://gource.io/), which is a tool for visualizing a source-controlled project's history