### PR TITLE
kubectl: kubefed will no longer be released as part of Kubernetes

### DIFF
--- a/bucket/kubectl.json
+++ b/bucket/kubectl.json
@@ -14,8 +14,7 @@
     },
     "extract_dir": "kubernetes\\client",
     "bin": [
-        "bin\\kubectl.exe",
-        "bin\\kubefed.exe"
+        "bin\\kubectl.exe"
     ],
     "checkver": {
         "url": "https://storage.googleapis.com/kubernetes-release/release/stable.txt",


### PR DESCRIPTION
See [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#multicluster).