### PR TITLE
Expose bucketdir variable in manifest test script

### DIFF
--- a/test/Scoop-Manifest.Tests.ps1
+++ b/test/Scoop-Manifest.Tests.ps1
@@ -45,7 +45,9 @@ describe "manifest-validation" {
 
     context "manifest validates against the schema" {
         beforeall {
-            $bucketdir = "$psscriptroot\..\bucket\"
+            if ($null -eq $bucketdir) {
+                $bucketdir = "$psscriptroot\..\bucket\"
+            }
             $manifest_files = Get-ChildItem $bucketdir *.json
             $validator = new-object Scoop.Validator($schema, $true)
         }


### PR DESCRIPTION
So other buckets could reuse the manifest test script, by specifying `$bucketdir`.  
e.g. https://github.com/h404bi/dorado/tree/develop