### PR TITLE
Update tests to work with pester version 4.0.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 
 init:
   - ps: (get-psprovider 'FileSystem').Home = $(pwd)
-  - ps: choco install -y pester
+  - ps: Install-Module -Name Pester -Force
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,7 @@ branches:
 
 init:
   - ps: (get-psprovider 'FileSystem').Home = $(pwd)
-  - ps: "if($env:APPVEYOR_CHOCO_PESTER_OPTIONS -ne $null) { write-host -f yellow 'NOTE: customized `pester` installation is being used' }"
-  - ps: choco install -y pester $env:APPVEYOR_CHOCO_PESTER_OPTIONS
+  - ps: choco install -y pester
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ init:
 build: off
 
 test_script:
-  - ps: $result = pester -path test/ -outputfile TestResults.xml -outputformat NUnitXML -passthru; $env:failedcount = $result.failedcount
+  - ps: $result = invoke-pester -path test/ -outputfile TestResults.xml -outputformat NUnitXML -passthru; $env:failedcount = $result.failedcount
   - ps: (new-object net.webclient).uploadfile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (resolve-path ./TestResults.xml))
   - ps: if($env:failedcount -gt 0) { exit $env:failedcount }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,6 @@ init:
 build: off
 
 test_script:
-  - ps: $result = invoke-pester -path test/ -outputfile TestResults.xml -outputformat NUnitXML -passthru; $env:failedcount = $result.failedcount
+  - ps: $result = pester -path test/ -outputfile TestResults.xml -outputformat NUnitXML -passthru; $env:failedcount = $result.failedcount
   - ps: (new-object net.webclient).uploadfile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (resolve-path ./TestResults.xml))
   - ps: if($env:failedcount -gt 0) { exit $env:failedcount }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 
 init:
   - ps: (get-psprovider 'FileSystem').Home = $(pwd)
-  - ps: Install-Module -Name Pester -Force
+  - ps: Install-Module -Name Pester -Repository PSGallery -Force
 
 build: off
 

--- a/test/Scoop-Alias.Tests.ps1
+++ b/test/Scoop-Alias.Tests.ps1
@@ -27,7 +27,7 @@ describe "add_alias" {
       $alias_file | should exist
 
       add_alias "rm" "test"
-      $alias_file | should contain ""
+      $alias_file | should FileContentMatch ""
     }
   }
 }

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -35,7 +35,7 @@ describe "movedir" {
         $dir = "$working_dir\user"
         movedir "$dir\_tmp\$extract_dir" "$dir\$extract_to"
 
-        "$dir\test.txt" | should contain "this is the one"
+        "$dir\test.txt" | should FileContentMatch "this is the one"
         "$dir\_tmp\$extract_dir" | should not exist
     }
 
@@ -43,12 +43,12 @@ describe "movedir" {
         $dir = "$working_dir\user with space"
         movedir "$dir\_tmp\$extract_dir" "$dir\$extract_to"
 
-        "$dir\test.txt" | should contain "this is the one"
+        "$dir\test.txt" | should FileContentMatch "this is the one"
         "$dir\_tmp\$extract_dir" | should not exist
 
         # test trailing \ in from dir
         movedir "$dir\_tmp\$null" "$dir\another"
-        "$dir\another\test.txt" | should contain "testing"
+        "$dir\another\test.txt" | should FileContentMatch "testing"
         "$dir\_tmp" | should not exist
     }
 
@@ -56,7 +56,7 @@ describe "movedir" {
         $dir = "$working_dir\user with 'quote"
         movedir "$dir\_tmp\$extract_dir" "$dir\$extract_to"
 
-        "$dir\test.txt" | should contain "this is the one"
+        "$dir\test.txt" | should FileContentMatch "this is the one"
         "$dir\_tmp\$extract_dir" | should not exist
     }
 }


### PR DESCRIPTION
Merge when pester version 4.0.8 gets approved on [chocolatey](https://chocolatey.org/packages/pester) and tests on appveyor start failing.