### PR TITLE
Add possibility to give icon path for shortcuts

### DIFF
--- a/lib/shortcuts.ps1
+++ b/lib/shortcuts.ps1
@@ -4,7 +4,10 @@ function create_startmenu_shortcuts($manifest, $dir, $global, $arch) {
     $shortcuts | ?{ $_ -ne $null } | % {
         $target = $_.item(0)
         $name = $_.item(1)
-        startmenu_shortcut "$dir\$target" $name $global
+        if($_.length > 2) {
+            $icon = $_.item(2)
+        }
+        startmenu_shortcut "$dir\$target" $name "$dir\$icon" $global
     }
 }
 
@@ -16,7 +19,7 @@ function shortcut_folder($global) {
     "$([environment]::getfolderpath('startmenu'))\Programs\Scoop Apps"
 }
 
-function startmenu_shortcut($target, $shortcutName, $global) {
+function startmenu_shortcut($target, $shortcutName, $icon, $global) {
     if(!(Test-Path $target)) {
         Write-Host -f DarkRed "Creating shortcut for $shortcutName ($(fname $target)) failed: Couldn't find $target"
         return
@@ -28,6 +31,9 @@ function startmenu_shortcut($target, $shortcutName, $global) {
     $wsShell = New-Object -ComObject WScript.Shell
     $wsShell = $wsShell.CreateShortcut("$scoop_startmenu_folder\$shortcutName.lnk")
     $wsShell.TargetPath = "$target"
+    if(Test-Path $icon -PathType Leaf) {
+        $wsShell.IconLocation  = "$icon"
+    }
     $wsShell.Save()
     write-host "Creating shortcut for $shortcutName ($(fname $target))"
 }


### PR DESCRIPTION
For some apps, the target linked in the shortcut does not contain the app icon. A third parameter in the shortcut array can now be used to specify the icon location.

Example:
```
    "shortcuts": [
        [
            "bin/idea.bat",
            "IntelliJ IDEA",
            "bin/idea.exe"
        ]
    ],
```
The documentation in the wiki should be amended if this gets accepted.