### PR TITLE
Add post installation script for MariaDB

### DIFF
--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -47,15 +47,13 @@
     "persist": [
         "data"
     ],
-    "post_install": [
-        "#Initialize data directory (without generating root password)
-        if (!(Test-Path \"$dir\\data\\auto.cnf\")) {
-            mysqld --initialize-insecure
-        }"
-	],
-	"notes": "To create service, you will need run following command as an administrator.
+    "post_install": "#Initialize data directory (without generating root password)
+    if (!(Test-Path \"$dir\\data\\auto.cnf\")) {
+        mysqld --initialize-insecure
+    }",
+    "notes": "Run following command as administrator to run MariaDB as a service.
 
-mysqld --install [Service Name(default: MySQL)]
+mysqld --install \"[Service Name(default:MySQL)]\"
 ",
     "checkver": {
         "url": "https://downloads.mariadb.org/",

--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -47,6 +47,16 @@
     "persist": [
         "data"
     ],
+    "post_install": [
+        "#Initialize data directory (without generating root password)
+        if (!(Test-Path \"$dir\\data\\auto.cnf\")) {
+            mysqld --initialize-insecure
+        }"
+	],
+	"notes": "To create service, you will need run following command as an administrator.
+
+mysqld --install [Service Name(default: MySQL)]
+",
     "checkver": {
         "url": "https://downloads.mariadb.org/",
         "re": "Download ([\\d.]+) Stable"


### PR DESCRIPTION
This commit adds a post installation script to initialize data directory by using `initialize-insecure` option like the case of MySQL and shows the command creates service. Unlike MySQL, I don't put lines make `my.ini` file.