### PR TITLE
Use official GnuPG binaries, not GPG4Win, and revert version from 3.0 to 2.2.3.

### DIFF
--- a/bucket/gpg.json
+++ b/bucket/gpg.json
@@ -1,22 +1,18 @@
 {
-    "version": "3.0.0",
-    "license": "GNU",
-    "url": "https://files.gpg4win.org/gpg4win-3.0.0.exe#/dl.7z",
-    "hash": "2565bf6faf8defb8fa61b0b1a30f0e68e2ca5ceb3177d08516e00ca1620252bf",
-    "homepage": "https://www.gpg4win.org",
+    "homepage": "https://www.gnupg.org/",
+    "license": "GPL",
+    "version": "2.2.3",
+    "url": "https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32-2.2.3_20171120.exe#/dl.7z",
+    "hash": "df8295774c47ff07c046c31e2f70d973ba2db8658c0f88039edda5eec5c3f247",
+    "extract_dir": "bin",
     "bin": [
-        [
-            "gpg2.exe",
-            "gpg",
-            ""
-        ],
-        "gpg2.exe"
+        "gpg.exe"
     ],
     "checkver": {
-        "url": "https://www.gpg4win.org/get-gpg4win.html",
-        "re": "Download Gpg4win ([\\d.]+)"
+        "url": "https://www.gnupg.org/download/index.html",
+        "re": "(?s)<td.*?GnuPG.*?([\\d.]{5}).*?(\\d{4})-(\\d{2})-(\\d{2})"
     },
     "autoupdate": {
-        "url": "https://files.gpg4win.org/gpg4win-$version.exe#/dl.7z"
+        "url": "https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32-$match1_$match2$match3$match4.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
I tried installing gpg yesterday, and I ran into some errors. It seemed neither gpg.exe, nor gpg2.exe actually existed in the package downloaded. GPG4Win actually contains the installer of GnuPG, but it does not contain the binaries themselves ready for referencing.

Moreover, GnuPG is in version 2.2.3, not 3.0.0. That is GPG4Win software bundle version.

So I made these "breaking changes", as it reverts version from 3.0.0 to 2.2.3, but this is necessary (as the previous one is not the version of GnuPG, but GPG4Win), and I referenced the official binaries from gnupg.org, and updated checkver and autoupdate accordingly.

I tested it, and it worked fine. 