### PR TITLE
Update minio-client to version 2017-10-14T00-51-16Z

### DIFF
--- a/bucket/minio-client.json
+++ b/bucket/minio-client.json
@@ -1,16 +1,12 @@
 {
     "homepage": "https://minio.io/",
     "license": "https://github.com/minio/mc/blob/master/LICENSE",
-    "version": "2017-06-15T03-38-43Z",
+    "version": "2017-10-14T00-51-16Z",
     "bin": "mc.exe",
     "architecture": {
         "64bit": {
-            "url": "https://dl.minio.io/client/mc/release/windows-amd64/mc.RELEASE.2017-06-15T03-38-43Z#/mc.exe",
-            "hash": "sha1:06df9c6d3bc5fc69329428b6d3b80f1fa7615e4c"
-        },
-        "32bit": {
-            "url": "https://dl.minio.io/client/mc/release/windows-386/mc.RELEASE.2017-06-15T03-38-43Z#/mc.exe",
-            "hash": "sha1:5c13e9017304c2525251197a71eeec69a591801f"
+            "url": "https://dl.minio.io/client/mc/release/windows-amd64/mc.RELEASE.2017-10-14T00-51-16Z#/mc.exe",
+            "hash": "sha1:c10dc779f66ed0d9320f16835f1b458977b21ee2"
         }
     },
     "suggest": {
@@ -24,12 +20,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://dl.minio.io/client/mc/release/windows-amd64/mc.RELEASE.$version#/mc.exe",
-                "hash": {
-                    "url": "$baseurl/mc.shasum"
-                }
-            },
-            "32bit": {
-                "url": "https://dl.minio.io/client/mc/release/windows-386/mc.RELEASE.$version#/mc.exe",
                 "hash": {
                     "url": "$baseurl/mc.shasum"
                 }


### PR DESCRIPTION
Remove 32bit as 32bit builds are no longer provided by maintainers (see [PR](https://github.com/minio/minio/pull/4811)).

Update to version 2017-10-14T00-51-16Z