### PR TITLE
Ant: do not add directory to PATH

### DIFF
--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -5,7 +5,9 @@
     "url": "https://www-us.apache.org/dist/ant/binaries/apache-ant-1.10.1-bin.zip",
     "hash": "sha512:cf85d2b52ac379eaf83ae98544fd0317833a57811764cb1f5082f1ef046ba4f069bddf980f594ca00a93e1b37b4e646fdc8885a37651c5c9e8fc5d2b595256f6",
     "extract_dir": "apache-ant-1.10.1",
-    "env_add_path": "bin",
+    "bin": [
+        "bin\\ant.cmd"
+    ],
     "env_set": {
         "ANT_HOME": "$dir"
     },


### PR DESCRIPTION
I have removed the `bin` directory from `%PATH%` and added `ant.cmd` to it.