### PR TITLE
Enable writing to hidden .scoop file (#1978)

### DIFF
--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -53,7 +53,7 @@ function set_config($name, $val) {
         $cfg.remove($name)
     }
 
-    convertto-json $cfg | out-file $cfgpath -encoding utf8
+    convertto-json $cfg | set-content $cfgpath -encoding utf8
 }
 
 $cfg = load_cfg


### PR DESCRIPTION
Fixes writing the config to the `~/.scoop` file if that file is hidden. (#1978)

`Out-File` can't write to existing hidden files, even with the `-Force` switch. Using `Set-Content` instead seems to work fine (it doesn't even need the -Force)