### PR TITLE
Checked if uninstaller removed its directory.

### DIFF
--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -73,8 +73,10 @@ $apps | % {
     try {
         rm -r $dir -ea stop -force
     } catch {
-        error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
-        continue
+        if(test-path $dir) {
+            error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
+            continue
+        }
     }
 
     # remove older versions


### PR DESCRIPTION
Sometimes uninstaller removes its own directory by itself. In these cases scoop fails uninstallation process with the following error:
```
PS C:\Users\Chebotarev_V\scoop\apps\scoop\current> scoop uninstall flux
Uninstalling 'flux' (4.66).
Running uninstaller... done.
Removing shim for 'flux'.
Unlinking ~\scoop\apps\flux\current
ERROR Couldn't remove '~\scoop\apps\flux\4.66'; it may be in use.
```

Example:
```
scoop bucket add user https://github.com/excitoon/scoop-user.git
scoop install user/flux
```

This patch fixes it.