### PR TITLE
Update git-with-openssh to version 2.16.1.windows.3

### DIFF
--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -2,15 +2,15 @@
     "##": "Maintainers: when updating this manifest to a new version, you might like to also update git.json",
     "homepage": "https://git-for-windows.github.io/",
     "license": "GPL2",
-    "version": "2.16.1.windows.1",
+    "version": "2.16.1.windows.3",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.1/PortableGit-2.16.1-64-bit.7z.exe#/dl.7z",
-            "hash": "657296d33adceb1d7dabb17847dbd9ee5a45c4ef9d8d8aade2bfb42e57682baf"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.3/PortableGit-2.16.1.3-64-bit.7z.exe#/dl.7z",
+            "hash": "bcb3ca27ae151313ab369d9f39b018129035d7fa018fa0df364424b6e22be4d3"
         },
         "32bit": {
-            "url": "https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.1/PortableGit-2.16.1-32-bit.7z.exe#/dl.7z",
-            "hash": "bc8cf57a206ca63d92aad649322bcec6600a41b91be61229d9282f61e42834ed"
+            "url": "https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.3/PortableGit-2.16.1.3-32-bit.7z.exe#/dl.7z",
+            "hash": "ae4cf93c391c66698856b8b38ba3a42e7fcc7141f61531562134f72b1c014f36"
         }
     },
     "bin": [
@@ -33,7 +33,7 @@
     ],
     "checkver": {
         "url": "https://github.com/git-for-windows/git/releases/latest",
-        "re": "revert back to normal when https bug is fixed (see #2001)"
+        "re": "v(?<version>[\\d\\w.]+)/PortableGit-(?<short>[\\d.]+).*\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Patch: https://github.com/git-for-windows/git/commit/60d8d6eae36358696027f95f0dc1a2dffc3b066b