### PR TITLE
create go shims instead of adding dir to path var

### DIFF
--- a/bucket/go.json
+++ b/bucket/go.json
@@ -6,7 +6,7 @@
     "env_set": {
         "GOROOT": "$dir"
     },
-    "env_add_path": "bin",
+    "bin": ["bin/go.exe","bin/gofmt.exe","bin/godoc.exe"],
     "installer": {
         "script": "add_first_in_path \"$env:USERPROFILE\\go\\bin\" $global"
     },


### PR DESCRIPTION
This change makes the script create shims in the scoop shims directory instead of adding another directory to the path env variable. I believe this might be prefered instead of adding to the path variable.