### PR TITLE
Update flow license to `MIT`

### DIFF
--- a/bucket/flow.json
+++ b/bucket/flow.json
@@ -1,6 +1,6 @@
 {
     "version": "0.59.0",
-    "license": "BSD",
+    "license": "MIT",
     "url": "https://github.com/facebook/flow/releases/download/v0.59.0/flow-win64-v0.59.0.zip",
     "homepage": "https://flowtype.org/",
     "hash": "0b93669d38f619fd79a0072144a4446e47002da150692a01e4ad8e0d21145d0c",


### PR DESCRIPTION
Update license to reflect Facebook's [change from BSD to MIT](https://code.facebook.com/posts/300798627056246/relicensing-react-jest-flow-and-immutable-js/). 😀  