### PR TITLE
Proposal: Use write-output in scoop list.

### DIFF
--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -17,29 +17,29 @@ $global = installed_apps $true | % { @{ name = $_; global = $true } }
 $apps = @($local) + @($global)
 
 if($apps) {
-    write-host "Installed apps$(if($query) { `" matching '$query'`"}): `n"
+    write-output ""
     $apps | sort { $_.name } | ? { !$query -or ($_.name -match $query) } | % {
         $app = $_.name
         $global = $_.global
         $ver = current_version $app $global
-
         $install_info = install_info $app $ver $global
-        write-host "  $app " -NoNewline
-        write-host -f DarkCyan $ver -NoNewline
+
+        $str = "$app $ver";
+
         if($global) {
-            write-host -f DarkRed ' *global*' -NoNewline
+            $str = "$str *global*"
         }
         if ($install_info.bucket) {
-            write-host -f Yellow " [$($install_info.bucket)]" -NoNewline
+            $str = "$str [$($install_info.bucket)]"
         } elseif ($install_info.url) {
-            write-host -f Yellow " [$($install_info.url)]" -NoNewline
+            $str = "$str [$($install_info.url)]"
         }
         if ($install_info.architecture -and $def_arch -ne $install_info.architecture) {
-            write-host -f DarkRed " {$($install_info.architecture)}" -NoNewline
+            $str = "$str {$($install_info.architecture)}"
         }
-        write-host ''
+        write-output $str
     }
-    write-host ''
+    write-output ""
     exit 0
 } else {
     write-host "There aren't any apps installed."


### PR DESCRIPTION
This is a minor quality of life thing, but currently `scoop list` has no output and cannot be piped. Coming from `homebrew`, I expect this to work:

```
scoop list | grep "putty"
```

This is useful for workstation setup scripts that try to check if something is already installed. Listing the apps with `write-output` instead of `write-host` means losing the colored text, but that seems like a fair tradeoff.