### PR TITLE
Fix: 'scoop cache' command not using SCOOP_CACHE

### DIFF
--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -23,7 +23,7 @@ function cacheinfo($file) {
 }
 
 function show($app) {
-    $files = @(gci "$scoopdir\cache" | ? { $_.name -match "^$app" })
+    $files = @(gci "$cachedir" | ? { $_.name -match "^$app" })
     $total_length = ($files | measure length -sum).sum -as [double]
 
     $f_app  = @{ expression={"$($_.app) ($($_.version))" }}
@@ -39,7 +39,7 @@ function show($app) {
 switch($cmd) {
     'rm' {
         if(!$app) { 'ERROR: <app> missing'; my_usage; exit 1 }
-        rm "$scoopdir\cache\$app#*"
+        rm "$cachedir\$app#*"
     }
     'show' {
         show $app


### PR DESCRIPTION
I think this was just overlooked? `scoop-cache.ps1` doesn't use the `$cachedir` variable, so it doesn't get the SCOOP_CACHE support added in #1364.

The result being that while the install command correctly uses the folder in SCOOP_CACHE, all *scoop cache ...* commands error because they can't find a `...scoop\cache` folder.