### PR TITLE
Vim: Create gvim.cmd file for gvim shim (fixes #2006)

### DIFF
--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -19,7 +19,46 @@
             "vim.exe",
             "vi"
         ],
-        "gvim.exe"
+        [
+            "gvim.cmd",
+            "gvim"
+        ]
+    ],
+    "pre_install": [
+        "# Create gvim.cmd",
+        "@\"",
+        "@echo off",
+        "setlocal",
+        "set VIM_EXE_DIR=$dir",
+        "if exist \"%VIM_EXE_DIR%\\gvim.exe\" goto havevim",
+        "echo \"%VIM_EXE_DIR%\\gvim.exe\" not found",
+        "goto eof",
+        ":havevim",
+        "rem collect the arguments in VIMARGS for Win95",
+        "set VIMARGS=",
+        "set VIMNOFORK=",
+        ":loopstart",
+        "if .%1==. goto loopend",
+        "if NOT .%1==.--nofork goto noforklongarg",
+        "set VIMNOFORK=1",
+        ":noforklongarg",
+        "if NOT .%1==.-f goto noforkarg",
+        "set VIMNOFORK=1",
+        ":noforkarg",
+        "set VIMARGS=%VIMARGS% %1",
+        "shift",
+        "goto loopstart",
+        ":loopend",
+        "rem for WinNT we can use %*",
+        "if .%VIMNOFORK%==.1 goto noforknt",
+        "start \"dummy\" /b \"%VIM_EXE_DIR%\\gvim.exe\"  %*",
+        "goto eof",
+        ":noforknt",
+        "start \"dummy\" /b /wait \"%VIM_EXE_DIR%\\gvim.exe\"  %*",
+        ":eof",
+        "set VIMARGS=",
+        "set VIMNOFORK=",
+        "\"@ | out-file -encoding oem \"$dir\\gvim.cmd\""
     ],
     "post_install": "if( !(test-path ~\\.vimrc) -and !(test-path ~\\_vimrc) -and !(test-path ~\\vimfiles\\vimrc) -and !(test-path $env:VIM\\_vimrc) ) {
         cp \"$dir\\vimrc_example.vim\" ~\\_vimrc


### PR DESCRIPTION
See #2006 for discussion. Creates a gvim.cmd file in pre_install

For some reason, this didn't work (wouldn't create the .cmd file) when I first added it to post_install instead.

This might also need adding to the extras/gvim package (I don't actually know what that package is for? It seems almost identical to the vim package)

**Edit**: I should emphasize that, this breaks the `gvim` shim for those using (Git) Bash, until something like #1951 is implemented.