### PR TITLE
Add ColorTool (Windows Console Colortool)

### DIFF
--- a/bucket/colortool.json
+++ b/bucket/colortool.json
@@ -5,6 +5,9 @@
     "url": "https://github.com/Microsoft/console/releases/download/1708.14008/colortool.zip",
     "hash": "ef317660a8caca83c708b2915274b2b4d611a3ab90c4de128d21b58461fcddfa",
     "bin": "colortool.exe",
+    "persist": [
+        "schemes"
+    ],
     "checkver": {
          "github": "https://github.com/Microsoft/console"
     },

--- a/bucket/colortool.json
+++ b/bucket/colortool.json
@@ -1,0 +1,14 @@
+{
+    "homepage": "https://github.com/Microsoft/Console/tree/master/tools/ColorTool",
+    "version": "1708.14008",
+    "license": "MIT",
+    "url": "https://github.com/Microsoft/console/releases/download/1708.14008/colortool.zip",
+    "hash": "ef317660a8caca83c708b2915274b2b4d611a3ab90c4de128d21b58461fcddfa",
+    "bin": "colortool.exe",
+    "checkver": {
+         "github": "https://github.com/Microsoft/console"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Microsoft/console/releases/download/$version/colortool.zip"
+    }
+}


### PR DESCRIPTION
https://github.com/Microsoft/Console/tree/master/tools/ColorTool

[Introducing the Windows Console Colortool – Windows Command Line Tools For Developers](https://blogs.msdn.microsoft.com/commandline/2017/08/11/introducing-the-windows-console-colortool/)