### PR TITLE
ffmpeg 64bit hash fixed!

### DIFF
--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -5,7 +5,7 @@
     "architecture": {
         "64bit": {
             "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20180122-2e96f52-win64-static.zip",
-            "hash": "83aa0486a95a35daf183279a8d43e4a15fe00caccf1fd6c4ea1bdfccc83ea8ef",
+            "hash": "bf204aa99b7f5d8c77b73025c7e8c397481b1f928ca8bacd3f30791ebcc417a1",
             "extract_dir": "ffmpeg-20180122-2e96f52-win64-static"
         },
         "32bit": {


### PR DESCRIPTION
```
~ $ scoop install ffmpeg
Installing 'ffmpeg' (20180122-2e96f52) [64bit]
ffmpeg-20180122-2e96f52-win64-static.zip (49.3 MB) [================================================================================================] 100%%
Checking hash of ffmpeg-20180122-2e96f52-win64-static.zip... Hash check failed for 'https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20180122-2e96f52-win64-static.zip'.
Expected:
    83aa0486a95a35daf183279a8d43e4a15fe00caccf1fd6c4ea1bdfccc83ea8ef
Actual:
    bf204aa99b7f5d8c77b73025c7e8c397481b1f928ca8bacd3f30791ebcc417a1
```
ffmpeg 64bit hash is fixed!