### PR TITLE
Update win32-openssh to version 1.0.0.0

### DIFF
--- a/bucket/win32-openssh.json
+++ b/bucket/win32-openssh.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://github.com/PowerShell/Win32-OpenSSH",
-    "version": "0.0.24.0",
+    "version": "1.0.0.0",
     "license": "https://raw.githubusercontent.com/PowerShell/Win32-OpenSSH/L1-Prod/LICENCE",
     "architecture": {
         "32bit": {
-            "hash": "dd4529b3509f5254a93d90a40bf6de080fd899447183f89e49477fcadc31e42c",
-            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/0.0.24.0/OpenSSH-Win32.zip",
+            "hash": "0466cc64bbab15e819965c764d2d40b15eccae91dcc260c3fd66dfcbe6e9953c",
+            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v1.0.0.0/OpenSSH-Win32.zip",
             "extract_dir": "OpenSSH-Win32"
         },
         "64bit": {
-            "hash": "b25648e6765e979929a9888b482f736776014dad252d4dee43f990683d70f9e3",
-            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/0.0.24.0/OpenSSH-Win64.zip",
+            "hash": "9a68c9bd5a51efc31be0231c8bddb829fe274beee9147a836922f23d05e8a0a3",
+            "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v1.0.0.0/OpenSSH-Win64.zip",
             "extract_dir": "OpenSSH-Win64"
         }
     },
@@ -33,10 +33,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/$version/OpenSSH-Win32.zip"
+                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v$version/OpenSSH-Win32.zip"
             },
             "64bit": {
-                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/$version/OpenSSH-Win64.zip"
+                "url": "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v$version/OpenSSH-Win64.zip"
             }
         }
     }


### PR DESCRIPTION
Still flagged in the release notes as `This is a pre-release (non-production ready)` so I've left the notes. 