### PR TITLE
Add Yasm package

### DIFF
--- a/bucket/yasm.json
+++ b/bucket/yasm.json
@@ -1,0 +1,33 @@
+{
+    "description": "Modular assembler based on NASM",
+    "homepage": "http://yasm.tortall.net/",
+    "license": "BSD 3-Clause",
+    "version": "1.3.0",
+    "architecture": {
+        "64bit": {
+            "hash": "d160b1d97266f3f28a71b4420a0ad2cd088a7977c2dd3b25af155652d8d8d91f",
+            "url": "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe#/yasm.exe"
+        },
+        "32bit": {
+            "hash": "db8ef9348ae858354cee4cc2f99e0f36de8a47a121de4cfeea5a16d45dd5ac1b",
+            "url": "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win32.exe#/yasm.exe"
+        }
+    },
+    "bin": [
+        "yasm.exe"
+    ],
+    "checkver": {
+        "url": "https://yasm.tortall.net/Download.html",
+        "re": "Latest Release: [\\d.]+"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://www.tortall.net/projects/yasm/releases/yasm-$version-win64.exe#/yasm.exe"
+            },
+            "32bit": {
+                "url": "http://www.tortall.net/projects/yasm/releases/yasm-$version-win32.exe#/yasm.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds the Yasm modular assembler to the default Scoop bucket.