### PR TITLE
added jruby

### DIFF
--- a/bucket/jruby.json
+++ b/bucket/jruby.json
@@ -3,9 +3,10 @@
     "version": "9.1.13.0",
     "url": "https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.zip",
     "hash": "e43c63ad3f832a2333b59479654a97a5f98e609ad79759fd917b5d99ddc6671c",
+    "extract_dir": "jruby-9.1.13.0",
     "persist": "gems",
     "env_add_path": [
-        "jruby-9.1.13.0\\bin",
+        "bin",
         "gems\\bin"
     ],
     "env_set": {
@@ -18,12 +19,17 @@
             "openjdk"
         ]
     },
-    "notes": "Install a JDK and set JAVA_HOME if you don't already have. JRuby won't work without it.\nAlso note that this installation overrides GEM_HOME and GEM_PATH from any previous Ruby or JRuby installation.",
+    "notes": "Install a JDK and set JAVA_HOME if you don't already have. JRuby won't work without it.
+Also note that this installation overrides GEM_HOME and GEM_PATH from any previous Ruby or JRuby installation.",
     "checkver": {
         "url": "http://jruby.org/download",
-        "re": "Current Release:.JRuby.([\\d.]+)"
+        "re": "Current Release:\\s+JRuby\\s+([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://s3.amazonaws.com/jruby.org/downloads/$version/jruby-bin-$version.zip"
+        "url": "https://s3.amazonaws.com/jruby.org/downloads/$version/jruby-bin-$version.zip",
+        "extract_dir": "jruby-$version",
+        "hash": {
+            "url": "$url.sha256"
+        }
     }
 }

--- a/bucket/jruby.json
+++ b/bucket/jruby.json
@@ -23,5 +23,7 @@
         "url": "http://jruby.org/download",
         "re": "Current Release:.JRuby.([\\d.]+)"
     },
-    "autoupdate": "https://s3.amazonaws.com/jruby.org/downloads/$version/jruby-bin-$version.zip"
+    "autoupdate": {
+        "url": "https://s3.amazonaws.com/jruby.org/downloads/$version/jruby-bin-$version.zip"
+    }
 }

--- a/bucket/jruby.json
+++ b/bucket/jruby.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "http://jruby.org/",
+    "version": "9.1.13.0",
+    "url": "https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.zip",
+    "hash": "e43c63ad3f832a2333b59479654a97a5f98e609ad79759fd917b5d99ddc6671c",
+    "persist": "gems",
+    "env_add_path": [
+        "jruby-9.1.13.0\\bin",
+        "gems\\bin"
+    ],
+    "env_set": {
+        "JRUBY_HOME": "$dir",
+        "GEM_HOME": "$dir\\gems",
+        "GEM_PATH": "$dir\\gems"
+    },
+    "suggest": {
+        "OpenJDK": [
+            "openjdk"
+        ]
+    },
+    "notes": "Install a JDK and set JAVA_HOME if you don't already have. JRuby won't work without it.\nAlso note that this installation overrides GEM_HOME and GEM_PATH from any previous Ruby or JRuby installation.",
+    "checkver": {
+        "url": "http://jruby.org/download",
+        "re": "Current Release:.JRuby.([\\d.]+)"
+    },
+    "autoupdate": "https://s3.amazonaws.com/jruby.org/downloads/$version/jruby-bin-$version.zip"
+}


### PR DESCRIPTION
JRuby is a ruby implementation on JVM and thus requires a jdk in order to work. Since there are different jdks available, like openjdk or oracle jdk, it isn't explitely required as an dependency but only suggested.