### PR TITLE
Refactor app() to parse_app() for better "bucket/app@version" handling

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -338,7 +338,7 @@ function ensure_architecture($architecture_opt) {
 function ensure_all_installed($apps, $global) {
     $installed = @()
     $apps | Select-Object -Unique | Where-Object { $_.name -ne 'scoop' } | ForEach-Object {
-        $app = $_
+        $app, $null, $null = parse_app $_
         if(installed $app $false) {
             $installed += ,@($app, $false)
         } elseif (installed $app $true) {
@@ -464,31 +464,15 @@ function applist($apps, $global) {
     return ,@($apps | ForEach-Object { ,@($_, $global) })
 }
 
-function app($app) {
+function parse_app($app) {
     $app = [string]$app
-    if($app -notmatch '^((ht)|f)tps?://') {
-        if($app -match '([a-zA-Z0-9-]+)/([a-zA-Z0-9-]+)') {
-            return $matches[2], $matches[1]
+    if($app -notmatch '^((ht)|f)tps?://' -and $app -notmatch '^(?:[\w]\:\\|\\\\)') {
+        if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>[a-zA-Z0-9-.]+)(?:@(?<version>.*))?') {
+            return $matches['app'], $matches['bucket'], $matches['version']
         }
     }
 
-    $app, $null
-}
-
-function is_app_with_specific_version([String] $app) {
-    $appWithVersion = get_app_with_version $app
-    $appWithVersion.version -ne 'latest'
-}
-
-function get_app_with_version([String] $app) {
-    $segments = $app -split '@'
-    $name     = $segments[0]
-    $version  = $segments[1];
-
-    return @{
-        "app" = $name;
-        "version" = if ($version) { $version } else { 'latest' }
-    }
+    $app, $null, $null
 }
 
 function last_scoop_update() {

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -20,10 +20,8 @@ function deps($app, $arch) {
 }
 
 function dep_resolve($app, $arch, $resolved, $unresolved) {
+    $app, $bucket, $null = parse_app $app
     $unresolved += $app
-
-    $query = $app
-    $app, $bucket = app $query
     $null, $manifest, $null, $null = locate $app $bucket
     if(!$manifest) { abort "Couldn't find manifest for '$app'$(if(!$bucket) { '.' } else { " from '$bucket' bucket." })" }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -10,8 +10,8 @@ function nightly_version($date, $quiet = $false) {
 }
 
 function install_app($app, $architecture, $global, $suggested, $use_cache = $true) {
-    $app, $bucket = app $app
-    $app, $manifest, $bucket, $url = locate $app $bucket
+    $app, $bucket, $null = parse_app $app
+    $app, $manifest, $null, $url = locate $app $bucket
     $check_hash = $true
 
     if(!$manifest) {
@@ -911,7 +911,7 @@ function show_notes($manifest, $dir, $original_dir, $persist_dir) {
 
 function all_installed($apps, $global) {
     $apps | Where-Object {
-        $app, $null = app $_
+        $app, $null, $null = parse_app $_
         installed $app $global
     }
 }
@@ -952,7 +952,7 @@ function show_suggestions($suggested) {
 
             $fulfilled = $false
             foreach($suggestion in $feature_suggestions) {
-                $suggested_app, $bucket = app $suggestion
+                $suggested_app, $bucket, $null = parse_app $suggestion
 
                 if($installed_apps -contains $suggested_app) {
                     $fulfilled = $true;

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -75,9 +75,8 @@ function supports_architecture($manifest, $architecture) {
     return -not [String]::IsNullOrEmpty((arch_specific 'url' $manifest $architecture))
 }
 
-function generate_user_manifest($app, $version) {
-
-    $null, $manifest, $bucket, $null = locate $app
+function generate_user_manifest($app, $bucket, $version) {
+    $null, $manifest, $bucket, $null = locate $app $bucket
     if ("$($manifest.version)" -eq "$version") {
         return manifest_path $app $bucket
     }

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -28,6 +28,8 @@ if($apps -eq '*') {
 $apps | ForEach-Object {
     ($app, $global) = $_
 
+    $app, $bucket, $version = parse_app $app
+
     if(($global -eq $null) -and (installed $app $true)) {
         # set global flag when running reset command on specific app
         $global = $true
@@ -38,16 +40,12 @@ $apps | ForEach-Object {
         return
     }
 
-    $appWithVersion = get_app_with_version $app
-    $app            = $appWithVersion.app;
-    $version        = $appWithVersion.version;
-
     if(!(installed $app)) {
         error "'$app' isn't installed"
         return
     }
 
-    if ($version -eq 'latest') {
+    if ($null -eq $version) {
         $version = current_version $app $global
     }
 

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -217,24 +217,52 @@ describe 'sanitary_path' {
 
 describe 'app' {
     it 'parses the bucket name from an app query' {
+        $query = "C:\test.json"
+        $app, $bucket, $version = parse_app $query
+        $app | should be "C:\test.json"
+        $bucket | should be $null
+        $version | should be $null
+
+        $query = "https://example.com/test.json"
+        $app, $bucket, $version = parse_app $query
+        $app | should be "https://example.com/test.json"
+        $bucket | should be $null
+        $version | should be $null
+
         $query = "test"
-        $app, $bucket = app $query
+        $app, $bucket, $version = parse_app $query
         $app | should be "test"
         $bucket | should be $null
+        $version | should be $null
 
         $query = "extras/enso"
-        $app, $bucket = app $query
+        $app, $bucket, $version = parse_app $query
         $app | should be "enso"
         $bucket | should be "extras"
+        $version | should be $null
 
         $query = "test-app"
-        $app, $bucket = app $query
+        $app, $bucket, $version = parse_app $query
         $app | should be "test-app"
         $bucket | should be $null
+        $version | should be $null
 
         $query = "test-bucket/test-app"
-        $app, $bucket = app $query
+        $app, $bucket, $version = parse_app $query
         $app | should be "test-app"
         $bucket | should be "test-bucket"
+        $version | should be $null
+
+        $query = "test-bucket/test-app@1.8.0"
+        $app, $bucket, $version = parse_app $query
+        $app | should be "test-app"
+        $bucket | should be "test-bucket"
+        $version | should be "1.8.0"
+
+        $query = "test-bucket/test-app@1.8.0-rc2"
+        $app, $bucket, $version = parse_app $query
+        $app | should be "test-app"
+        $bucket | should be "test-bucket"
+        $version | should be "1.8.0-rc2"
     }
 }


### PR DESCRIPTION
This should fix some issues with the installation from different buckets and also allows specific versions.

It now parses these app names:
- php-bucket/php71-amqp@1.8.0
- php-bucket/php71-amqp
- php71-amqp@1.8.0
- php71-amqp@1.9.0-rc2

Removed:
- is_app_with_specific_version()
- get_app_with_version()

Heavy testing required!