### PR TITLE
Support TLS 1.2 for scoop search

### DIFF
--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -113,6 +113,8 @@ function search_remotes($query) {
     }
 }
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 if (!$local_results -and !(github_ratelimit_reached)) {
     $remote_results = search_remotes $query
     if(!$remote_results) { [console]::error.writeline("No matches found."); exit 1 }


### PR DESCRIPTION
`scoop-search` fails with the error below when trying to access GitHub API endpoint.

```
invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\sekost\scoop\apps\scoop\current\libexec\scoop-search.ps1:53 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
```

This fix tells .NET runtime to use TLS 1.2 security protocol for HTTPS.
Fixes the problem on Windows 10 1709, PowerShell 5.1

Not sure if it introduces any compatibility issues on older versions of Windows / PowerShell.

**Possibly this fix needs to be placed in another file.**

Fixes #2063 
