### PR TITLE
Enable win32yank on neovim

### DIFF
--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -1,4 +1,4 @@
-
+{
     "version": "0.2.2",
     "license": "https://github.com/neovim/neovim/blob/master/LICENSE",
     "architecture": {
@@ -17,7 +17,11 @@
         ]
     },
     "homepage": "https://neovim.io/",
-    "env_add_path": "Neovim\\bin",
+    "bin": [
+        "Neovim\\bin\\nvim.exe",
+        "Neovim\\bin\\nvim-qt.exe",
+        "Neovim\\bin\\win32yank.exe"
+    ],
     "shortcuts": [
         [
             "Neovim\\bin\\nvim-qt.exe",

--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -1,4 +1,4 @@
-{
+
     "version": "0.2.2",
     "license": "https://github.com/neovim/neovim/blob/master/LICENSE",
     "architecture": {
@@ -17,10 +17,7 @@
         ]
     },
     "homepage": "https://neovim.io/",
-    "bin": [
-        "Neovim\\bin\\nvim.exe",
-        "Neovim\\bin\\nvim-qt.exe"
-    ],
+    "env_add_path": "Neovim\\bin",
     "shortcuts": [
         [
             "Neovim\\bin\\nvim-qt.exe",


### PR DESCRIPTION
Use path instead of bin to add neovim copy-paste (win32yank) in windows.