### PR TITLE
Fix miniconda3 manifest.

### DIFF
--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -6,11 +6,18 @@
         "url": "https://repo.continuum.io/miniconda",
         "re": "Miniconda3-([\\d.]+)-Windows"
     },
+    "bin": [
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
     "installer": {
         "file": "miniconda3-installer.exe",
         "args": [
              "/S",
              "/InstallationType=JustMe",
+             "/RegisterPython=1",
              "/AddToPath=0",
              "/D=$dir"
         ]


### PR DESCRIPTION
When creating the manifest for miniconda3 I forgot to add the installer option that allows external tools to recognize anaconda as the system's python distribution and I also forgot to add the `bin` tag to link the python executable for anaconda. 

This pull request addresses those issues.