### PR TITLE
bfg: version variable is not resolved properly

### DIFF
--- a/bucket/bfg.json
+++ b/bucket/bfg.json
@@ -15,7 +15,7 @@
         "BFG_HOME": "$dir"
     },
     "pre_install": "
-        $exe = 'java -jar $env:BFG_HOME\\bfg-$version.jar $args'
+        $exe = \"java -jar `$env:BFG_HOME\\bfg-$version.jar `$args\"
         write-output $exe | out-file -filepath $dir\\bfg.ps1
     ",
     "checkver": {


### PR DESCRIPTION
The variable $version needs to be resolved during pre_install step. It is not set at shim rumtime.