### PR TITLE
Add git-annex at 2018-02-27 (6.20180219-ge162efdbd)

### DIFF
--- a/bucket/git-annex.json
+++ b/bucket/git-annex.json
@@ -2,14 +2,14 @@
     "description": "Manage files with git, without comitting them",
     "homepage": "https://www.agwa.name/projects/git-crypt/",
     "license": "GPL-3.0",
-    "version": "2018-02-27",
-    "_comment": "Pull version from git: 6.20180219-ge162efdbd",
+    "version": "6.20180227",
+    "notes": "NOTE: Running `git-annex version` may report a slightly older version number",
     "bin": "usr/bin/git-annex.exe",
     "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z",
     "hash": "c57c7d74b5fd63dbf614da829a6320507a11817a55a18b33ba52e1ffa0f30ed4",
     "checkver": {
-        "url": "https://downloads.kitenet.net/git-annex/windows/current/",
-        "re": ">(\\d{4}-\\d{2}-\\d{2}) "
+        "url": "http://hackage.haskell.org/package/git-annex",
+        "re": "/git-annex-([\\d.]+)\\.tar\\.gz"
     },
     "autoupdate": {
         "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z"

--- a/bucket/git-annex.json
+++ b/bucket/git-annex.json
@@ -8,7 +8,7 @@
     "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z",
     "hash": "c57c7d74b5fd63dbf614da829a6320507a11817a55a18b33ba52e1ffa0f30ed4",
     "checkver": {
-        "url": "http://hackage.haskell.org/package/git-annex",
+        "url": "https://hackage.haskell.org/package/git-annex",
         "re": "/git-annex-([\\d.]+)\\.tar\\.gz"
     },
     "autoupdate": {

--- a/bucket/git-annex.json
+++ b/bucket/git-annex.json
@@ -1,0 +1,17 @@
+{
+    "description": "Manage files with git, without comitting them",
+    "homepage": "https://www.agwa.name/projects/git-crypt/",
+    "license": "GPL-3.0",
+    "version": "2018-02-27",
+    "_comment": "Pull version from git: 6.20180219-ge162efdbd",
+    "bin": "usr/bin/git-annex.exe",
+    "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z",
+    "hash": "c57c7d74b5fd63dbf614da829a6320507a11817a55a18b33ba52e1ffa0f30ed4",
+    "checkver": {
+        "url": "https://downloads.kitenet.net/git-annex/windows/current/",
+        "re": ">(\\d{4}-\\d{2}-\\d{2}) "
+    },
+    "autoupdate": {
+        "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
https://git-annex.branchable.com/publicrepos/ implies there is no public git, so the only way I can see to get the `6.20180219-ge162efdbd` version is running the exe.