### PR TITLE
Add aliases for standard vim commands

### DIFF
--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -19,7 +19,62 @@
             "vim.exe",
             "vi"
         ],
-        "gvim.exe"
+        [
+            "vim.exe",
+            "ex",
+            "-e"
+        ],
+        [
+            "vim.exe",
+            "view",
+            "-R"
+        ],
+        [
+            "vim.exe",
+            "rvim",
+            "-Z"
+        ],
+        [
+            "vim.exe",
+            "rview",
+            "-RZ"
+        ],
+        [
+            "vim.exe",
+            "vimdiff",
+            "-d"
+        ],
+        "gvim.exe",
+        [
+            "gvim.exe",
+            "gview",
+            "-R"
+        ],
+        [
+            "gvim.exe",
+            "evim",
+            "-y"
+        ],
+        [
+            "gvim.exe",
+            "eview",
+            "-Ry"
+        ],
+        [
+            "gvim.exe",
+            "rgvim",
+            "-Z"
+        ],
+        [
+            "gvim.exe",
+            "rgview",
+            "-RZ"
+        ],
+        [
+            "gvim.exe",
+            "gvimdiff",
+            "-d"
+        ]
     ],
     "post_install": "if( !(test-path ~\\.vimrc) -and !(test-path ~\\_vimrc) -and !(test-path ~\\vimfiles\\vimrc) -and !(test-path $env:VIM\\_vimrc) ) {
         cp \"$dir\\vimrc_example.vim\" ~\\_vimrc


### PR DESCRIPTION
A standard vim installation on *nix comes with extra commands for
starting vim in various modes.

The following aliases (from the vim man page) are added:

 - ex
 - view
 - rvim
 - rview
 - vimdiff
 - gview
 - evim
 - eview
 - rgvim
 - rgview
 - gvimdiff