### PR TITLE
Update cygwin to 2.883

### DIFF
--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -1,5 +1,5 @@
 {
-    "version": "2017.12.11",
+    "version": "2.883",
     "homepage": "https://cygwin.com/",
     "architecture": {
         "64bit": {
@@ -10,6 +10,20 @@
             "url": "https://cygwin.com/setup-x86.exe",
             "hash": "bb1091a79fe4d9826d818e7a3bc4b63f05c3c9fbfcdaf8e3c28310c8f4ecd4ce"
         }
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cygwin.com/setup-x86_64.exe"
+            },
+            "32bit": {
+                "url": "https://cygwin.com/setup-x86.exe"
+            }
+        }
+    },
+    "checkver": {
+        "re": "<a.*href=\"/git/\\?p=cygwin-apps/setup\\.git;a=tag.*\">([\\d.]+)</a>",
+        "url": "https://cygwin.com/git/?p=cygwin-apps/setup.git;a=tags"
     },
     "bin": [
         [

--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -1,24 +1,14 @@
 {
-    "version": "2.9.0",
+    "version": "2017.12.11",
     "homepage": "https://cygwin.com/",
     "architecture": {
         "64bit": {
             "url": "https://cygwin.com/setup-x86_64.exe",
-            "hash": "56f41491671bef8de546e2c9221e6a7ec51a2168a9ba28a0d10c25d15be60ab2"
+            "hash": "dbadd1f5f57ba68f9e0e224c8e71331f88234cf39b019a04958006a99fd6604b"
         },
         "32bit": {
             "url": "https://cygwin.com/setup-x86.exe",
-            "hash": "8bc0d306226a12628a73a2e15e324daf96b24099df0cc4e2a7199d176215fded"
-        }
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://cygwin.com/setup-x86_64.exe"
-            },
-            "32bit": {
-                "url": "https://cygwin.com/setup-x86.exe"
-            }
+            "hash": "bb1091a79fe4d9826d818e7a3bc4b63f05c3c9fbfcdaf8e3c28310c8f4ecd4ce"
         }
     },
     "bin": [
@@ -28,9 +18,6 @@
             "--login -i"
         ]
     ],
-    "checkver": {
-        "re": "The most recent version of the Cygwin DLL is[^>]*>([\\d\\.]+)<"
-    },
     "installer": {
         "args": [
             "--no-admin",


### PR DESCRIPTION
Removed checkver and autoupdate as these don't work. The version number isn't even in the metadata for setup.exe, so we'll use the date of the file for the version.