### PR TITLE
Remove Gratipay from donation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,3 @@ Support this project
 If you find Scoop useful and would like to support ongoing development and maintenance, here's how:
 
 * [PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=DM2SUH9EUXSKJ) (one-time donation)
-* [Gratipay](https://gratipay.com/~lukesampson) (ongoing donations)
-
-[![](http://img.shields.io/gratipay/user/lukesampson.svg)]()


### PR DESCRIPTION
Gratipay doesn't exist anymore, see:
- https://gratipay.com/
- https://gratipay.news/the-end-cbfba8f50981

Consider an alternative, like:
- https://en.liberapay.com/
- https://www.patreon.com/
- https://opencollective.com/