### PR TITLE
add fnproject

### DIFF
--- a/bucket/fnproject.json
+++ b/bucket/fnproject.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "http://fnproject.io/",
+    "license": "https://github.com/fnproject/cli/blob/master/LICENSE",
+    "version": "0.4.7",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fnproject/cli/releases/download/0.4.7/fn.exe"
+        }
+    },
+    "bin": "fn.exe",
+    "checkver": {
+        "github": "https://github.com/fnproject/cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fnproject/cli/releases/download/$version/fn.exe"
+            }
+        }
+    }
+}

--- a/bucket/fnproject.json
+++ b/bucket/fnproject.json
@@ -1,10 +1,11 @@
 {
     "homepage": "http://fnproject.io/",
     "license": "https://github.com/fnproject/cli/blob/master/LICENSE",
-    "version": "0.4.7",
+    "version": "0.4.10",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fnproject/cli/releases/download/0.4.7/fn.exe"
+            "url": "https://github.com/fnproject/cli/releases/download/0.4.10/fn.exe",
+            "hash": "a7eeef5da32d3a3dff2bc9e6c08964c9af63c622301732db486ef5186fb3b3b2"
         }
     },
     "bin": "fn.exe",


### PR DESCRIPTION
[fnproject](http://fnproject.io) is an AWS Lambda-equivalent.  This is the CLI that is used on Windows to interface with Docker to pull the server and create, deploy, and administer your fn apps.