### PR TITLE
Improve "scoop alias list" output (#2160)

### DIFF
--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -9,7 +9,11 @@
 #     scoop alias add <name> <command> <description>
 #
 # e.g.:
-#     scoop alias add rm 'scoop uninstall $args[0]' "Uninstalls an app"
+#     scoop alias add rm 'scoop uninstall $args[0]' 'Uninstalls an app'
+#     scoop alias add upgrade 'scoop update *' 'Updates all apps, just like brew or apt'
+#
+# Options:
+#   -v, --verbose   Show alias description and table headers (works only for 'list')
 
 param(
   [String]$opt,

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -74,19 +74,21 @@ function rm_alias($name) {
 }
 
 function list_aliases {
-  $aliases = @{}
+  $aliases = @()
 
-  (init_alias_config).getenumerator() | ForEach-Object {
-    $summary = summary (Get-Content (command_path $_.name) -raw)
-    if(!($summary)) { $summary = '' }
-    $aliases.add("$($_.name) ", $summary)
+  (init_alias_config).GetEnumerator() | ForEach-Object {
+    $content = Get-Content (command_path $_.name)
+    $command = ($content | Select-Object -Skip 1).Trim()
+    $summary = (summary $content).Trim()
+
+    $aliases += New-Object psobject -Property @{Name=$_.name; Summary=$summary; Command=$command}
   }
 
   if(!$aliases.count) {
     warn "No aliases founds."
   }
 
-  $aliases.getenumerator() | Sort-Object name | Format-Table -hidetablehead -autosize -wrap
+  $aliases.GetEnumerator() | Sort-Object Name | Select-Object Name, Command, Summary | Format-Table -autosize -wrap
 }
 
 switch($opt) {

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -11,7 +11,13 @@
 # e.g.:
 #     scoop alias add rm 'scoop uninstall $args[0]' "Uninstalls an app"
 
-param($opt, $name, $command, $description)
+param(
+  [String]$opt,
+  [String]$name,
+  [String]$command,
+  [String]$description,
+  [Switch]$verbose = $false
+)
 
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\help.ps1"
@@ -87,8 +93,12 @@ function list_aliases {
   if(!$aliases.count) {
     warn "No aliases founds."
   }
-
-  $aliases.GetEnumerator() | Sort-Object Name | Select-Object Name, Command, Summary | Format-Table -autosize -wrap
+  $aliases = $aliases.GetEnumerator() | Sort-Object Name
+  if($verbose) {
+    return $aliases | Select-Object Name, Command, Summary | Format-Table -autosize -wrap
+  } else {
+    return $aliases | Select-Object Name, Command | Format-Table -autosize -hidetablehead -wrap
+  }
 }
 
 switch($opt) {


### PR DESCRIPTION
See: https://github.com/lukesampson/scoop/issues/2160

Example output:
```
λ scoop alias list

i       scoop install
test    composer install
u       scoop uninstall
upgrade scoop update *
```

```
λ scoop alias list -v

Name    Command          Summary
----    -------          -------
i       scoop install
test    composer install Run composer install in current directory
u       scoop uninstall
upgrade scoop update *   Updates all apps like brew or apt
```