### PR TITLE
wraptext: use buffer width instead of window width (fixes #2190)

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -389,7 +389,7 @@ function ensure_robocopy_in_path {
 }
 
 function wraptext($text, $width) {
-    if(!$width) { $width = $host.ui.rawui.windowsize.width };
+    if(!$width) { $width = $host.ui.rawui.buffersize.width };
     $width -= 1 # be conservative: doesn't seem to print the last char
 
     $text -split '\r?\n' | ForEach-Object {


### PR DESCRIPTION
There exist two size properties in `$host.ui.rawui`: `windowsize` and `buffersize`. PowerShell ISE doesn't support windowsize, causing `wraptext` to incorrectly wrap in ISE. (#2190).

In the modern Windows 10 console (and eg the terminal in vscode), the widths of buffersize and windowsize are always the same.

This change only affects those using pre-Windows 10 conhost, or the Windows 10 conhost in legacy mode; and furthermore only if they have the console window sized narrower than the buffer size (giving a horizontal scroll bar). In this situation, all text in the console is suboptimally displayed anyway.

The code was first added in https://github.com/lukesampson/scoop/commit/a21a2d2f1f7445a85137cd222a6e6349441111b4, 5 years ago