### PR TITLE
Maven: remove M2_HOME variable, do not persist conf

### DIFF
--- a/bucket/maven.json
+++ b/bucket/maven.json
@@ -6,9 +6,6 @@
     "hash": "90e9f0d700743516d1f610fcd63a5d49751d0743db713909f9ef933747a38b8a",
     "extract_dir": "apache-maven-3.5.2",
     "env_add_path": "bin",
-    "env_set": {
-        "M2_HOME": "$dir"
-    },
     "suggest": {
         "JDK": [
             "extras/oraclejdk",


### PR DESCRIPTION
I have removed the `M2_HOME` environment variable, it is not used by Maven. Maven uses the `%USERPROFILE%\.m2` directory. The `conf` directory does not have to be persisted. It contains only examples and is not used by Maven. Maven uses configuration files in the `%USERPROFILE%\.m2` directory.