### PR TITLE
Prevent directory creation from being output to console in persistence

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1009,7 +1009,7 @@ function persist_data($manifest, $original_dir, $persist_dir) {
                     Move-Item $source $target
                 } elseif($target.GetType() -eq [System.IO.DirectoryInfo]) {
                     # if there is no source and it's a directory we create an empty directory
-                    ensure $target.FullName
+                    ensure $target.FullName | out-null
                 }
             } elseif ($source.Exists) {
                 # (re)move original (keep a copy)


### PR DESCRIPTION
When directories are being persisted and do not exist already in the source, a couple unnecessary lines are output at the end. Piping this to `out-null` makes it look much better.

![image](https://user-images.githubusercontent.com/1138417/35740735-a83baca0-082d-11e8-93df-d584df371c0e.png)
