### PR TITLE
Fix yasm checkver

### DIFF
--- a/bucket/yasm.json
+++ b/bucket/yasm.json
@@ -17,8 +17,8 @@
         "yasm.exe"
     ],
     "checkver": {
-        "url": "https://yasm.tortall.net/Download.html",
-        "re": "Latest Release: [\\d.]+"
+        "url": "http://yasm.tortall.net/Download.html",
+        "re": "Latest Release: ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Patches the checkver included with #1964.

- Change `https` to `http`
- Fix `re` to grab version