### PR TITLE
minishift - fix version extract dir (again)

### DIFF
--- a/bucket/minishift.json
+++ b/bucket/minishift.json
@@ -19,10 +19,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/minishift/minishift/releases/download/v$version/minishift-$version-windows-amd64.zip",
-                "extract_dir": "minishift-$version-windows-amd64"
+                "url": "https://github.com/minishift/minishift/releases/download/v$version/minishift-$version-windows-amd64.zip"
             }
         },
+        "extract_dir": "minishift-$version-windows-amd64",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/minishift.json
+++ b/bucket/minishift.json
@@ -9,7 +9,7 @@
             "hash": "769f586ce90dc6ca2d807c45614357829b8d5cf07edabdd2b6dbbabd71c9b86e"
         }
     },
-    "extract_dir": "minishift-1.16.0-windows-amd64",
+    "extract_dir": "minishift-1.16.1-windows-amd64",
     "bin": [
         "minishift.exe"
     ],


### PR DESCRIPTION
It seems that this field keeps getting missed when people are bumping versions, causing the install to fail.  I'm fixing it, but it would be nice if there were more places where you could put in `$version`, but it doesn't seem to be something you can just put anywhere you want, though.