### PR TITLE
Update latex to version 2.9.6615

### DIFF
--- a/bucket/latex.json
+++ b/bucket/latex.json
@@ -1,15 +1,19 @@
 {
     "homepage": "https://miktex.org",
-    "version": "2.9.6521",
+    "version": "2.9.6615",
     "license": "https://miktex.org/copying",
-    "url": "https://ftp.uni-erlangen.de/ctan/systems/win32/miktex/setup/miktex-portable-2.9.6521.exe#/dl.7z",
-    "hash": "745a6fa16593cda188bda10dc0915d2343301b5b0e5ca5a4800cf02385ae48b3",
+    "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/miktex-portable-2.9.6615.exe#/dl.7z",
+    "hash": "87e7ed8e5a953d050ebe77625c5361627aea7f8a9cfbcea0e279c02929672152",
     "env_add_path": "texmfs\\install\\miktex\\bin",
     "checkver": {
         "url": "https://miktex.org/portable",
         "re": "miktex-portable-([\\d.]+).exe"
     },
     "autoupdate": {
-        "url": "https://ftp.uni-erlangen.de/ctan/systems/win32/miktex/setup/miktex-portable-$version.exe#/dl.7z"
+        "url": "https://miktex.org/download/ctan/systems/win32/miktex/setup/windows-x86/miktex-portable-$version.exe#/dl.7z",
+        "hash": {
+            "url": "https://miktex.org/portable",
+            "find": "SHA-256:</td>\\s*<td>\\s*([a-fA-F0-9]{64})"
+        }
     }
 }


### PR DESCRIPTION
- Update to version 2.9.6615
- Extract SHA-256 from website; 190 mb download to compute hash!