### PR TITLE
Add .bz2 files to decompression

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -16,7 +16,7 @@ function requires_lessmsi ($manifest, $architecture) {
 }
 
 function file_requires_7zip($fname) {
-    $fname -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(7z)|(rar)|(iso)|(xz)|(lzh))$'
+    $fname -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(bz2)|(7z)|(rar)|(iso)|(xz)|(lzh))$'
 }
 
 function extract_7zip($path, $to, $recurse) {


### PR DESCRIPTION
7-zip can also extract .bz2 files. This just adds it to the list of known filenames for auto-extraction.