### PR TITLE
Fix homepage url and file hash

### DIFF
--- a/bucket/git-annex.json
+++ b/bucket/git-annex.json
@@ -1,12 +1,12 @@
 {
     "description": "Manage files with git, without comitting them",
-    "homepage": "https://www.agwa.name/projects/git-crypt/",
+    "homepage": "http://git-annex.branchable.com/",
     "license": "GPL-3.0",
     "version": "6.20180427",
     "notes": "NOTE: Running `git-annex version` may report a slightly older version number",
     "bin": "usr/bin/git-annex.exe",
     "url": "https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe#/dl.7z",
-    "hash": "09c252e55706a58be8302b3b806591f7899d062404d866258fd3aa25349b6f8c",
+    "hash": "66c1743217e120f5056153d1882727a96d950df64c903d8af9773d317711fe01",
     "checkver": {
         "url": "https://hackage.haskell.org/package/git-annex",
         "re": "/git-annex-([\\d.]+)\\.tar\\.gz"


### PR DESCRIPTION
Fix error message ``Hash check failed ...``. Update file hash to match https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe.info