### PR TITLE
Hashfix for which v2.20!

### DIFF
--- a/bucket/which.json
+++ b/bucket/which.json
@@ -6,7 +6,7 @@
         "https://sourceforge.net/projects/gnuwin32/files/which/2.20/which-2.20-bin.zip"
     ],
     "hash": [
-        "035ec15541649f75459fb81f02406c72e1129fc9041b308160938ae712a603a4"
+        "7a07d3f7cca5c0b38ca811984ef8da536da32932d68c1a6cce33ec2462b930bf"
     ],
     "bin": "bin\\which.exe"
 }


### PR DESCRIPTION
Hashfix for which v2.20.
BTW, There is an error while extracting. If anybody can fix (I don't think it's about manifest or what), feel free to edit the request!
```
bucket hashfix = $ scpin .\which.json
Installing 'which' (2.20) [64bit]
which-2.20-bin.zip (652 B) [========================================================================================================================] 100%
Checking hash of which-2.20-bin.zip... ok.
Extracting... Unzip failed: Exception calling "ExtractToDirectory" with "2" argument(s): "End of Central Directory record could not be found."
```
Edit:
I found the problem but I don't understand why it happens.
When scoop download "which-2.20-bin.zip" it is 652 bytes. When I manually download from same link it is 41,833 bytes.

```
Downloads $ hashcheck .\which-2.20-bin.zip
SHA256 hash of .\which-2.20-bin.zip:
035ec15541649f75459fb81f02406c72e1129fc9041b308160938ae712a603a4
CertUtil: -hashfile command completed successfully.

cache $ hashcheck .\which#2.20#https_sourceforge.net_projects_gnuwin32_files_which_2.20_which-2.20-bin.zip
SHA256 hash of .\which#2.20#https_sourceforge.net_projects_gnuwin32_files_which_2.20_which-2.20-bin.zip:
7a07d3f7cca5c0b38ca811984ef8da536da32932d68c1a6cce33ec2462b930bf
CertUtil: -hashfile command completed successfully.
```