### PR TITLE
Fixed Bazel dependencies and added environment variable.

### DIFF
--- a/bucket/bazel.json
+++ b/bucket/bazel.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://bazel.build",
+    "version": "0.11.1",
+    "license": "Apache-2.0",
+    "url": "https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-windows-x86_64.zip",
+    "hash": "01245dba6bf4b5695ad5e18b4df768ae5bdd71265808379609369e54d9a6a801",
+    "bin": "bazel.exe",
+    "checkver": {
+        "github": "https://github.com/bazelbuild/bazel"
+    },
+    "autoupdate": {
+        "url": "https://github.com/bazelbuild/bazel/releases/download/$version/bazel-$version-windows-x86_64.zip",
+        "hash": {
+            "mode": "extract",
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/bazel.json
+++ b/bucket/bazel.json
@@ -1,27 +1,40 @@
 {
     "homepage": "https://bazel.build",
-    "version": "0.11.1",
-    "license": "Apache License 2.0",
+    "version": "0.13.0",
+    "license": "Apache-2.0",
     "bin": "bazel.exe",
-    "depends": [ "python27", "msys2", "git", "curl", "zip", "unzip" ],
+    "suggest": {
+        "MSYS2": [
+            "msys2"
+        ],
+        "Python27": [
+            "versions/python27"
+        ],
+        "curl": [
+            "curl"
+        ]
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-windows-x86_64.zip",
-            "hash": "01245dba6bf4b5695ad5e18b4df768ae5bdd71265808379609369e54d9a6a801"
-        },
+            "url": "https://github.com/bazelbuild/bazel/releases/download/0.13.0/bazel-0.13.0-windows-x86_64.zip",
+            "hash": "de81cff0604618646d4e0ab64e078229fd75753628df51f5df833e0f1cd24147"
+        }
     },
     "checkver": {
         "github": "https://github.com/bazelbuild/bazel"
     },
     "autoupdate": {
-        "url": "https://github.com/bazelbuild/bazel/releases/download/$version/bazel-$version-windows-x86_64.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bazelbuild/bazel/releases/download/$version/bazel-$version-windows-x86_64.zip"
+            }
+        },
         "hash": {
             "mode": "extract",
             "url": "$url.sha256"
         }
     },
     "env_set": {
-        "BAZEL_SH": "$(appdir msys2)/current/usr/bin/bash"
-    },
-    "bin": "bazel.exe"
+        "BAZEL_SH": "$(appdir msys2)\\current\\usr\\bin\\bash.exe"
+    }
 }

--- a/bucket/bazel.json
+++ b/bucket/bazel.json
@@ -1,10 +1,15 @@
 {
     "homepage": "https://bazel.build",
     "version": "0.11.1",
-    "license": "Apache-2.0",
-    "url": "https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-windows-x86_64.zip",
-    "hash": "01245dba6bf4b5695ad5e18b4df768ae5bdd71265808379609369e54d9a6a801",
+    "license": "Apache License 2.0",
     "bin": "bazel.exe",
+    "depends": [ "python27", "msys2", "git", "curl", "zip", "unzip" ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-windows-x86_64.zip",
+            "hash": "01245dba6bf4b5695ad5e18b4df768ae5bdd71265808379609369e54d9a6a801"
+        },
+    },
     "checkver": {
         "github": "https://github.com/bazelbuild/bazel"
     },
@@ -14,5 +19,9 @@
             "mode": "extract",
             "url": "$url.sha256"
         }
-    }
+    },
+    "env_set": {
+        "BAZEL_SH": "$(appdir msys2)/current/usr/bin/bash"
+    },
+    "bin": "bazel.exe"
 }

--- a/bucket/zip.json
+++ b/bucket/zip.json
@@ -2,27 +2,21 @@
     "homepage": "http://www.info-zip.org/",
     "license": "http://www.info-zip.org/pub/infozip/license.html",
     "description": "Zip compression utilities",
-    "version": "3.0",
+    "version": "3.1d26",
     "bin": [
         "zip.exe",
         "zipcloak.exe",
         "zipnote.exe",
         "zipsplit.exe"
     ],
+    "url": "http://r.windows.random.supplies/zip3.1d26.zip",
+    "hash": "822b1a808636e28d0c67e76572a21dc2bc1b2a1c092cc01c762c883e2c2cbd63",
     "architecture": {
-        "32bit": {
-            "hash": "f8bbc1821d50400245107ce8cfa4a6c7b524387b58bbd6cbe9c20094e82c3bb5",
-            "url": "https://r15ch13.keybase.pub/scoop/zip/zip300xn.zip"
-        },
         "64bit": {
-            "hash": "ed29893fcd7f8b2afb2ead0461663584b740b5d064d4e1c87084107941197a7b",
-            "url": "https://r15ch13.keybase.pub/scoop/zip/zip300xn-x64.zip"
+            "extract_dir": "x64"
+        },
+        "32bit": {
+            "extract_dir": "x32"
         }
-    },
-    "pre_install": [
-        "if(Test-Path \"$dir\\zip300xn-x64.zip\") {",
-        "unzip \"$dir\\zip300xn-x64.zip\" \"$dir\"",
-        "Remove-Item \"$dir\\zip300xn-x64.zip\"",
-        "}"
-    ]
+    }
 }

--- a/bucket/zip.json
+++ b/bucket/zip.json
@@ -2,21 +2,27 @@
     "homepage": "http://www.info-zip.org/",
     "license": "http://www.info-zip.org/pub/infozip/license.html",
     "description": "Zip compression utilities",
-    "version": "3.1d26",
+    "version": "3.0",
     "bin": [
         "zip.exe",
         "zipcloak.exe",
         "zipnote.exe",
         "zipsplit.exe"
     ],
-    "url": "http://r.windows.random.supplies/zip3.1d26.zip",
-    "hash": "822b1a808636e28d0c67e76572a21dc2bc1b2a1c092cc01c762c883e2c2cbd63",
     "architecture": {
-        "64bit": {
-            "extract_dir": "x64"
-        },
         "32bit": {
-            "extract_dir": "x32"
+            "hash": "f8bbc1821d50400245107ce8cfa4a6c7b524387b58bbd6cbe9c20094e82c3bb5",
+            "url": "https://r15ch13.keybase.pub/scoop/zip/zip300xn.zip"
+        },
+        "64bit": {
+            "hash": "ed29893fcd7f8b2afb2ead0461663584b740b5d064d4e1c87084107941197a7b",
+            "url": "https://r15ch13.keybase.pub/scoop/zip/zip300xn-x64.zip"
         }
-    }
+    },
+    "pre_install": [
+        "if(Test-Path \"$dir\\zip300xn-x64.zip\") {",
+        "unzip \"$dir\\zip300xn-x64.zip\" \"$dir\"",
+        "Remove-Item \"$dir\\zip300xn-x64.zip\"",
+        "}"
+    ]
 }


### PR DESCRIPTION
See #2186.

Zip is taken from http://www.paehl.com and repackaged to zip (sic!) in order to avoid `7z` dependency.
