### PR TITLE
Adapt to path change of Newtonsoft.Json.dll from #2024 (see f0a15886)

### DIFF
--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -88,7 +88,7 @@ Function ConvertToPrettyJson {
 }
 
 function json_path([String] $json, [String] $jsonpath, [String] $basename) {
-    Add-Type -Path "$psscriptroot\..\supporting\validator\Newtonsoft.Json.dll"
+    Add-Type -Path "$psscriptroot\..\supporting\validator\bin\Newtonsoft.Json.dll"
     $jsonpath = $jsonpath.Replace("`$basename", $basename)
     $obj = [Newtonsoft.Json.Linq.JObject]::Parse($json)
     $result = $null


### PR DESCRIPTION
The move of the Newtonsoft.Json.dll breaks the virustotal subcommand.  This PR fixes it.

Other similar PRs in the buckets `versions' and `extras' are forthcoming.

Thanks in advance,
-- 
Philippe Crama