### PR TITLE
Haskell 32bit (blocked)

### DIFF
--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -34,6 +34,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://haskell.org/platform/download/$version/HaskellPlatform-$version-core-x86_64-setup.exe"
+            },
+            "32bit": {
+                "url": "https://haskell.org/platform/download/$version/HaskellPlatform-$version-core-i386-setup.exe"
             }
         }
     }


### PR DESCRIPTION
Currently there are no 32bit builds for haskell
This PR is here to be ready to readd 32bit support as soon they support it again

Note from the [download page](https://www.haskell.org/platform/windows.html)
> The 8.2.1 platform release is for 64 bit Windows only, due to issues with GHC 8.2.1 on 32 bit Windows. Future releases are anticipated to resume 32 bit support.