### PR TITLE
neovim: Do not include win32yank in PATH

### DIFF
--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -19,8 +19,7 @@
     "homepage": "https://neovim.io/",
     "bin": [
         "Neovim\\bin\\nvim.exe",
-        "Neovim\\bin\\nvim-qt.exe",
-        "Neovim\\bin\\win32yank.exe"
+        "Neovim\\bin\\nvim-qt.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
This commit relates to #1985, reverts 3fc87da006e21dad39c13522427a35368ce402e2, and resolves #2021.

Neovim doesn't require win32yank.exe in the user's PATH. The shimexe version of win32yank.exe causes problems with clipboard+=unnamedplus in Neovim. Since it's not required in the PATH, and the shimexe version cause issues, this removes win32yank's shim.

Say the neovim clipboard option is set to set clipboard+=unnamedplus. If the win32yank.exe shim genereated by Scoop exists in the user's PATH, then it will be used. The shimexe [0] version of win32yank leaves dangling window instances, in the foreground, after every yank or paste operation. This indicates an incompatibility between Neovim and the win32yank.exe shimexe.

Neovim does not require win32yank.exe in the user's PATH. This is because Neovim looks for win32yank using the executeable() function [1]. The executeable() function always finds executeables in the same directory as vim [2]. Therefore, win32yank.exe isn't required to exist in the user's PATH variable for Neovim.

[0] https://github.com/lukesampson/scoop/blob/2d9f9640685e9b82526cccdfdb874f8aa8a17745/supporting/shimexe/shim.cs
[1] https://github.com/neovim/neovim/blob/dc536295875640ef5d7b28d8135d0ef72d782d5e/runtime/autoload/provider/clipboard.vim#L98
[2] https://github.com/neovim/neovim/blob/a1530ece87c329363b40ea92e71097b783ad5215/runtime/doc/eval.txt#L3226