### PR TITLE
Update yarn config locations to fix global

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -18,9 +18,8 @@
         "bin"
     ],
     "post_install": "
-        yarn config delete cache # 0.24.6 | remove wrong configuration value | delete after two updates
-        yarn config set cache-folder \"$persist_dir\\cache\"
-        yarn config set prefix \"$persist_dir\\bin\"
+        yarn config set cache-folder \"$dir\\cache\"
+        yarn config set prefix \"$dir\"
     ",
     "env_add_path": [
         "bin",


### PR DESCRIPTION
**Notes:**

- Drop `bin` from the prefix location. Yarn add's bin automatically for the bin folder. Currently this results in a bin\bin folder. From docs:

> For example, yarn config set prefix `~/.yarn` will ensure all global packages will have their executables installed to `~/.yarn/bin`.

- Update both configs calls to be relative to `dir` and not `persist_dir`. Yarn generates command shims for global modules that will be relative to the prefix directory. Separately, the current/* folders were being added to the user's path. This means that the command shims were being built relative to the persist dir, but they were being invoked from the current dir. The paths were different and this prevents the global apps from working. Both are now relative to the current dir. This should be non-breaking and fixes global modules. More details: https://github.com/yarnpkg/yarn/issues/4930