### PR TITLE
Converted llvm download to 7z to avoid elevated permissions request

### DIFF
--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -4,23 +4,13 @@
     "license": "University of Illinois/NCSA Open Source License",
     "architecture": {
         "32bit": {
-            "url": "https://releases.llvm.org/5.0.1/LLVM-5.0.1-win32.exe",
+            "url": "https://releases.llvm.org/5.0.1/LLVM-5.0.1-win32.exe/#7z",
             "hash": "5de70ab482edb2da7ac20126dc58e23a691498aa644ca23a7b10c32c9ee62157"
         },
         "64bit": {
-            "url": "https://releases.llvm.org/5.0.1/LLVM-5.0.1-win64.exe",
+            "url": "https://releases.llvm.org/5.0.1/LLVM-5.0.1-win64.exe/#7z",
             "hash": "981543611d719624acb29a2cffd6a479cff36e8ab5ee8a57d8eca4f9c4c6956f"
         }
-    },
-    "installer": {
-        "args": [
-            "/S",
-            "/D=$dir"
-        ]
-    },
-    "uninstaller": {
-        "file": "Uninstall.exe",
-        "args": "/S"
     },
     "env_add_path": "bin",
     "checkver": "\\/releases\\/download.html#([\\d.]+)",


### PR DESCRIPTION
The installer and uninstaller do not appear to have `/noadmin` options. converting to a 7z and adding bin appears to work. I'm not sure what the installer was attempting to do, so I believe this is an acceptable change.