### PR TITLE
Edit post installation script of MySQL bucket

### DIFF
--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -32,7 +32,7 @@
     "post_install": "
 #Initialize data directory (without generating root password)
 if (!(Test-Path \"$dir\\data\\auto.cnf\")) {
-	mysqld --initialize-insecure
+    mysqld --initialize-insecure
 }
 #Output client configuration to my.ini file so no username is required when connecting
 echo \"\" | out-file \"$dir/my.ini\" -Encoding ASCII -Append

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -32,16 +32,12 @@
     "post_install": "
 #Initialize data directory (without generating root password)
 if (!(Test-Path \"$dir\\data\\auto.cnf\")) {
-    mysqld --initialize-insecure
+	mysqld --initialize-insecure
 }
-
-#Copy provided sample file to live file location
-cp $dir/my-default.ini $dir/my.ini
-
 #Output client configuration to my.ini file so no username is required when connecting
-echo \"\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
-echo \"[client]\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
-echo \"user=root\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+echo \"\" | out-file \"$dir/my.ini\" -Encoding ASCII -Append
+echo \"[client]\" | out-file \"$dir/my.ini\" -Encoding ASCII -Append
+echo \"user=root\" | out-file \"$dir/my.ini\" -Encoding ASCII -Append
 ",
     "checkver": {
         "url": "https://dev.mysql.com/downloads/mysql/",


### PR DESCRIPTION
* Since [MySQL 5.7.18](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-18.html#mysqld-5-7-18-packaging), my-default file is no longer distributed in package so we can't the line to produce my.ini by copying my-default file.
* In Powershell, Out-file seems to make Byte Order Mark automatically and this occurs following error so this is a temporary commit which changes UTF-8 to ASCII doesn't make BOM.

> mysql: [ERROR] Found option without preceding group in config file …\scoop\apps\mysql\current\my.ini at line 1!
> mysql: [ERROR] Fatal error in defaults handling. Program aborted!