### PR TITLE
Enabled shimming of external applications

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -271,9 +271,9 @@ powershell -noprofile -ex unrestricted `"& '$resolved_path' %args%;exit `$lastex
 
 function search_in_path($target) {
     $path = (env 'PATH' $false) + ";" + (env 'PATH' $true)
-    $path.split(';') | % {
-        if(test-path "$_\$target" -pathType leaf) {
-            return "$_\$target"
+    foreach($dir in $path.split(';')) {
+        if(test-path "$dir\$target" -pathType leaf) {
+            return "$dir\$target"
         }
     }
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -269,6 +269,15 @@ powershell -noprofile -ex unrestricted `"& '$resolved_path' %args%;exit `$lastex
     }
 }
 
+function search_in_path($target) {
+    $path = (env 'PATH' $false) + ";" + (env 'PATH' $true)
+    $path.split(';') | % {
+        if(test-path "$_\$target") {
+            return "$_\$target"
+        }
+    }
+}
+
 function ensure_in_path($dir, $global) {
     $path = env 'PATH' $global
     $dir = fullpath $dir

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -272,7 +272,7 @@ powershell -noprofile -ex unrestricted `"& '$resolved_path' %args%;exit `$lastex
 function search_in_path($target) {
     $path = (env 'PATH' $false) + ";" + (env 'PATH' $true)
     $path.split(';') | % {
-        if(test-path "$_\$target") {
+        if(test-path "$_\$target" -pathType leaf) {
             return "$_\$target"
         }
     }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -679,14 +679,14 @@ function create_shims($manifest, $dir, $global, $arch) {
         $target, $name, $arg = shim_def $_
         write-output "Creating shim for '$name'."
 
-        if(test-path "$dir\$target") {
+        if(test-path "$dir\$target" -pathType leaf) {
             $bin = "$dir\$target"
-        } elseif(test-path $target) {
+        } elseif(test-path $target -pathType leaf) {
             $bin = $target
         } else {
             $bin = search_in_path $target
         }
-        if(!(test-path $bin)) { abort "Can't shim '$target': File doesn't exist."}
+        if(!$bin) { abort "Can't shim '$target': File doesn't exist."}
 
         shim $bin $global $name (substitute $arg @{ '$dir' = $dir; '$original_dir' = $original_dir; '$persist_dir' = $persist_dir})
     }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -679,14 +679,16 @@ function create_shims($manifest, $dir, $global, $arch) {
         $target, $name, $arg = shim_def $_
         write-output "Creating shim for '$name'."
 
-        # check valid bin
-        $bin = "$dir\$target"
-        if(!(is_in_dir $dir $bin)) {
-            abort "Error in manifest: bin '$target' is outside the app directory."
+        if(test-path "$dir\$target") {
+            $bin = "$dir\$target"
+        } elseif(test-path $target) {
+            $bin = $target
+        } else {
+            $bin = search_in_path $target
         }
         if(!(test-path $bin)) { abort "Can't shim '$target': File doesn't exist."}
 
-        shim "$dir\$target" $global $name (substitute $arg @{ '$dir' = $dir; '$original_dir' = $original_dir; '$persist_dir' = $persist_dir})
+        shim $bin $global $name (substitute $arg @{ '$dir' = $dir; '$original_dir' = $original_dir; '$persist_dir' = $persist_dir})
     }
 }
 


### PR DESCRIPTION
Hi.

Now one can make shims for external applications (system, other applications installed by scoop and so on).

First, `$bin` is to be searched in `$dir`, then globally, then in user and system `PATH`.

Examples:
```
    "bin": [ [ "winver.exe", "myver", "" ] ]
```

```
    "depends": [ "python" ],
    "bin": [
        [ "python.exe", "myscript", "$dir/myscript.py" ],
        [ "python.exe", "myscript.py", "$dir/myscript.py" ]
    ]
```

```
    "depends": [ "bash" ],
    "bin": [
        [ "bash.exe", "myscript", "$dir/myscript.sh" ],
        [ "bash.exe", "myscript.sh", "$dir/myscript.sh" ]
    ]
```
