### PR TITLE
Add replace for regexp, allow regexp and replace for jsonpaths

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -61,6 +61,7 @@ $queue | % {
     }
     $regex = ""
     $jsonpath = ""
+    $replace = ""
 
     if ($json.checkver -eq "github") {
         if (!$json.homepage.StartsWith("https://github.com/")) {
@@ -83,6 +84,10 @@ $queue | % {
         $jsonpath = $json.checkver.jp
     }
 
+    if ($json.checkver.replace) {
+        $replace = $json.checkver.replace
+    }
+
     if(!$jsonpath -and !$regex) {
         $regex = $json.checkver
     }
@@ -96,6 +101,7 @@ $queue | % {
         json = $json;
         jsonpath = $jsonpath;
         reverse = $reverse;
+        replace = $replace;
     }
 
     $wc.headers.add('Referer', (strip_filename $url))
@@ -117,6 +123,7 @@ while($in_progress -gt 0) {
     $regexp = $state.regex
     $jsonpath = $state.jsonpath
     $reverse = $state.reverse
+    $replace = $state.replace
     $ver = ""
 
     $err = $ev.sourceeventargs.error
@@ -130,8 +137,8 @@ while($in_progress -gt 0) {
         continue
     }
 
-    if($jsonpath -and $regexp) {
-        write-host -f darkred "'jp' and 're' shouldn't be used together"
+    if(!$regex -and $replace) {
+        write-host -f darkred "'replace' requires 're'"
         continue
     }
 
@@ -146,6 +153,11 @@ while($in_progress -gt 0) {
         }
     }
 
+    if($jsonpath -and $regexp) {
+        $page = $ver
+        $ver = ""
+    }
+
     if($regexp) {
         $regex = new-object System.Text.RegularExpressions.Regex($regexp)
         if($reverse) {
@@ -158,7 +170,10 @@ while($in_progress -gt 0) {
             $matchesHashtable = @{}
             $regex.GetGroupNames() | % { $matchesHashtable.Add($_, $match.Groups[$_].Value) }
             $ver = $matchesHashtable['1']
-            if(!$ver) {
+            if ($replace) {
+                $ver = $regex.replace($match.Value, $replace)
+            }
+            if (!$ver) {
                 $ver = $matchesHashtable['version']
             }
         } else {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -84,7 +84,7 @@ $queue | % {
         $jsonpath = $json.checkver.jp
     }
 
-    if ($json.checkver.replace) {
+    if ($json.checkver.replace -and $json.checkver.replace.GetType() -eq [System.String]) {
         $replace = $json.checkver.replace
     }
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -173,7 +173,7 @@ while($in_progress -gt 0) {
             if ($replace) {
                 $ver = $regex.replace($match.Value, $replace)
             }
-            if (!$ver) {
+            if(!$ver) {
                 $ver = $matchesHashtable['version']
             }
         } else {


### PR DESCRIPTION
Allows for more dynamic version extractions, eg when jsonpath doesn't exactly match the version, or when you want to rearrange the regexp matches for a better version string.

I've changed so now both `jp` and `re` are allowed at the same time. `jp` is executed first, and then `re` is applied on the jsonpath. If `replace` is defined, it is applied on the regexp match.

Examples:
```
    "checkver": {
        "url": "https://superduper.io/versions.json",
        "jp": "$..name",
        "re": "(?<version>[\\d.]+)",
        "replace": "2.${version}"
    },
```
