### PR TITLE
fix for TSL-SSL issue

### DIFF
--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -49,7 +49,8 @@ function search_bucket($bucket, $query) {
 
 function download_json($url) {
     $progressPreference = 'silentlycontinue'
-    $result = invoke-webrequest $url -UseBasicParsing | Select-Object -exp content | convertfrom-json
+    [System.Net.ServicePointManager]::SecurityProtocol = @("Tls12","Tls11","Tls","Ssl3")
+    $result = invoke-webrequest $url -UseBasicParsing | select -exp content | convertfrom-json
     $progressPreference = 'continue'
     $result
 }


### PR DESCRIPTION
I got an following TSL-SSL error when tried to use scoop search.
I used following solution from stackoverflow to resolve this issue. It is only one line to choose TSL-SSL version for web request.
https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel

```
invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\ati_o\scoop\apps\scoop\current\libexec\scoop-search.ps1:52 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\ati_o\scoop\apps\scoop\current\libexec\scoop-search.ps1:52 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\ati_o\scoop\apps\scoop\current\libexec\scoop-search.ps1:52 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\ati_o\scoop\apps\scoop\current\libexec\scoop-search.ps1:52 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\ati_o\scoop\apps\scoop\current\libexec\scoop-search.ps1:52 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\ati_o\scoop\apps\scoop\current\libexec\scoop-search.ps1:52 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

invoke-webrequest : The request was aborted: Could not create SSL/TLS secure channel.
At C:\Users\ati_o\scoop\apps\scoop\current\libexec\scoop-search.ps1:52 char:15
+     $result = invoke-webrequest $url -UseBasicParsing | select -exp c ...
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

No matches found.
```