### PR TITLE
Gradle: remove GRADLE_HOME from manifest

### DIFF
--- a/bucket/gradle.json
+++ b/bucket/gradle.json
@@ -6,9 +6,6 @@
     "url": "https://services.gradle.org/distributions/gradle-4.3.1-bin.zip",
     "extract_dir": "gradle-4.3.1",
     "bin": "bin\\gradle.bat",
-    "env_set": {
-        "GRADLE_HOME": "$dir"
-    },
     "suggest": {
         "JDK": [
             "extras/oraclejdk",


### PR DESCRIPTION
This commit removes the `%GRADLE_HOME%` environment variable. It is not used by Gradle. See this [discussion](https://discuss.gradle.org/t/do-we-really-need-gradle-home-docs-site-inconsistency/21671).