### PR TITLE
add nonportable bucket

### DIFF
--- a/buckets.json
+++ b/buckets.json
@@ -4,5 +4,6 @@
     "nightlies": "https://github.com/scoopinstaller/nightlies",
     "nirsoft": "https://github.com/kodybrown/scoop-nirsoft",
     "php": "https://github.com/nueko/scoop-php.git",
-    "nerd-fonts": "https://github.com/matthewjberger/scoop-nerd-fonts.git"
+    "nerd-fonts": "https://github.com/matthewjberger/scoop-nerd-fonts.git",
+    "nonportable": "https://github.com/oltolm/scoop-nonportable"
 }


### PR DESCRIPTION
I decided to create a public [bucket](https://github.com/oltolm/scoop-nonportable) for normal nonportable apps. Please add it to the list of buckets. I have described some of the advantages of nonportable apps in the [README](https://github.com/oltolm/scoop-nonportable).