### PR TITLE
Make Vim installation more standard and less intrusive

### DIFF
--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -17,11 +17,11 @@
         "vim.exe",
         "gvim.exe"
     ],
-    "post_install": "if(!(test-path ~\\.vimrc)) {
-        cp \"$dir\\vimrc_example.vim\" ~\\.vimrc
-        \"set shell=$((gcm powershell).path)\\ -executionpolicy\\ bypass\" | out-file  ~\\.vimrc -append -encoding ascii
-        echo '~/.vimrc was created with your shell set to Powershell.'
-    } else { echo '~/.vimrc exists, skipping' }",
+    "post_install": "if( !(test-path ~\\.vimrc) -and !(test-path ~\\_vimrc) -and !(test-path ~\\vimfiles\\vimrc) -and !(test-path $env:VIM\\_vimrc) ) {
+        cp \"$dir\\vimrc_example.vim\" ~\\_vimrc
+        \"set shell=$((gcm powershell).path)\\ -executionpolicy\\ bypass\" | out-file  ~\\_vimrc -append -encoding ascii
+        echo 'Default vimrc file created in ~/_vimrc, with shell set to PowerShell.'
+    } else { echo 'Existing vimrc file found, no default configuration created' }",
     "checkver": {
         "github": "https://github.com/vim/vim-win32-installer"
     },

--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -25,9 +25,6 @@
     "checkver": {
         "github": "https://github.com/vim/vim-win32-installer"
     },
-    "env_set": {
-        "VIM": "$dir"
-    },
     "autoupdate": {
         "architecture": {
             "32bit": {


### PR DESCRIPTION
I've made a few adjustments to the Vim installation, to make it adhere more to Vim standards, and to be less intrusive.

The current installation has a few problems:

- Even if the user has an existing Vim configuration, eg. in `$HOME\vimfiles\vimrc,` a new vimrc file will be created at `$HOME\.vimrc` during installation. The new default configuration will take precedence over the existing configuration, and if the user deletes default vimrc file, a new one will be created next time Vim is updated.

- The installation will break any existing installation of Vim, as it sets the environment variable `VIM`.

To address these issues, I have made the following changes:

- Check for an existing vimrc file in (almost) all standard locations for Vim in Windows. (`:help vimrc`)
  The installation checks the following locations:
    `$HOME\_vimrc`
    `$HOME\.vimrc`
    `$HOME\vimfiles\vimrc`
    `$VIM\_vimrc`

- Use `_vimrc` instead of `.vimrc` as default vimrc file name. This is the standard for Vim in Windows. (`:help vimrc`)

- Don't set `VIM` environment variable.
  This should not be necessary in a normal installation, as Vim does a good job of guessing the right value. (`:help $VIM`)
