### PR TITLE
Use SPDX license identifiers in the default bucket

### DIFF
--- a/bucket/ack.json
+++ b/bucket/ack.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://beyondgrep.com/",
-    "license": "https://opensource.org/licenses/Artistic-2.0",
+    "license": "Artistic-2.0",
     "version": "2.22",
     "url": "https://beyondgrep.com/ack-2.22-single-file#/ack-single-file",
     "hash": "fd0617585b88517a3d41d3d206c1dc38058c57b90dfd88c278049a41aeb5be38",

--- a/bucket/ag.json
+++ b/bucket/ag.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://geoff.greer.fm/ag/",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "version": "2.1.0-28-g4aa9f05",
     "architecture": {
         "64bit": {

--- a/bucket/allure.json
+++ b/bucket/allure.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/allure-framework/allure2",
     "version": "2.6.0",
-    "license": "https://github.com/allure-framework/allure2/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "url": "https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/2.6.0/allure-2.6.0.zip",
     "hash": "d2600c93b2a7db748e11e6e158c0c32fe0e53e86881632f021e4a3c80b60ca14",
     "extract_dir": "allure-2.6.0",

--- a/bucket/ant.json
+++ b/bucket/ant.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://ant.apache.org/",
     "version": "1.10.3",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://www-us.apache.org/dist/ant/binaries/apache-ant-1.10.3-bin.zip",
     "hash": "sha512:e8f82a00ecfc460050975061ace65bb7e3e7156c97a5ed2dafdb1f9ef50165a8b8baaaf3164c5b39c70f51101167b188d81abb7a966945b9830a31a64043c463",
     "extract_dir": "apache-ant-1.10.3",

--- a/bucket/apache.json
+++ b/bucket/apache.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.apachelounge.com",
     "version": "2.4.33",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://www.apachelounge.com/download/VC15/binaries/httpd-2.4.33-win64-VC15.zip",

--- a/bucket/apex.json
+++ b/bucket/apex.json
@@ -1,7 +1,7 @@
 {
     "description": "Apex lets you build, deploy, and manage AWS Lambda functions.",
     "homepage": "http://apex.run/",
-    "license": "https://github.com/apex/apex/blob/master/LICENSE",
+    "license": "MIT",
     "version": "0.16.0",
     "architecture": {
         "64bit": {

--- a/bucket/aria2.json
+++ b/bucket/aria2.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://aria2.github.io/",
-    "license": "GPL2 or later",
+    "license": "GPL-2.0-or-later",
     "version": "1.33.1",
     "architecture": {
         "32bit": {

--- a/bucket/armor.json
+++ b/bucket/armor.json
@@ -2,7 +2,7 @@
     "description": "Uncomplicated, modern HTTP server",
     "version": "0.4.7",
     "homepage": "https://github.com/labstack/armor",
-    "license": "https://github.com/labstack/armor/blob/master/LICENSE",
+    "license": "MIT",
     "architecture": {
         "32bit": {
             "url": "https://github.com/labstack/armor/releases/download/0.4.7/armor_0.4.7_windows_32-bit.zip",

--- a/bucket/artifact.json
+++ b/bucket/artifact.json
@@ -2,7 +2,7 @@
     "description": "The open source design documentation tool",
     "version": "1.0.1",
     "homepage": "https://github.com/vitiral/artifact",
-    "license": "LGPL",
+    "license": "MIT OR Apache-2.0",
     "bin": "art.exe",
     "checkver": "github",
     "architecture": {

--- a/bucket/atomicparsley.json
+++ b/bucket/atomicparsley.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://atomicparsley.sourceforge.net/",
     "version": "0.9.0",
-    "license": "GPLv2",
+    "license": "GPL-2.0",
     "url": "https://downloads.sourceforge.net/project/atomicparsley/atomicparsley/AtomicParsley%20v0.9.0/AtomicParsley-win32-0.9.0.zip",
     "hash": "f363630462ea01d7de948c3e4d231159fa91916d8d7f971a7e8b3bc478dbe846",
     "extract_dir": "AtomicParsley-win32-0.9.0",

--- a/bucket/bfg.json
+++ b/bucket/bfg.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://rtyley.github.io/bfg-repo-cleaner/",
-    "license": "GPL",
+    "license": "GPL-3.0-or-later",
     "version": "1.13.0",
     "url": "https://repo1.maven.org/maven2/com/madgag/bfg/1.13.0/bfg-1.13.0.jar",
     "hash": "bf22bab9dd42d4682b490d6bc366afdad6c3da99f97521032d3be8ba7526c8ce",

--- a/bucket/bochs.json
+++ b/bucket/bochs.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://bochs.sourceforge.net/",
     "version": "2.6.9",
-    "license": "LGPL",
+    "license": "LGPL-2.1",
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/bochs/bochs/2.6.9/bochs-2.6.9-win64.zip",

--- a/bucket/buffalo.json
+++ b/bucket/buffalo.json
@@ -2,7 +2,7 @@
     "homepage": "https://gobuffalo.io",
     "description": "A Go web development eco-system, designed to make the life of a Go web developer easier.",
     "version": "0.11.0",
-    "license": "https://github.com/gobuffalo/buffalo/blob/master/LICENSE.txt",
+    "license": "MIT",
     "url": "https://github.com/gobuffalo/buffalo/releases/download/v0.11.0/buffalo_0.11.0_windows_amd64.tar.gz",
     "hash": "c109deab5356ab36a048a196f34dabdb53090a517d23e781762087bc449c384c",
     "bin": [

--- a/bucket/busybox.json
+++ b/bucket/busybox.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://frippery.org/busybox",
     "version": "2121-ga316078ad",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "architecture": {
         "32bit": {
             "url": "https://frippery.org/files/busybox/busybox-w32-FRP-2121-ga316078ad.exe#/busybox.exe",

--- a/bucket/cacert.json
+++ b/bucket/cacert.json
@@ -1,7 +1,7 @@
 {
     "version": "2018-03-07",
     "homepage": "https://curl.haxx.se/docs/caextract.html",
-    "license": "MPL 2.0",
+    "license": "MPL-2.0",
     "url": "https://curl.haxx.se/ca/cacert-2018-03-07.pem#/cacert.pem",
     "hash": "79ea479e9f329de7075c40154c591b51eb056d458bc4dff76d9a4b9c6c4f6d0b",
     "checkver": {

--- a/bucket/caddy.json
+++ b/bucket/caddy.json
@@ -1,7 +1,7 @@
 {
     "version": "0.10.14",
     "homepage": "https://caddyserver.com",
-    "license": "https://github.com/mholt/caddy/blob/master/LICENSE.txt",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/mholt/caddy/releases/download/v0.10.14/caddy_v0.10.14_windows_amd64.zip",

--- a/bucket/cdrtools.json
+++ b/bucket/cdrtools.json
@@ -29,7 +29,7 @@
     "description": "Burn and read CDs, DVDs, and Blu-ray discs",
     "hash": "f534062cab7585b82bd764f02bc65fb0c7c27ac1615786bfc81c35880ce4acc6",
     "homepage": "https://sourceforge.net/projects/tumagcc/",
-    "license": "CDDL-1.0/GPL-2.0/LGPL-2.1",
+    "license": "CDDL-1.0 OR GPL-2.0 OR LGPL-2.1",
     "url": "https://downloads.sourceforge.net/project/tumagcc/schily-cdrtools-3.01.7z",
     "version": "3.01"
 }

--- a/bucket/cmake.json
+++ b/bucket/cmake.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://cmake.org/",
     "version": "3.11.1",
-    "license": "https://cmake.org/licensing/",
+    "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
             "url": "https://cmake.org/files/v3.11/cmake-3.11.1-win64-x64.zip",

--- a/bucket/composer.json
+++ b/bucket/composer.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://getcomposer.org/",
-    "license": "https://github.com/composer/composer/blob/master/LICENSE",
+    "license": "MIT",
     "version": "1.6.4",
     "url": "https://getcomposer.org/download/1.6.4/composer.phar",
     "bin": "composer.ps1",

--- a/bucket/consul.json
+++ b/bucket/consul.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.consul.io",
-    "license": "Mozilla Public License 2.0",
+    "license": "MPL-2.0",
     "version": "1.0.7",
     "architecture": {
         "64bit": {

--- a/bucket/coreutils.json
+++ b/bucket/coreutils.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.mingw.org/wiki/msys",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "version": "5.97.3",
     "url": [
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.13-2/msysCORE-1.0.13-2-msys-1.0.13-bin.tar.lzma",

--- a/bucket/csvtosql.json
+++ b/bucket/csvtosql.json
@@ -1,6 +1,6 @@
 {
     "version": "v0.1.1-alpha",
-    "license": "https://raw.githubusercontent.com/deevus/CsvToSql/master/UNLICENSE.txt",
+    "license": "Unlicense",
     "url": "https://github.com/deevus/CsvToSql/archive/v0.1.1-alpha.zip",
     "depends": "gow",
     "homepage": "https://github.com/deevus/CsvToSql",

--- a/bucket/ctags.json
+++ b/bucket/ctags.json
@@ -5,6 +5,6 @@
     "extract_dir": "ctags58",
     "bin": "ctags.exe",
     "hash": "e1f5909ec0c7a58fd2149139fa6a1dc532070a3d919dd183671c57a32f8b243d",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "checkver": "Version ([\\d.]+)"
 }

--- a/bucket/cutter.json
+++ b/bucket/cutter.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/radareorg/cutter",
-    "license": "https://github.com/radareorg/cutter/blob/master/COPYING",
+    "license": "GPL-3.0",
     "version": "1.3",
     "architecture": {
         "64bit": {

--- a/bucket/dart-sass.json
+++ b/bucket/dart-sass.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/sass/dart-sass",
     "version": "1.2.1",
-    "license": "https://raw.githubusercontent.com/sass/dart-sass/master/LICENSE",
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/sass/dart-sass/releases/download/1.2.1/dart-sass-1.2.1-windows-x64.zip",

--- a/bucket/dd.json
+++ b/bucket/dd.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.chrysocome.net/dd",
-    "license": "http://www.chrysocome.net/gpl",
+    "license": "GPL-2.0",
     "description": "Allows the flexible copying of data in a win32 environment",
     "version": "0.6beta3",
     "url": "http://www.chrysocome.net/downloads/dd-0.6beta3.zip",

--- a/bucket/dep.json
+++ b/bucket/dep.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/golang/dep",
     "version": "0.4.1",
-    "license": "https://github.com/golang/dep/blob/master/LICENSE",
+    "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
             "url": "https://github.com/golang/dep/releases/download/v0.4.1/dep-windows-amd64.exe#/dep.exe",

--- a/bucket/devd.json
+++ b/bucket/devd.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://corte.si/posts/devd/intro/index.html",
-    "license": "https://github.com/cortesi/devd/blob/master/LICENSE",
+    "license": "MIT",
     "version": "0.8",
     "url": "https://github.com/cortesi/devd/releases/download/v0.8/devd-0.8-windows64.zip",
     "hash": "fe08f585eca8e9e6a60afb88d5e7054da1e1c6cd317a32071be11199051731d1",

--- a/bucket/dig.json
+++ b/bucket/dig.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.isc.org/",
-    "license": "https://www.isc.org/downloads/software-support-policy/isc-license/",
+    "license": "ISC",
     "version": "9.12.1",
     "architecture": {
         "64bit": {

--- a/bucket/digdag.json
+++ b/bucket/digdag.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.digdag.io/",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "version": "0.9.24",
     "url": "https://dl.bintray.com/digdag/maven/digdag-0.9.24.jar#/digdag.jar",
     "hash": "3e092a961ea3775d729e40e48d1e0f149f90d39ad89dbeb3d483e237e2f13a4f",

--- a/bucket/dnvm.json
+++ b/bucket/dnvm.json
@@ -1,6 +1,6 @@
 {
     "version": "latest",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://raw.githubusercontent.com/aspnet/Home/danroth27/restorednvm/dnvm.ps1",
     "homepage": "https://github.com/aspnet/Home",
     "env_set": {

--- a/bucket/docker-compose.json
+++ b/bucket/docker-compose.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/docker/compose",
     "version": "1.21.0",
-    "license": "Apache",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/docker/compose/releases/download/1.21.0/docker-compose-Windows-x86_64.exe#/docker-compose.exe",

--- a/bucket/docker-machine.json
+++ b/bucket/docker-machine.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/docker/machine",
     "version": "0.14.0",
-    "license": "Apache",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/docker/machine/releases/download/v0.14.0/docker-machine-Windows-x86_64.exe#/docker-machine.exe",

--- a/bucket/docker.json
+++ b/bucket/docker.json
@@ -1,6 +1,6 @@
 {
     "version": "17.05.0-ce",
-    "license": "https://github.com/docker/docker/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://get.docker.com/builds/Windows/x86_64/docker-17.05.0-ce.zip",

--- a/bucket/dos2unix.json
+++ b/bucket/dos2unix.json
@@ -2,7 +2,7 @@
     "homepage": "http://dos2unix.sourceforge.net/",
     "description": "Convert text files with DOS or Mac line endings to Unix line endings and vice versa",
     "version": "7.4.0",
-    "license": "BSD",
+    "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/dos2unix/dos2unix/7.4.0/dos2unix-7.4.0-win64.zip",

--- a/bucket/dosbox.json
+++ b/bucket/dosbox.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.dosbox.com/",
     "version": "0.74",
-    "license": "GPL",
+    "license": "GPL-2.0",
     "url": "https://downloads.sourceforge.net/project/dosbox/dosbox/0.74/DOSBox0.74-win32-installer.exe",
     "hash": "c149cb85f732beb95bf6564d72bdfdd9306f7050edfd9d2cd475420efe3b84fc",
     "installer": {

--- a/bucket/doxygen.json
+++ b/bucket/doxygen.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.doxygen.nl/",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "version": "1.8.14",
     "architecture": {
         "64bit": {

--- a/bucket/draft.json
+++ b/bucket/draft.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/Azure/draft",
-    "license": "https://github.com/Azure/draft/blob/master/LICENSE",
+    "license": "MIT",
     "version": "0.13.0",
     "architecture": {
         "64bit": {

--- a/bucket/drone.json
+++ b/bucket/drone.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://drone.io/",
     "version": "0.8.5",
-    "license": "Apache License 2.0",
+    "license": "Apache-2.0",
     "url": "https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_windows_amd64.tar.gz",
     "hash": "98bc8907bd14e36ef251d2fc6117d233f62e6e7d25e5511be98bbba228bf3e86",
     "bin": "drone.exe",

--- a/bucket/elm.json
+++ b/bucket/elm.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://elm-lang.org",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "0.18",
     "url": "https://44a95588fe4cc47efd96-ec3c2a753a12d2be9f23ba16873acc23.ssl.cf2.rackcdn.com/Elm-Platform-0.18.exe#dl.7z",
     "hash": "e4b392e2cb8deb0bcf6c4d0b5f69f4df187416ea815d4ab09bafa5c036640967",

--- a/bucket/erlang.json
+++ b/bucket/erlang.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.erlang.org",
     "version": "20.3",
-    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "http://erlang.org/download/otp_win64_20.3.exe",

--- a/bucket/eventstore.json
+++ b/bucket/eventstore.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://eventstore.org/",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "4.1.0",
     "url": "https://eventstore.org/downloads/EventStore-OSS-Win-v4.1.0.zip",
     "hash": "4377159cccbe90e59c974598a630ba8f904d24daa082bc35478fd47af3816d64",

--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -1,7 +1,7 @@
 {
     "version": "20180420-30940be",
     "homepage": "https://ffmpeg.zeranoe.com/builds/",
-    "license": "GPL3",
+    "license": "GPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20180420-30940be-win64-static.zip",

--- a/bucket/ffmpeg.json
+++ b/bucket/ffmpeg.json
@@ -1,7 +1,7 @@
 {
     "version": "3.4.2",
     "homepage": "https://ffmpeg.zeranoe.com/builds/",
-    "license": "GPL3",
+    "license": "GPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-3.4.2-win64-static.zip",

--- a/bucket/file.json
+++ b/bucket/file.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://gnuwin32.sourceforge.net/packages/file.htm",
     "version": "5.03",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "url": [
         "https://sourceforge.net/projects/gnuwin32/files/file/5.03/file-5.03-bin.zip",
         "https://sourceforge.net/projects/gnuwin32/files/file/5.03/file-5.03-dep.zip"

--- a/bucket/findutils.json
+++ b/bucket/findutils.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.mingw.org/wiki/msys",
     "version": "4.4.2",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "url": [
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.13-2/msysCORE-1.0.13-2-msys-1.0.13-bin.tar.lzma",
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/gettext/gettext-0.17-2/libintl-0.17-2-msys-dll-8.tar.lzma",

--- a/bucket/flatc.json
+++ b/bucket/flatc.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://google.github.io/flatbuffers/index.html",
-    "license": "Apache2",
+    "license": "Apache-2.0",
     "version": "1.9.0",
     "url": "https://github.com/google/flatbuffers/releases/download/v1.9.0/flatc_windows_exe.zip",
     "bin": "flatc.exe",

--- a/bucket/flyway.json
+++ b/bucket/flyway.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://flywaydb.org/",
-    "license": "https://github.com/flyway/flyway/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "5.0.7",
     "url": "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/5.0.7/flyway-commandline-5.0.7-windows-x64.zip",
     "extract_dir": "flyway-5.0.7",

--- a/bucket/fnproject.json
+++ b/bucket/fnproject.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://fnproject.io/",
-    "license": "https://github.com/fnproject/cli/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "0.4.73",
     "architecture": {
         "64bit": {

--- a/bucket/fossil.json
+++ b/bucket/fossil.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.fossil-scm.org/",
     "version": "2.5",
-    "license": "https://www.fossil-scm.org/index.html/doc/trunk/COPYRIGHT-BSD2.txt",
+    "license": "BSD-2-Clause",
     "hash": "cad1caf56db436ca2a29e7b4919459482832dea6f6f3114258d28cbbfbc6bcb6",
     "url": "https://www.fossil-scm.org/index.html/uv/fossil-w32-2.5.zip",
     "bin": "fossil.exe",

--- a/bucket/gawk.json
+++ b/bucket/gawk.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.mingw.org/wiki/MSYS",
     "version": "3.1.7",
-    "license": "GPL3",
+    "license": "GPL-3.0",
     "url": [
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/gawk/gawk-3.1.7-2/gawk-3.1.7-2-msys-1.0.13-bin.tar.lzma",
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.18-1/msysCORE-1.0.18-1-msys-1.0.18-bin.tar.lzma",

--- a/bucket/gcc.json
+++ b/bucket/gcc.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://mingw-w64.org",
     "version": "7.2.0",
-    "license": "GPL3",
+    "license": "GPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.2.0/threads-posix/seh/x86_64-7.2.0-release-posix-seh-rt_v5-rev1.7z",

--- a/bucket/ghostscript.json
+++ b/bucket/ghostscript.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.ghostscript.com",
     "version": "9.23",
-    "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+    "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/gs923w64.exe#/dl.7z",

--- a/bucket/gibo.json
+++ b/bucket/gibo.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.6",
     "homepage": "https://github.com/simonwhitaker/gibo",
-    "license": "https://github.com/simonwhitaker/gibo/blob/master/UNLICENSE",
+    "license": "Unlicense",
     "description": "gibo (short for .gitignore boilerplates) is a shell script to help you easily access .gitignore boilerplates from github.com/github/gitignore.",
     "url": "https://github.com/simonwhitaker/gibo/archive/1.0.6.zip",
     "hash": "0072748745d46a968834655b1b0e7f14307875b002cd516adc6f95d24f9f495c",

--- a/bucket/git-up.json
+++ b/bucket/git-up.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/msiemens/PyGitUp",
-    "license": "https://github.com/msiemens/PyGitUp/blob/master/LICENCE",
+    "license": "MIT",
     "version": "1.4.6",
     "url": "https://github.com/msiemens/PyGitUp/archive/v1.4.6.zip",
     "hash": "1d5becf87fbe311124d01c722e5f3621bcfff19d9328810f6a6768aa8659c6e5",

--- a/bucket/git-with-openssh.json
+++ b/bucket/git-with-openssh.json
@@ -1,7 +1,7 @@
 {
     "##": "Maintainers: when updating this manifest to a new version, you might like to also update git.json",
     "homepage": "https://git-for-windows.github.io/",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "version": "2.17.0.windows.1",
     "architecture": {
         "64bit": {

--- a/bucket/git.json
+++ b/bucket/git.json
@@ -1,7 +1,7 @@
 {
     "##": "Maintainers: when updating this manifest to a new version, you might like to also update git-with-openssh.json",
     "homepage": "https://git-for-windows.github.io/",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "version": "2.17.0.windows.1",
     "architecture": {
         "64bit": {

--- a/bucket/git19.json
+++ b/bucket/git19.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://git-for-windows.github.io/",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "version": "1.9.5-preview20150319",
     "url": "https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20150319/PortableGit-1.9.5-preview20150319.7z",
     "hash": "26261872847b18d171a197c8e4b3f4c0e60b4310c4b8ef1f4d9884950288aa7c",

--- a/bucket/glide.json
+++ b/bucket/glide.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://glide.sh/",
-    "license": "https://github.com/Masterminds/glide/blob/master/LICENSE",
+    "license": "MIT",
     "version": "0.13.1",
     "architecture": {
         "64bit": {

--- a/bucket/gnupg.json
+++ b/bucket/gnupg.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.gnupg.org/",
     "version": "2.2.5",
-    "license": "GPLv3",
+    "license": "GPL-3.0",
     "url": "https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32-2.2.5_20180222.exe#/dl.7z",
     "hash": "sha1:080f801e833c7a9e0441d55cd19d4bdb5bb261f9",
     "env_add_path": "bin",

--- a/bucket/gnupg1.json
+++ b/bucket/gnupg1.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.gnupg.org/",
     "version": "1.4.22",
-    "license": "GPLv3",
+    "license": "GPL-3.0",
     "url": "https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32cli-1.4.22.exe#/dl.7z",
     "hash": "7d0344a951ca49d34d2a884c9962d5104f73b637aeef717f33ee25c7a0465dca",
     "bin": [

--- a/bucket/go.json
+++ b/bucket/go.json
@@ -1,7 +1,7 @@
 {
     "version": "1.10.1",
     "homepage": "https://golang.org",
-    "license": "https://golang.org/LICENSE",
+    "license": "BSD-3-Clause",
     "extract_dir": "go",
     "env_set": {
         "GOROOT": "$dir"

--- a/bucket/gource.json
+++ b/bucket/gource.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://gource.io/",
     "version": "0.47",
-    "license": "GPL3",
+    "license": "GPL-3.0",
     "url": "https://github.com/acaudwell/Gource/releases/download/gource-0.47/gource-0.47.win64.zip",
     "checkver": {
         "url": "https://github.com/acaudwell/Gource/releases/latest",

--- a/bucket/gpg.json
+++ b/bucket/gpg.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.gnupg.org/",
     "version": "2.2.5",
-    "license": "GPLv3",
+    "license": "GPL-3.0",
     "url": "https://www.gnupg.org/ftp/gcrypt/binary/gnupg-w32-2.2.5_20180222.exe#/dl.7z",
     "hash": "sha1:080f801e833c7a9e0441d55cd19d4bdb5bb261f9",
     "env_add_path": "bin",

--- a/bucket/gradle.json
+++ b/bucket/gradle.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://gradle.org",
     "version": "4.7",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "hash": "fca5087dc8b50c64655c000989635664a73b11b9bd3703c7d6cabd31b7dcdb04",
     "url": "https://services.gradle.org/distributions/gradle-4.7-bin.zip",
     "extract_dir": "gradle-4.7",

--- a/bucket/grails.json
+++ b/bucket/grails.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://grails.org/",
     "version": "3.3.5",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://github.com/grails/grails-core/releases/download/v3.3.5/grails-3.3.5.zip",
     "hash": "b5840f3272b7bbec2c3b4c221b540e8d881ab463ff596d5ceb7b64bad892261d",
     "extract_dir": "grails-3.3.5",

--- a/bucket/graphicsmagick-q16.json
+++ b/bucket/graphicsmagick-q16.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.graphicsmagick.org/",
-    "license": "http://www.graphicsmagick.org/Copyright.html",
+    "license": "MIT",
     "version": "1.3.28",
     "architecture": {
         "64bit": {

--- a/bucket/graphicsmagick-q8.json
+++ b/bucket/graphicsmagick-q8.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.graphicsmagick.org/",
-    "license": "http://www.graphicsmagick.org/Copyright.html",
+    "license": "MIT",
     "version": "1.3.28",
     "architecture": {
         "64bit": {

--- a/bucket/grep.json
+++ b/bucket/grep.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://gnuwin32.sourceforge.net/packages/grep.htm",
     "version": "2.5.4",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "url": [
         "https://sourceforge.net/projects/gnuwin32/files/grep/2.5.4/grep-2.5.4-bin.zip",
         "https://sourceforge.net/projects/gnuwin32/files/grep/2.5.4/grep-2.5.4-dep.zip"

--- a/bucket/groovy.json
+++ b/bucket/groovy.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.groovy-lang.org/",
     "version": "2.4.15",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.15.zip",
     "hash": "bd4ca37a4d1b3704526d56fc48c119a8f70d418093d8703724407d65250f4aed",
     "extract_dir": "groovy-2.4.15",

--- a/bucket/gzip.json
+++ b/bucket/gzip.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.mingw.org/wiki/msys",
     "version": "1.3.12",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "url": [
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/gzip/gzip-1.3.12-2/gzip-1.3.12-2-msys-1.0.13-bin.tar.lzma",
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.18-1/msysCORE-1.0.18-1-msys-1.0.18-bin.tar.lzma"

--- a/bucket/hashcat.json
+++ b/bucket/hashcat.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://hashcat.net/hashcat/",
-    "license": "mit",
+    "license": "MIT",
     "version": "4.1.0",
     "url": "https://hashcat.net/files/hashcat-4.1.0.7z",
     "extract_dir": "hashcat-4.1.0",

--- a/bucket/haxe.json
+++ b/bucket/haxe.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://haxe.org/",
     "version": "3.4.7",
-    "license": "https://haxe.org/foundation/open-source.html",
+    "license": "GPL-2.0-or-later",
     "url": "https://github.com/HaxeFoundation/haxe/releases/download/3.4.7/haxe-3.4.7-win.zip",
     "hash": "d98b0f0e5c5bb000e9b9e99817c45af362658c9273e66ce5cb52359e6ade15a6",
     "bin": [

--- a/bucket/helm.json
+++ b/bucket/helm.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://helm.sh/",
-    "license": "https://github.com/kubernetes/helm/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "2.8.2",
     "architecture": {
         "64bit": {

--- a/bucket/highlight.json
+++ b/bucket/highlight.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.andre-simon.de/doku/highlight/en/highlight.php",
     "version": "3.42",
-    "license": "GPL3",
+    "license": "GPL-3.0",
     "architecture": {
         "64bit": {
             "url": "http://www.andre-simon.de/zip/highlight-3.42-x64.zip",

--- a/bucket/hugo.json
+++ b/bucket/hugo.json
@@ -1,6 +1,6 @@
 {
     "version": "0.39",
-    "license": "https://github.com/spf13/hugo/blob/master/LICENSE.md",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/spf13/hugo/releases/download/v0.39/hugo_0.39_windows-64bit.zip",

--- a/bucket/iconv.json
+++ b/bucket/iconv.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.mingw.org/",
     "version": "1.14-3",
-    "license": "GPLv3+",
+    "license": "GPL-3.0-or-later",
     "url": [
         "https://sourceforge.net/projects/mingw/files/MinGW/Base/libiconv/libiconv-1.14-3/libiconv-1.14-3-mingw32-bin.tar.lzma",
         "https://sourceforge.net/projects/mingw/files/MinGW/Base/libiconv/libiconv-1.14-3/libiconv-1.14-3-mingw32-dll.tar.lzma",

--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.imagemagick.org/script/index.php",
-    "license": "https://www.imagemagick.org/script/license.php",
+    "license": "ImageMagick",
     "version": "7.0.7-28",
     "architecture": {
         "64bit": {

--- a/bucket/invoke-build.json
+++ b/bucket/invoke-build.json
@@ -1,6 +1,6 @@
 {
     "version": "5.4.1",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "extract_dir": "tools",
     "url": "https://nuget.org/api/v2/package/Invoke-Build/5.4.1#/dl.7z",
     "homepage": "https://github.com/nightroman/Invoke-Build",

--- a/bucket/jq.json
+++ b/bucket/jq.json
@@ -1,6 +1,6 @@
 {
     "version": "1.5",
-    "license": "https://creativecommons.org/licenses/by/3.0/",
+    "license": "MIT",
     "architecture": {
         "32bit": {
             "url": "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-win32.exe#/jq.exe",

--- a/bucket/kompose.json
+++ b/bucket/kompose.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://kompose.io",
     "description": "Kompose is a conversion tool for Docker Compose to container orchestrators such as Kubernetes (or OpenShift).",
-    "license": "https://raw.githubusercontent.com/kubernetes/kompose/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "1.12.0",
     "architecture": {
         "64bit": {

--- a/bucket/kotlin-native.json
+++ b/bucket/kotlin-native.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://kotlinlang.org/",
     "version": "0.6.2",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://github.com/JetBrains/kotlin-native/releases/download/v0.6.2/kotlin-native-windows-0.6.2.zip",
     "hash": "e0f38cbf653a1942b4e3a6619f27a9c1cbed5cff47a7e7bcd68c0b623147f6a4",
     "extract_dir": "kotlin-native-windows-0.6.2",

--- a/bucket/kotlin.json
+++ b/bucket/kotlin.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://kotlinlang.org/",
     "version": "1.2.40",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://github.com/JetBrains/kotlin/releases/download/v1.2.40/kotlin-compiler-1.2.40.zip",
     "hash": "3498571126c335be0feec24075c359f1954d46bbabccafc729ec49db1a509658",
     "extract_dir": "kotlinc",

--- a/bucket/kubectl.json
+++ b/bucket/kubectl.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://kubernetes.io/docs/user-guide/kubectl-overview/",
-    "license": "https://github.com/kubernetes/kubernetes/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "1.10.1",
     "architecture": {
         "64bit": {

--- a/bucket/kvm.json
+++ b/bucket/kvm.json
@@ -1,6 +1,6 @@
 {
     "version": "latest",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": [
         "https://raw.githubusercontent.com/aspnet/Home/release/kvm.ps1"
     ],

--- a/bucket/lessmsi.json
+++ b/bucket/lessmsi.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/activescott/lessmsi/",
     "version": "1.6.1",
-    "license": "https://github.com/activescott/lessmsi/raw/master/LICENSE",
+    "license": "MIT",
     "hash": "540b8801e08ec39ba26a100c855898f455410cecbae4991afae7bb2b4df026c7",
     "url": "https://github.com/activescott/lessmsi/releases/download/v1.6.1/lessmsi-v1.6.1.zip",
     "bin": "lessmsi.exe",

--- a/bucket/llvm.json
+++ b/bucket/llvm.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.llvm.org/",
     "version": "6.0.0",
-    "license": "University of Illinois/NCSA Open Source License",
+    "license": "NCSA",
     "architecture": {
         "32bit": {
             "url": "https://releases.llvm.org/6.0.0/LLVM-6.0.0-win32.exe#/llvm.7z",

--- a/bucket/mailsend.json
+++ b/bucket/mailsend.json
@@ -1,6 +1,6 @@
 {
     "version": "1.19",
-    "license": "https://github.com/muquit/mailsend/blob/master/COPYRIGHT",
+    "license": "BSD-3-Clause",
     "url": "https://github.com/muquit/mailsend/releases/download/1.19/mailsend1.19.exe.zip",
     "homepage": "https://github.com/muquit/mailsend",
     "checkver": {

--- a/bucket/make.json
+++ b/bucket/make.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.gnu.org/software/make/",
     "version": "4.2",
-    "license": "GPLv3",
+    "license": "GPL-3.0",
     "architecture": {
         "64bit": {
             "url": "ftp://ftp.equation.com/make/64/make.exe",

--- a/bucket/mariadb.json
+++ b/bucket/mariadb.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://mariadb.org",
     "version": "10.2.14",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "architecture": {
         "64bit": {
             "url": "https://downloads.mariadb.org/f/mariadb-10.2.14/winx64-packages/mariadb-10.2.14-winx64.zip",

--- a/bucket/maven.json
+++ b/bucket/maven.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://maven.apache.org/",
     "version": "3.5.3",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://archive.apache.org/dist/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.zip",
     "hash": "sha1:4a4844990333e2548540729ce9ab57f52a63148d",
     "extract_dir": "apache-maven-3.5.3",

--- a/bucket/mercurial.json
+++ b/bucket/mercurial.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.mercurial-scm.org/",
     "version": "4.5.3",
-    "license": "https://www.gnu.org/licenses/gpl-2.0.txt",
+    "license": "GPL-2.0",
     "architecture": {
         "64bit": {
             "url": "https://www.mercurial-scm.org/release/windows/Mercurial-4.5.3-x64.exe",

--- a/bucket/minikube.json
+++ b/bucket/minikube.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://kubernetes.io/docs/getting-started-guides/minikube/",
-    "license": "https://github.com/kubernetes/minikube/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "0.26.1",
     "architecture": {
         "64bit": {

--- a/bucket/minio-client.json
+++ b/bucket/minio-client.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://minio.io/",
-    "license": "https://github.com/minio/mc/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "2018-03-25T01-22-22Z",
     "bin": "mc.exe",
     "architecture": {

--- a/bucket/minio.json
+++ b/bucket/minio.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://minio.io/",
-    "license": "https://github.com/minio/minio/blob/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "2018-04-19T22-54-58Z",
     "bin": "minio.exe",
     "architecture": {

--- a/bucket/minishift.json
+++ b/bucket/minishift.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.openshift.org/minishift",
     "description": "Minishift is a tool that helps you run OpenShift locally by running a single-node OpenShift cluster inside a VM. You can try out OpenShift or develop with it, day-to-day, on your local host.",
-    "license": "https://raw.githubusercontent.com/minishift/minishift/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "1.16.1",
     "architecture": {
         "64bit": {

--- a/bucket/minisign.json
+++ b/bucket/minisign.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://jedisct1.github.io/minisign/",
     "description": "A dead simple tool to sign files and verify signatures",
-    "license": "https://github.com/jedisct1/minisign/blob/master/LICENSE",
+    "license": "ISC",
     "version": "0.8",
     "url": "https://github.com/jedisct1/minisign/releases/download/0.8/minisign-win32.zip",
     "hash": "e74849a99547c724e797a4115ead199fe0558cb234d0d2d1655b10d236d1b5c4",

--- a/bucket/modd.json
+++ b/bucket/modd.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://corte.si/posts/modd/announce/index.html",
-    "license": "https://github.com/cortesi/modd/blob/master/LICENSE",
+    "license": "MIT",
     "version": "0.5",
     "url": "https://github.com/cortesi/modd/releases/download/v0.5/modd-0.5-windows64.zip",
     "hash": "0417e71834aba98a58fc9b65395a8212f39a7fa336cb95cdf2005ebc28315d05",

--- a/bucket/mongodb.json
+++ b/bucket/mongodb.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.mongodb.org",
     "version": "3.6.4",
-    "license": "https://www.mongodb.org/about/licensing/",
+    "license": "AGPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-3.6.4-signed.msi",

--- a/bucket/mono.json
+++ b/bucket/mono.json
@@ -1,7 +1,7 @@
 {
     "version": "5.10.1.47",
     "homepage": "http://www.mono-project.com/",
-    "license": "https://raw.githubusercontent.com/mono/mono/master/LICENSE",
+    "license": "MIT",
     "url": "https://download.mono-project.com/archive/5.10.1/windows-installer/mono-5.10.1.47-gtksharp-2.12.45-win32-0.msi",
     "hash": "5e97f7913bd96ee6b8a950ffc7238af2bbc1715e639a9a2114be13f69e36f71e",
     "extract_dir": "Mono",

--- a/bucket/mysql.json
+++ b/bucket/mysql.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://dev.mysql.com/downloads/mysql/",
     "version": "5.7.22",
-    "license": "GPLv2",
+    "license": "GPL-2.0",
     "architecture": {
         "64bit": {
             "url": "https://dev.mysql.com/get/mysql-5.7.22-winx64.zip",

--- a/bucket/neko.json
+++ b/bucket/neko.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://nekovm.org/",
     "version": "2.2.0",
-    "license": "https://github.com/HaxeFoundation/neko/blob/master/LICENSE",
+    "license": "MIT",
     "url": "https://nekovm.org/media/neko-2.2.0-win.zip",
     "hash": "93d7ca96698a6825f38ca8eea49e2e6b691c0849270174f6c1bd531290db8d69",
     "extract_dir": "neko-2.2.0-win",

--- a/bucket/ninja.json
+++ b/bucket/ninja.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://ninja-build.org/",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "version": "1.8.2",
     "url": "https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip",
     "hash": "c80313e6c26c0b9e0c241504718e2d8bbc2798b73429933adf03fdc6d84f0e70",

--- a/bucket/nuget.json
+++ b/bucket/nuget.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.nuget.org/",
     "version": "4.6.2",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://dist.nuget.org/win-x86-commandline/v4.6.2/NuGet.exe",
     "hash": "2c562c1a18d720d4885546083ec8eaad6773a6b80befb02564088cc1e55b304e",
     "bin": "NuGet.exe",

--- a/bucket/openjdk.json
+++ b/bucket/openjdk.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/ojdkbuild/ojdkbuild",
     "version": "1.8.0.161-1",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ojdkbuild/ojdkbuild/releases/download/1.8.0.161-1/java-1.8.0-openjdk-1.8.0.161-1.b14.ojdkbuild.windows.x86_64.zip",

--- a/bucket/openshift-origin-client.json
+++ b/bucket/openshift-origin-client.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.openshift.org",
     "description": "OpenShift Origin is a distribution of Kubernetes optimized for continuous application development and multi-tenant deployment. OpenShift adds developer and operations-centric tools on top of Kubernetes to enable rapid application development, easy deployment and scaling, and long-term lifecycle maintenance for small and large teams.",
-    "license": "https://raw.githubusercontent.com/openshift/origin/master/LICENSE",
+    "license": "Apache-2.0",
     "version": "3.9.0",
     "architecture": {
         "64bit": {

--- a/bucket/openssl.json
+++ b/bucket/openssl.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
     "version": "1.1.0h",
-    "license": "https://www.openssl.org/source/license.html",
+    "license": "OpenSSL",
     "architecture": {
         "64bit": {
             "url": "https://slproweb.com/download/Win64OpenSSL-1_1_0h.exe",

--- a/bucket/pester.json
+++ b/bucket/pester.json
@@ -1,7 +1,7 @@
 {
     "description": "Pester is a test and mock framework for PowerShell.",
     "version": "4.3.1",
-    "license": "https://raw.githubusercontent.com/pester/Pester/master/LICENSE",
+    "license": "Apache-2.0",
     "url": "https://github.com/pester/pester/archive/4.3.1.tar.gz",
     "homepage": "https://github.com/pester/Pester",
     "hash": "34cabbfb33d46f9a91386308a3b86023af602845980b6c8507979db5c29214d0",

--- a/bucket/php-nts.json
+++ b/bucket/php-nts.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://windows.php.net",
     "version": "7.2.4",
-    "license": "https://php.net/license/",
+    "license": "PHP-3.01",
     "architecture": {
         "64bit": {
             "url": "https://windows.php.net/downloads/releases/php-7.2.4-nts-Win32-VC15-x64.zip",

--- a/bucket/php.json
+++ b/bucket/php.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://windows.php.net",
     "version": "7.2.4",
-    "license": "https://php.net/license/",
+    "license": "PHP-3.01",
     "architecture": {
         "64bit": {
             "url": "https://windows.php.net/downloads/releases/php-7.2.4-Win32-VC15-x64.zip",

--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.postgresql.org/",
     "version": "10.3",
-    "license": "https://www.postgresql.org/about/licence/",
+    "license": "PostgreSQL",
     "architecture": {
         "64bit": {
             "url": "https://get.enterprisedb.com/postgresql/postgresql-10.3-1-windows-x64-binaries.zip",

--- a/bucket/premake4.json
+++ b/bucket/premake4.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://premake.github.io/download.html",
     "version": "4.4-b5",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "url": "https://downloads.sourceforge.net/project/premake/Premake/4.4/premake-4.4-beta5-windows.zip",
     "hash": "09614c122156617a2b7973cc9f686daa32e64e3e7335d38db887cfb8f6a8574d",
     "bin": [

--- a/bucket/premake5.json
+++ b/bucket/premake5.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://premake.github.io/",
     "version": "5.0.0-alpha12",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "url": "https://github.com/premake/premake-core/releases/download/v5.0.0-alpha12/premake-5.0.0-alpha12-windows.zip",
     "hash": "d12ee2f8cfa0ab29a08c9bcaab3a5f76e575ae000b1596ee61d4f4916e9d154c",
     "bin": [

--- a/bucket/r.json
+++ b/bucket/r.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.r-project.org",
     "version": "3.4.4",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "architecture": {
         "64bit": {
             "url": "https://cran.rstudio.com/bin/windows/base/R-3.4.4-win.exe",

--- a/bucket/racket.json
+++ b/bucket/racket.json
@@ -1,7 +1,7 @@
 {
     "version": "6.12",
     "homepage": "https://racket-lang.org",
-    "license": "LGPL",
+    "license": "LGPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://mirror.racket-lang.org/installers/6.12/racket-6.12-x86_64-win32.exe#/dl.7z",

--- a/bucket/radare2.json
+++ b/bucket/radare2.json
@@ -1,6 +1,6 @@
 {
     "version": "2.5.0",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "homepage": "https://www.radare.org/r/",
     "architecture": {
         "64bit": {

--- a/bucket/rancher-compose.json
+++ b/bucket/rancher-compose.json
@@ -11,7 +11,7 @@
             "hash": "465e651c5fedcdd91417a7e25bcab351c9e99732192263afbcb91496138ef7d9"
         }
     },
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "extract_dir": "rancher-compose-v0.12.5",
     "bin": [
         "rancher-compose.exe"

--- a/bucket/rclone.json
+++ b/bucket/rclone.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://rclone.org",
     "version": "1.40",
-    "license": "https://github.com/ncw/rclone/blob/master/COPYING",
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/ncw/rclone/releases/download/v1.40/rclone-v1.40-windows-amd64.zip",

--- a/bucket/red.json
+++ b/bucket/red.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.red-lang.org",
     "version": "0.6.3",
-    "license": "BSD-3 and BSL",
+    "license": "BSD-3 AND BSL-1.0",
     "url": "https://static.red-lang.org/dl/win/red-063.exe#/red.exe",
     "hash": "105d0f7b009a802a35a636c5dbedc69e89477fd62b6ba77690845fd78d436171",
     "bin": "red.exe",

--- a/bucket/restic.json
+++ b/bucket/restic.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://restic.github.io/",
     "version": "0.8.3",
-    "license": "https://github.com/restic/restic/blob/master/LICENSE",
+    "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
             "url": "https://github.com/restic/restic/releases/download/v0.8.3/restic_0.8.3_windows_amd64.zip",

--- a/bucket/rethinkdb.json
+++ b/bucket/rethinkdb.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.rethinkdb.com/",
-    "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+    "license": "AGPL-3.0",
     "version": "2.3.6",
     "architecture": {
         "64bit": {

--- a/bucket/rtmpdump.json
+++ b/bucket/rtmpdump.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://rtmpdump.mplayerhq.hu/",
     "version": "2.3",
-    "license": "GPLv2",
+    "license": "GPL-2.0",
     "url": "https://rtmpdump.mplayerhq.hu/download/rtmpdump-2.3-windows.zip",
     "hash": "6948aa372f04952d5675917c6ca2c7c0bf6b109de21a4323adc93247fff0189f",
     "extract_dir": "rtmpdump-2.3",

--- a/bucket/rust-msvc.json
+++ b/bucket/rust-msvc.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.rust-lang.org",
     "version": "1.25.0",
-    "license": "MIT/Apache 2.0",
+    "license": "MIT OR Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://static.rust-lang.org/dist/rust-1.25.0-x86_64-pc-windows-msvc.msi",

--- a/bucket/rust.json
+++ b/bucket/rust.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.rust-lang.org",
     "version": "1.25.0",
-    "license": "MIT/Apache 2.0",
+    "license": "MIT OR Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://static.rust-lang.org/dist/rust-1.25.0-x86_64-pc-windows-gnu.msi",

--- a/bucket/scala.json
+++ b/bucket/scala.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.scala-lang.org/",
     "version": "2.12.5",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "url": "https://downloads.typesafe.com/scala/2.12.5/scala-2.12.5.zip",
     "hash": "98d9e46f8ebe3696739a2016e0d763877c0242b265bb7cce9ee3ac828fe2bb14",
     "extract_dir": "scala-2.12.5",

--- a/bucket/scholdoc.json
+++ b/bucket/scholdoc.json
@@ -1,6 +1,6 @@
 {
     "version": "0.1.3-alpha",
-    "license": "",
+    "license": "GPL-2.0",
     "extract_dir": "Scholdoc",
     "url": "http://scholarlymarkdown.com/scholdoc-distribution/windows/scholdoc-0.1.3-alpha-windows.msi",
     "homepage": "http://scholdoc.scholarlymarkdown.com/",

--- a/bucket/scriptcs.json
+++ b/bucket/scriptcs.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://scriptcs.net/",
     "version": "0.17.1",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "url": "https://chocolatey.org/api/v2/package/ScriptCs/0.17.1?fn=/dl.zip",
     "hash": "4b6de155f6c5811311df060b626098a771e8534d2d6e3ce51ea99da5e2ec0783",
     "extract_dir": "tools",

--- a/bucket/sed.json
+++ b/bucket/sed.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://gnuwin32.sourceforge.net/packages/sed.htm",
     "version": "4.2.1",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "url": [
         "https://sourceforge.net/projects/gnuwin32/files/sed/4.2.1/sed-4.2.1-bin.zip",
         "https://sourceforge.net/projects/gnuwin32/files/sed/4.2.1/sed-4.2.1-dep.zip"

--- a/bucket/sonarqube.json
+++ b/bucket/sonarqube.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.sonarqube.org",
     "version": "7.1",
-    "license": "GNU Lesser GPL License, Version 3",
+    "license": "LGPL-3.0",
     "url": "https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.1.zip",
     "hash": "sha1:5777921d4f9789b34d3f2a883c3d75e23246d8db",
     "architecture": {

--- a/bucket/stack.json
+++ b/bucket/stack.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.haskellstack.org",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1.6.5",
     "architecture": {
         "64bit": {

--- a/bucket/syncany-cli.json
+++ b/bucket/syncany-cli.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.syncany.org/",
     "description": "An open-source cloud storage and filesharing application. Securely synchronize your files to any kind of storage!",
-    "license": "https://raw.githubusercontent.com/syncany/syncany/develop/LICENSE.md",
+    "license": "GPL-3.0-or-later",
     "version": "0.4.9",
     "url": "https://www.syncany.org/dist/releases/syncany-cli-0.4.9-alpha.exe",
     "hash": "6ee34b4767689abc983c0e5632dc4502cc3689e4e2d7f89f03a0a6afe67a44d8",

--- a/bucket/tar.json
+++ b/bucket/tar.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://www.mingw.org/wiki/msys",
     "version": "1.23",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "depends": "gzip",
     "url": [
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/tar/tar-1.23-1/tar-1.23-1-msys-1.0.13-bin.tar.lzma",

--- a/bucket/telnet.json
+++ b/bucket/telnet.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.mingw.org/wiki/msys",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "version": "msys-inetutils-1.7-1",
     "url": [
         "https://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.13-2/msysCORE-1.0.13-2-msys-1.0.13-bin.tar.lzma",

--- a/bucket/terraform.json
+++ b/bucket/terraform.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.terraform.io",
-    "license": "Mozilla Public License 2.0",
+    "license": "MPL-2.0",
     "version": "0.11.7",
     "architecture": {
         "64bit": {

--- a/bucket/thrift.json
+++ b/bucket/thrift.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://thrift.apache.org/",
     "version": "0.11.0",
-    "license": "Apache License v2.0",
+    "license": "Apache-2.0",
     "url": "https://www-us.apache.org/dist/thrift/0.11.0/thrift-0.11.0.exe#/thrift.exe",
     "hash": "29a45c267f64ada6663fd449677b4d8ba3b4b3c772a9fd23910f876a224c2776",
     "bin": "thrift.exe",

--- a/bucket/transmission-cli.json
+++ b/bucket/transmission-cli.json
@@ -1,7 +1,7 @@
 {
     "version": "2.92",
     "homepage": "https://transmissionbt.com/",
-    "license": "https://github.com/transmission/transmission/blob/master/COPYING",
+    "license": "GPL-2.0 OR GPL-3.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/transmission/transmission/releases/download/2.92/transmission-2.92-x64.msi",

--- a/bucket/tunnel.json
+++ b/bucket/tunnel.json
@@ -1,7 +1,7 @@
 {
     "version": "0.2.5",
     "homepage": "https://github.com/labstack/tunnel",
-    "license": "https://github.com/labstack/tunnel/blob/master/LICENSE",
+    "license": "MIT",
     "architecture": {
         "32bit": {
             "url": "https://github.com/labstack/tunnel/releases/download/0.2.5/tunnel_0.2.5_windows_32-bit.zip",

--- a/bucket/unar.json
+++ b/bucket/unar.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://theunarchiver.com/command-line",
-    "license": "GPL2.1",
+    "license": "GPL-2.0",
     "version": "1.8.1",
     "url": "https://cdn.theunarchiver.com/downloads/unarWindows.zip",
     "hash": "61A6B299606282F72F51C278801EAC11D3DCCFAC83E2D68BCCCE33539912E0DD",

--- a/bucket/unbound.json
+++ b/bucket/unbound.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://unbound.net/",
     "version": "1.7.0",
-    "license": "BSD",
+    "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
             "url": "https://unbound.net/downloads/unbound-1.7.0.zip",

--- a/bucket/up.json
+++ b/bucket/up.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/apex/up",
-    "license": "https://github.com/apex/up/blob/master/LICENSE",
+    "license": "GPL-3.0",
     "version": "0.6.1",
     "architecture": {
         "64bit": {

--- a/bucket/upx.json
+++ b/bucket/upx.json
@@ -6,7 +6,7 @@
     "hash": "74308db1183436576d011bfcc3e7c99c836fb052de7b7eb0539026366453d6e8",
     "extract_dir": "upx394w",
     "bin": "upx.exe",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "checkver": {
         "github": "https://github.com/upx/upx"
     },

--- a/bucket/vault.json
+++ b/bucket/vault.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.vaultproject.io",
-    "license": "Mozilla Public License 2.0",
+    "license": "MPL-2.0",
     "version": "0.10.0",
     "architecture": {
         "64bit": {

--- a/bucket/vbindiff.json
+++ b/bucket/vbindiff.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.cjmweb.net/vbindiff/",
     "version": "3.0-beta5",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "url": "https://www.cjmweb.net/vbindiff/VBinDiff-3.0_beta5.zip",
     "hash": "05e52b50d9101f9903cc1342fcc307eacf70485e8d942d43c7a440648c9c3a7f",
     "bin": "vbindiff.exe"

--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.vim.org",
-    "license": "http://vimdoc.sourceforge.net/htmldoc/uganda.html#license",
+    "license": "Vim",
     "version": "8.0.1737",
     "architecture": {
         "32bit": {

--- a/bucket/vimtutor.json
+++ b/bucket/vimtutor.json
@@ -1,6 +1,6 @@
 {
     "version": "3653063",
-    "license": "https://github.com/lukesampson/psutils/blob/master/LICENSE",
+    "license": "MIT",
     "url": "https://raw.github.com/lukesampson/psutils/3653063/vimtutor.ps1",
     "homepage": "https://github.com/lukesampson/psutils",
     "hash": "f6081071fa95a6f49c049e9d2aed2d2a2632ec47635b4b497a97bab5f5add498",

--- a/bucket/wget.json
+++ b/bucket/wget.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://eternallybored.org/misc/wget/",
-    "license": "GPL3",
+    "license": "GPL-3.0",
     "version": "1.19.4",
     "architecture": {
         "64bit": {

--- a/bucket/which.json
+++ b/bucket/which.json
@@ -1,7 +1,7 @@
 {
     "homepage": "http://gnuwin32.sourceforge.net/packages/which.htm",
     "version": "2.20",
-    "license": "GPL2",
+    "license": "GPL-2.0",
     "url": [
         "https://sourceforge.net/projects/gnuwin32/files/which/2.20/which-2.20-bin.zip"
     ],

--- a/bucket/win-acme.json
+++ b/bucket/win-acme.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/PKISharp/win-acme",
     "version": "1.9.10.1",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "hash": "3b129167220925d8a7130190a27a65a54912aa5d3c173eb66995a669e5572b59",
     "url": "https://github.com/PKISharp/win-acme/releases/download/v1.9.10.1/win-acme.v1.9.10.1.zip",
     "bin": "letsencrypt.exe",

--- a/bucket/wixtoolset.json
+++ b/bucket/wixtoolset.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://wixtoolset.org/",
-    "license": "https://github.com/wixtoolset/wix3/blob/develop/LICENSE.TXT",
+    "license": "MS-RL",
     "version": "3.11.1",
     "url": "https://github.com/wixtoolset/wix3/releases/download/wix3111rtm/wix311-binaries.zip",
     "hash": "37f0a533b0978a454efb5dc3bd3598becf9660aaf4287e55bf68ca6b527d051d",

--- a/bucket/yasm.json
+++ b/bucket/yasm.json
@@ -1,7 +1,7 @@
 {
     "description": "Modular assembler based on NASM",
     "homepage": "http://yasm.tortall.net/",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "version": "1.3.0",
     "architecture": {
         "64bit": {

--- a/bucket/zstd.json
+++ b/bucket/zstd.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://www.zstd.net/",
-    "license": "https://github.com/facebook/zstd/blob/dev/LICENSE",
+    "license": "BSD-3-Clause",
     "description": "Zstandard is a real-time compression algorithm, providing high compression ratios.",
     "version": "1.3.4",
     "architecture": {


### PR DESCRIPTION
This leads to more consistent license properties and allows for easier automated parsing. I left the custom URLs in packages that use custom licenses or whose license isn't clearly defined.

See the [SPDX License List](https://spdx.org/licenses/) for more information.