### PR TITLE
git: add new tig.exe to bin

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -25,7 +25,8 @@
         "usr\\bin\\ssh-add.exe",
         "usr\\bin\\ssh-agent.exe",
         "usr\\bin\\ssh-keygen.exe",
-        "usr\\bin\\ssh-keyscan.exe"
+        "usr\\bin\\ssh-keyscan.exe",
+        "usr\\bin\\tig.exe"
     ],
     "post_install": [
         "git config --global credential.helper manager"

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -17,6 +17,7 @@
         "cmd\\git.exe",
         "cmd\\gitk.exe",
         "cmd\\git-gui.exe",
+        "usr\\bin\\tig.exe",
         "git-bash.exe"
     ],
     "post_install": [


### PR DESCRIPTION
This useful git browser was added to the 2.14.2 release.

See
https://github.com/git-for-windows/git/releases/tag/v2.14.2.windows.1