### PR TITLE
Initial implementation of command to query virustotal.com

### DIFF
--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -1,0 +1,45 @@
+# Usage: scoop virustotal <app> [options]
+# Summary: Look for app's SHA256 on virustotal.com
+# Help: Look for app's SHA256 on virustotal.com
+#
+# The download's hash is also a key to access VirusTotal's scan results.
+# This allows to check the safety of the files without even downloading
+# them in many cases.
+#
+# Options:
+#   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
+
+. "$psscriptroot\..\lib\core.ps1"
+. "$psscriptroot\..\lib\help.ps1"
+. "$psscriptroot\..\lib\getopt.ps1"
+. "$psscriptroot\..\lib\manifest.ps1"
+. "$psscriptroot\..\lib\buckets.ps1"
+
+reset_aliases
+
+$opt, $apps, $err = getopt $args 'a:' 'arch='
+if($err) { "scoop virustotal: $err"; exit 1 }
+$architecture = ensure_architecture ($opt.a + $opt.arch)
+
+if($apps) {
+    $apps | % {
+        $manifest, $bucket = find_manifest $_
+        if($manifest) {
+            if([string]::isnullorempty($manifest.homepage)) {
+                abort "Could not find homepage in manifest for '$_'."
+            }
+            $h = hash $manifest $architecture
+            if ($h) {
+                $h | % { start "https://www.virustotal.com/#/file/$_/detection" }
+            }
+            else {
+                write-host -f darkred "No hash information for $_"
+            }
+        }
+        else {
+            abort "Could not find manifest for '$app'."
+        }
+    }
+} else { my_usage }
+
+exit 0

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -1,6 +1,6 @@
 # Usage: scoop virustotal <app> [options]
-# Summary: Look for app's SHA256 on virustotal.com
-# Help: Look for app's SHA256 on virustotal.com
+# Summary: Look for app's hash on virustotal.com
+# Help: Look for app's hash (MD5, SHA1 or SHA256) on virustotal.com
 #
 # The download's hash is also a key to access VirusTotal's scan results.
 # This allows to check the safety of the files without even downloading

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -26,8 +26,14 @@ Function Navigate-ToHash($hash) {
 }
 
 Function Start-VirusTotal ($h, $app) {
-    if ($h -match "(?<algo>[sm][hda]*[125]):.*") {
-        write-host -f darkred "$app uses a $($matches['algo']) hash and VirusTotal only supports SHA256"
+    if ($h -match "(?<algo>[^:]+):(?<hash>.*)") {
+        $hash = $matches["hash"]
+        if ($matches["algo"] -match "(md5|sha1|sha256)") {
+            Navigate-ToHash $hash
+        }
+        else {
+            write-host -f darkred "$app uses $($matches['algo']) hash and VirusTotal only supports md5, sha1 or sha256"
+        }
     }
     else {
         Navigate-ToHash $h

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -21,12 +21,16 @@ $opt, $apps, $err = getopt $args 'a:' 'arch='
 if($err) { "scoop virustotal: $err"; exit 1 }
 $architecture = ensure_architecture ($opt.a + $opt.arch)
 
+Function Navigate-ToHash($hash) {
+    start "https://www.virustotal.com/#/file/$($hash.ToLower())/detection"
+}
+
 Function Start-VirusTotal ($h, $app) {
     if ($h -match "(?<algo>[sm][hda]*[125]):.*") {
         write-host -f darkred "$app uses a $($matches['algo']) hash and VirusTotal only supports SHA256"
     }
     else {
-        start "https://www.virustotal.com/#/file/$_/detection"
+        Navigate-ToHash $h
     }
 }
 

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -21,19 +21,26 @@ $opt, $apps, $err = getopt $args 'a:' 'arch='
 if($err) { "scoop virustotal: $err"; exit 1 }
 $architecture = ensure_architecture ($opt.a + $opt.arch)
 
+Function Start-VirusTotal ($h, $app) {
+    if ($h -match "(?<algo>[sm][hda]*[125]):.*") {
+        write-host -f darkred "$app uses a $($matches['algo']) hash and VirusTotal only supports SHA256"
+    }
+    else {
+        start "https://www.virustotal.com/#/file/$_/detection"
+    }
+}
+
 if($apps) {
     $apps | % {
-        $manifest, $bucket = find_manifest $_
+        $app = $_
+        $manifest, $bucket = find_manifest $app
         if($manifest) {
-            if([string]::isnullorempty($manifest.homepage)) {
-                abort "Could not find homepage in manifest for '$_'."
-            }
             $h = hash $manifest $architecture
             if ($h) {
-                $h | % { start "https://www.virustotal.com/#/file/$_/detection" }
+                $h | % { Start-VirusTotal $_ $app }
             }
             else {
-                write-host -f darkred "No hash information for $_"
+                write-host -f darkred "No hash information for $app"
             }
         }
         else {


### PR DESCRIPTION
Before installing packages, I like to check they are clean...  Luckily, the hash of the package can be used to retrieve the status on https://virustotal.com and more often than not, they have been analyzed already.

I don't know what to test for this (I looked at scoop-home.ps1 for inspiration, but it doesn't seem there are any tests either).

Best regards,

Philippe Crama