### PR TITLE
Update leiningen to version 2.8.0

### DIFF
--- a/bucket/leiningen.json
+++ b/bucket/leiningen.json
@@ -1,10 +1,15 @@
 {
     "version": "2.8.0",
     "license": "Eclipse Public License 1.0",
-    "url": "https://raw.githubusercontent.com/technomancy/leiningen/04b88e57c4026b0e644d02d2fc7e2bd13197eaa2/bin/lein.bat",
+    "url": "https://raw.githubusercontent.com/technomancy/leiningen/2.8.0/bin/lein.bat",
     "homepage": "https://github.com/technomancy/leiningen",
     "bin": "lein.bat",
-    "hash": "733D1B6F782C23B2182054F0CD83DC965A4D294A168EBF08B3A70A5C67E230B5",
     "notes": "The command 'lein self-install' is required to complete the installation",
-    "checkver": "github"
+    "hash": "733d1b6f782c23b2182054f0cd83dc965a4d294a168ebf08b3a70a5c67e230b5",
+    "checkver": {
+        "github": "https://github.com/technomancy/leiningen"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/technomancy/leiningen/$version/bin/lein.bat"
+    }
 }

--- a/bucket/leiningen.json
+++ b/bucket/leiningen.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.7.1",
+    "version": "2.8.0",
     "license": "Eclipse Public License 1.0",
-    "url": "https://raw.githubusercontent.com/technomancy/leiningen/150d98b7ae873001615e14f5ba3da601e8261b76/bin/lein.bat",
+    "url": "https://raw.githubusercontent.com/technomancy/leiningen/04b88e57c4026b0e644d02d2fc7e2bd13197eaa2/bin/lein.bat",
     "homepage": "https://github.com/technomancy/leiningen",
     "bin": "lein.bat",
-    "hash": "32385e54b54ec99ac8a37792347ca4f1a3c7feb792066d7ffc8f1e4c5b7c7ad1",
+    "hash": "733D1B6F782C23B2182054F0CD83DC965A4D294A168EBF08B3A70A5C67E230B5",
     "notes": "The command 'lein self-install' is required to complete the installation",
     "checkver": "github"
 }

--- a/bucket/leiningen.json
+++ b/bucket/leiningen.json
@@ -4,8 +4,8 @@
     "url": "https://raw.githubusercontent.com/technomancy/leiningen/2.8.0/bin/lein.bat",
     "homepage": "https://github.com/technomancy/leiningen",
     "bin": "lein.bat",
-    "notes": "The command 'lein self-install' is required to complete the installation",
     "hash": "733d1b6f782c23b2182054f0cd83dc965a4d294a168ebf08b3a70a5c67e230b5",
+    "post_install": "lein self-install",
     "checkver": {
         "github": "https://github.com/technomancy/leiningen"
     },


### PR DESCRIPTION
Update to `2.8.0`. 

_Could_ use `autoupdate` and point to [latest stable](https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat) but run the risk of the checkver and this diverging resulting in hash failures. Thoughts?