### PR TITLE
Update vim aliases

### DIFF
--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -15,6 +15,10 @@
     "extract_dir": "vim\\vim80",
     "bin": [
         "vim.exe",
+        [
+            "vim.exe",
+            "vi"
+        ],
         "gvim.exe"
     ],
     "post_install": "if( !(test-path ~\\.vimrc) -and !(test-path ~\\_vimrc) -and !(test-path ~\\vimfiles\\vimrc) -and !(test-path $env:VIM\\_vimrc) ) {


### PR DESCRIPTION
Add a new `vi` alias to `vim` so that the following command does not error (as discussed on Gitter 2017/03/22)

```diff
PS scoop> vi /path/to/file

- vi : The term 'vi' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
- At line:1 char:1
-  vi
- ~~
-    + CategoryInfo          : ObjectNotFound: (vi:String) [], CommandNotFoundException
-    + FullyQualifiedErrorId : CommandNotFoundException


```