### PR TITLE
Better error handling during uninstallation.

### DIFF
--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -36,7 +36,7 @@ if($apps -eq 'scoop') {
 $apps = ensure_all_installed $apps $global
 if(!$apps) { exit 0 }
 
-$apps | ForEach-Object {
+:app_loop foreach($_ in $apps) {
     ($app, $global) = $_
 
     $version = current_version $app $global
@@ -86,7 +86,7 @@ $apps | ForEach-Object {
             Remove-Item -r -force -ea stop $dir
         } catch {
             error "Couldn't remove '$(friendly_path $dir)'; it may be in use."
-            continue
+            continue app_loop
         }
     }
 


### PR DESCRIPTION
If one uninstalls more than one application and have an error, she will receive pretty random behaviour - scoop will either stops (skipping other applications) or continue to uninstall the current. This is so because `continue` doesn't works with pipes and some `continue` were supposed to exit current iteration of nested loop. When one calls `continue` from `For-Each`, PowerShell simply exits `For-Each` (the same effect as if it was `break`:
```
PS C:\Users\Chebotarev_V\scoop\apps\scoop\current> @(1,2,3,4) | % { echo $_; continue }
1
PS C:\Users\Chebotarev_V\scoop\apps\scoop\current> foreach($_ in @(1,2,3,4)) { echo $_; continue; }
1
2
3
4
```