### PR TITLE
Change miniconda3 bin alias from 'python3' to 'python'

### DIFF
--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -9,7 +9,7 @@
     "bin": [
         [
             "python.exe",
-            "python3"
+            "python"
         ]
     ],
     "installer": {


### PR DESCRIPTION
It looks like the miniconda3 default installation doesn't alias python.exe to python3, so it's better to keep the scoop-created alias as just python.exe. I had some issues using miniconda3 with the vscode plugin for python because it was looking for "python.exe" instead of "python3.exe". This was an oversight on my part when creating the manifest originally.