### PR TITLE
Clean up some error messages

### DIFF
--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -53,8 +53,7 @@ if ((!$push -and !$request) -or $help) {
 }
 
 if(!($upstream -match "^(.*)\/(.*):(.*)$")) {
-    Write-Host -f DarkRed "Upstream must have this format: <user>/<repo>:<branch>"
-    exit 1
+    abort "Upstream must have this format: <user>/<repo>:<branch>"
 }
 
 function execute($cmd) {
@@ -62,8 +61,7 @@ function execute($cmd) {
     $output = iex $cmd
 
     if($LASTEXITCODE -gt 0) {
-        Write-Host -f Red "^^^ Error! See above ^^^ (last command: $cmd)"
-        exit 1
+        abort "^^^ Error! See above ^^^ (last command: $cmd)"
     }
     return $output
 }
@@ -91,7 +89,7 @@ function pull_requests($json, [String]$app, [String]$upstream, [String]$manifest
     execute "hub push origin $branch"
 
     if($LASTEXITCODE -gt 0) {
-        Write-Host -f DarkRed "Push failed! (hub push origin $branch)"
+        error "Push failed! (hub push origin $branch)"
         execute "hub reset"
         return
     }
@@ -107,9 +105,8 @@ function pull_requests($json, [String]$app, [String]$upstream, [String]$manifest
     $msg += "</table>"
     hub pull-request -m "$msg" -b '$upstream' -h '$branch'
     if($LASTEXITCODE -gt 0) {
-        Write-Host -f DarkRed "Pull Request failed! (hub pull-request -m 'Update $app to version $version' -b '$upstream' -h '$branch')"
         execute "hub reset"
-        exit 1
+        abort "Pull Request failed! (hub pull-request -m 'Update $app to version $version' -b '$upstream' -h '$branch')"
     }
 }
 
@@ -139,7 +136,7 @@ hub diff --name-only | % {
     $app = ([System.IO.Path]::GetFileNameWithoutExtension($manifest))
     $json = parse_json $manifest
     if(!$json.version) {
-        Write-Host -f Red "Invalid manifest: $manifest ..."
+        error "Invalid manifest: $manifest ..."
         return
     }
     $version = $json.version

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -65,7 +65,7 @@ $queue | % {
 
     if ($json.checkver -eq "github") {
         if (!$json.homepage.StartsWith("https://github.com/")) {
-            write-host "ERROR: $name checkver expects the homepage to be a github repository" -f DarkYellow
+            error "$name checkver expects the homepage to be a github repository"
         }
         $url = $json.homepage + "/releases/latest"
         $regex = $githubRegex

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -14,7 +14,6 @@ function install_psmodule($manifest, $dir, $global) {
     $module_name = $psmodule.name
     if(!$module_name) {
         abort "Invalid manifest: The 'name' property is missing from 'psmodule'."
-        return
     }
 
     $linkfrom = "$modulesdir\$module_name"

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -15,13 +15,13 @@ reset_aliases
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]
 
-if(!$app) { error 'ERROR: <app> missing'; my_usage; exit 1 }
+if(!$app) { error '<app> missing'; my_usage; exit 1 }
 
 $architecture = default_architecture
 try {
     $architecture = ensure_architecture ($opt.a + $opt.arch)
 } catch {
-    error "ERROR: $_"; exit 1
+    abort "ERROR: $_"
 }
 
 $deps = @(deps $app $architecture)

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -56,13 +56,13 @@ $architecture = default_architecture
 try {
     $architecture = ensure_architecture ($opt.a + $opt.arch)
 } catch {
-    error "ERROR: $_"; exit 1
+    abort "ERROR: $_"
 }
 
-if(!$apps) { error 'ERROR: <app> missing'; my_usage; exit 1 }
+if(!$apps) { error '<app> missing'; my_usage; exit 1 }
 
 if($global -and !(is_admin)) {
-    error 'ERROR: you need admin rights to install global apps'; exit 1
+    abort 'ERROR: you need admin rights to install global apps'
 }
 
 if(is_scoop_outdated) {

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -17,7 +17,7 @@ reset_aliases
 $opt, $apps, $err = getopt $args
 if($err) { "scoop reset: $err"; exit 1 }
 
-if(!$apps) { error 'ERROR: <app> missing'; my_usage; exit 1 }
+if(!$apps) { error '<app> missing'; my_usage; exit 1 }
 
 if($apps -eq '*') {
     $local = installed_apps $false | % { ,@($_, $false) }

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -206,7 +206,7 @@ $apps | % {
             }
             else {
                 if ($_.Exception.Message -match "\(204|429\)") {
-                    abort("$app`: VirusTotal request failed`: $($_.Exception.Message)", $exit_code)
+                    abort "$app`: VirusTotal request failed`: $($_.Exception.Message)" $exit_code
                 }
                 warn("$app`: VirusTotal request failed`: $($_.Exception.Message)")
             }


### PR DESCRIPTION
Cleans up code that outputs error messages:
- Removes the extra 'ERROR' text in the case of `error 'ERROR...`
- Uses the `error` function instead in some cases of `write-host '...' -f Red/DarkRed`...
- ...Except when an `exit` comes after it, in which case it's changed to use `abort` (in some cases this changes the text from darkred to red). The `abort` method doesn't prepend any text.


Haven't touched these cases:
- Code that (effectively) uses write-output instead of write-host to output error messages.
- Code that uses `[console]::error.writeline` instead, since I don't know exactly what this does/why it was used
- Lots of code uses `write-host -f DarkRed "..."`, but I haven't changed them all to use the error function because I don't know if preceding every error message with "ERROR " was really desired.

----

Additional note: For the scoop commands there's some inconsistency in what they do when arguments are missing. Some use `error` (in turn using `write-host`), eg:
https://github.com/lukesampson/scoop/blob/35eb73b2dbc4a8cde6189c8b46eccf03113b9f3b/libexec/scoop-install.ps1#L62

Others just output the text, eg:
https://github.com/lukesampson/scoop/blob/35eb73b2dbc4a8cde6189c8b46eccf03113b9f3b/libexec/scoop-cache.ps1#L41

