### PR TITLE
Added retry when unzip fail because of AV

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -155,51 +155,65 @@ function env($name,$global,$val='__get') {
     else { [environment]::setEnvironmentVariable($name,$val,$target) }
 }
 
-function unzip($path,$to) {
-    if(!(test-path $path)) { abort "can't find $path to unzip"}
+function isFileLocked([string]$path) {
+    $file = New-Object System.IO.FileInfo $path
+
+    if ((Test-Path -Path $path) -eq $false) {
+        return $false
+    }
+
+    try {
+        $stream = $file.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        if ($stream) {
+            $stream.Close()
+        }
+        return $false
+    }
+    catch {
+        # file is locked by a process.
+        return $true
+    }
+}
+
+function unzip($path, $to) {
+    if (!(test-path $path)) { abort "can't find $path to unzip"}
     try { add-type -assembly "System.IO.Compression.FileSystem" -ea stop }
     catch { unzip_old $path $to; return } # for .net earlier than 4.5
+    $retries = 0
+    while ($retries -le 10) {
+        if ($retries -eq 10) {
+            if (7zip_installed) {
+                extract_7zip $path $to $false
+            return
+            }
+            else {
+                abort "Unzip failed: Windows can't unzip because a process is locking the file.`nRun 'scoop install 7zip' and try again."
+        }
+            abort "Unzip failed: Too many retries!"
+        }
+        if (isFileLocked $path) {
+            write-host "Waiting for $path to be unlocked by another process... ($retries/10)"
+            $retries++
+            Start-Sleep -s 2
+        }
+        else {
+            break
+        }
+    }
     try {
-        [io.compression.zipfile]::extracttodirectory($path,$to)
-    } catch [system.io.pathtoolongexception] {
+        [io.compression.zipfile]::extracttodirectory($path, $to)
+    }
+    catch [system.io.pathtoolongexception] {
         # try to fall back to 7zip if path is too long
-        if(7zip_installed) {
+        if (7zip_installed) {
             extract_7zip $path $to $false
             return
-        } else {
+        }
+        else {
             abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
         }
-     } catch [system.io.ioexception] {
-        # First sleep for 5 s
-        # if AV was locking the file, we want the script to try again a few times after short sleeps
-        Start-Sleep -s 5
-        try {
-            [io.compression.zipfile]::extracttodirectory($path,$to)
-        } catch [system.io.pathtoolongexception] {
-            # try to fall back to 7zip if path is too long
-            if(7zip_installed) {
-                extract_7zip $path $to $false
-                return
-            } else {
-                abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
-            }
-        } catch [system.io.ioexception] {
-            # Second sleep for 3s
-            # if AV was locking the file, we want the script to try again a few times after short sleeps
-            Start-Sleep -s 3
-            try {
-                [io.compression.zipfile]::extracttodirectory($path,$to)
-            } catch [system.io.pathtoolongexception] {
-                # try to fall back to 7zip if path is too long
-                if(7zip_installed) {
-                    extract_7zip $path $to $false
-                    return
-                } else {
-                    abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
-                }
-            }
-        }
-    } catch {
+    }
+    catch {
         abort "Unzip failed: $_"
     }
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -184,9 +184,8 @@ function unzip($path, $to) {
         if ($retries -eq 10) {
             if (7zip_installed) {
                 extract_7zip $path $to $false
-            return
-            }
-            else {
+                return
+            } else {
                 abort "Unzip failed: Windows can't unzip because a process is locking the file.`nRun 'scoop install 7zip' and try again."
             }
         }
@@ -194,25 +193,22 @@ function unzip($path, $to) {
             write-host "Waiting for $path to be unlocked by another process... ($retries/10)"
             $retries++
             Start-Sleep -s 2
-        }
-        else {
+        } else {
             break
         }
     }
+
     try {
-        [io.compression.zipfile]::extracttodirectory($path, $to)
-    }
-    catch [system.io.pathtoolongexception] {
+        [io.compression.zipfile]::extracttodirectory($path,$to)
+    } catch [system.io.pathtoolongexception] {
         # try to fall back to 7zip if path is too long
-        if (7zip_installed) {
+        if(7zip_installed) {
             extract_7zip $path $to $false
             return
-        }
-        else {
+        } else {
             abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
         }
-    }
-    catch {
+    } catch {
         abort "Unzip failed: $_"
     }
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -199,7 +199,6 @@ function unzip($path,$to) {
                 }
             }
         }
-    
     } catch {
         abort "Unzip failed: $_"
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -188,8 +188,7 @@ function unzip($path, $to) {
             }
             else {
                 abort "Unzip failed: Windows can't unzip because a process is locking the file.`nRun 'scoop install 7zip' and try again."
-        }
-            abort "Unzip failed: Too many retries!"
+            }
         }
         if (isFileLocked $path) {
             write-host "Waiting for $path to be unlocked by another process... ($retries/10)"


### PR DESCRIPTION
Trend AV analyses and lock zip files just after download. I have added 2 retries in case of this event.

At work I can't change antivirus settings so I have no other choice than to modify the unzip function.