### PR TITLE
Adding VBinDiff.

### DIFF
--- a/bucket/vbindiff.json
+++ b/bucket/vbindiff.json
@@ -1,0 +1,8 @@
+{
+    "homepage": "https://www.cjmweb.net/vbindiff/",
+    "version": "3.0-beta5",
+    "license": "GPL2",
+    "url": "https://www.cjmweb.net/vbindiff/VBinDiff-3.0_beta5.zip",
+    "hash": "05e52b50d9101f9903cc1342fcc307eacf70485e8d942d43c7a440648c9c3a7f",
+    "bin": "vbindiff.exe"
+}


### PR DESCRIPTION
This is another tool I frequently uses to compare binary files in CLI.

I checked it locally with 'scoop install vbindiff.json' and it worked fine.