### PR TITLE
Update virustotal command

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -32,9 +32,11 @@ function is_admin {
 }
 
 # messages
-function abort($msg) { write-host $msg -f darkred; exit 1 }
-function error($msg) { write-host $msg -f darkred }
-function warn($msg) { write-host $msg -f darkyellow }
+function abort($msg, [int] $exit_code=1) { write-host $msg -f red; exit $exit_code }
+function error($msg) { write-host "ERROR $msg" -f darkred }
+function warn($msg) {  write-host "WARN  $msg" -f darkyellow }
+function info($msg) {  write-host "INFO  $msg" -f darkgray }
+function debug($msg) { write-host "DEBUG $msg" -f darkcyan }
 function success($msg) { write-host $msg -f darkgreen }
 
 function filesize($length) {


### PR DESCRIPTION
Add * option to check all installed apps
Add --global option to check globally installed apps
Add 60+ sec. pause after 4 queries/min to avoid 429/Too Many Requests
Add immediate abort if query limit is exceeded
Add INFO/WARN/ERROR prefixes to messages
Add DarkGray/DarkCyan/DarkRed colors to INFO/WARN/ERROR messages
Add using apikey if stored via: scoop config virustotal_api_key apikey
Change colors to DarkGreen/DarkYellow/Yellow/Red for 0/1/2/3+ hit count
Remove fragment from URL when submitting to virustotal.com
Standardized INFO/WARN/ERROR messages