### PR TITLE
Simplify rustup installer.

### DIFF
--- a/bucket/rustup.json
+++ b/bucket/rustup.json
@@ -13,57 +13,19 @@
         ".cargo",
         ".rustup"
     ],
-    "post_install": "
-        # Copy the installed cargo directory to the rustup persistent data directory
-        $cargoFolder = \"$env:USERPROFILE\\.cargo\"
-        $cargoFolderDestination = \"$persist_dir\\.cargo\"
-        if(Test-Path $cargoFolder)
-        {
-            if(Test-Path $cargoFolderDestination)
-            {
-                Write-Host -F yellow \"Removing existing .cargo folder from scoop's persistent rustup data directory.\"
-                [System.IO.Directory]::Delete($cargoFolderDestination,$true)
-            }
-            Write-Host -F yellow \"Moving '$cargoFolder' to '$persist_dir'\"
-            Move-Item -Force \"$cargoFolder\" \"$persist_dir\"
-        }
-
-        # Copy the installed rustup directory to the rustup persistent data directory
-        $rustupFolder = \"$env:USERPROFILE\\.rustup\"
-        $rustupFolderDestination = \"$persist_dir\\.rustup\"
-        $multirustShortcut = \"$env:USERPROFILE\\.multirust\"
-        if(Test-Path $rustupFolder)
-        {
-            if(Test-Path $rustupFolderDestination)
-            {
-                Write-Host -F yellow \"Removing existing .rustup folder from scoop's persistent rustup data directory.\"
-                [System.IO.Directory]::Delete($rustupFolderDestination,$true)
-
-            }
-            Write-Host -F yellow \"Moving '$rustupFolder' to '$persist_dir'\"
-            Move-Item -Force \"$rustupFolder\" \"$persist_dir\"
-            if(Test-Path $multirustShortcut)
-            {
-                Write-Host -F yellow \"Removing old multirust junction.\"
-                [System.IO.Directory]::Delete($multirustShortcut,$true)
-            }
-        }
-    ",
     "env_add_path": ".cargo\\bin",
     "env_set": {
         "CARGO_HOME": "$persist_dir\\.cargo",
         "RUSTUP_HOME": "$persist_dir\\.rustup"
     },
-    "notes": "You'll need to restart powershell/cmd to have it reload the environment variables so rustup will work correctly",
     "installer": {
         "script": "
+            # Create environment variables for this process
+            [Environment]::SetEnvironmentVariable('CARGO_HOME', \"$persist_dir\\.cargo\", 'Process')
+            [Environment]::SetEnvironmentVariable('RUSTUP_HOME', \"$persist_dir\\.rustup\", 'Process')
+
+            # Install Rustup
             & \"$dir\\rustup-init.exe\" -y --no-modify-path
-        "
-    },
-    "uninstaller": {
-        "script": "
-            [Environment]::SetEnvironmentVariable('RUSTUP_HOME',$null,'User')
-            [Environment]::SetEnvironmentVariable('CARGO_HOME',$null,'User')
         "
     }
 }


### PR DESCRIPTION
This installs rustup directly to the persistent data directory by setting the CARGO_HOME and RUSTUP_HOME environment variables for the process before running the rustup installer.