### PR TITLE
Option to skip hash validation and error message improvements

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -42,3 +42,25 @@ function find_manifest($app, $bucket) {
         if($manifest) { return $manifest, $bucket }
     }
 }
+
+function new_issue_msg($app, $bucket, $title, $body) {
+    $app, $manifest, $bucket, $url = locate $app $bucket
+    $url = known_bucket_repo $bucket
+    if($manifest -and $null -eq $url -and $null -eq $bucket) {
+        $url = 'https://github.com/lukesampson/scoop'
+    }
+    if(!$url) {
+        return "Please contact the bucket maintainer!"
+    }
+
+    $title = [System.Web.HttpUtility]::UrlEncode("$app@$($manifest.version): $title")
+    $body = [System.Web.HttpUtility]::UrlEncode($body)
+    $url = $url -replace '^(.*).git$','$1'
+    $url = "$url/issues/new?title=$title"
+    if($body) {
+        $url += "&body=$body"
+    }
+
+    $msg = "`nPlease create a new issue by using the following link and paste your console output:"
+    return "$msg`n$url"
+}

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -246,7 +246,7 @@ function movedir($from, $to) {
 
     $out = robocopy "$from" "$to" /e /move
     if($lastexitcode -ge 8) {
-        throw "Error moving directory: `n$out"
+        throw "Could not find '$(fname $from)'!"
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -246,7 +246,7 @@ function movedir($from, $to) {
 
     $out = robocopy "$from" "$to" /e /move
     if($lastexitcode -ge 8) {
-        throw "Could not find '$(fname $from)'!"
+        throw "Could not find '$(fname $from)'! (error $lastexitcode)"
     }
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -501,6 +501,16 @@ function parse_app([string] $app) {
     return $app, $null, $null
 }
 
+function show_app($app, $bucket, $version) {
+    if($bucket) {
+        $app = "$bucket/$app"
+    }
+    if($version) {
+        $app = "$app@$version"
+    }
+    return $app
+}
+
 function last_scoop_update() {
     $last_update = (scoop config lastupdate)
     if(!$last_update) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -9,10 +9,9 @@ function nightly_version($date, $quiet = $false) {
     "nightly-$date_str"
 }
 
-function install_app($app, $architecture, $global, $suggested, $use_cache = $true) {
+function install_app($app, $architecture, $global, $suggested, $use_cache = $true, $check_hash = $true) {
     $app, $bucket, $null = parse_app $app
     $app, $manifest, $bucket, $url = locate $app $bucket
-    $check_hash = $true
 
     if(!$manifest) {
         abort "Couldn't find manifest for '$app'$(if($url) { " at the URL $url" })."
@@ -41,7 +40,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     $original_dir = $dir # keep reference to real (not linked) directory
     $persist_dir = persistdir $app $global
 
-    $fname = dl_urls $app $version $manifest $architecture $dir $use_cache $check_hash
+    $fname = dl_urls $app $version $manifest $bucket $architecture $dir $use_cache $check_hash
     unpack_inno $fname $manifest $dir
     pre_install $manifest $architecture
     run_installer $fname $manifest $architecture $dir $global
@@ -272,7 +271,7 @@ function dl_progress($read, $total, $url) {
     [console]::SetCursorPosition($left, $top)
 }
 
-function dl_urls($app, $version, $manifest, $architecture, $dir, $use_cache = $true, $check_hash = $true) {
+function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_cache = $true, $check_hash = $true) {
     # we only want to show this warning once
     if(!$use_cache) { warn "Cache is being ignored." }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -359,7 +359,13 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
             }
             # fails if zip contains long paths (e.g. atom.json)
             #cp "$dir\_tmp\$extract_dir\*" "$dir\$extract_to" -r -force -ea stop
-            movedir "$dir\_tmp\$extract_dir" "$dir\$extract_to"
+            try {
+                movedir "$dir\_tmp\$extract_dir" "$dir\$extract_to"
+            }
+            catch {
+                error $_
+                abort $(new_issue_msg $app $bucket "extract_dir error")
+            }
 
             if(test-path "$dir\_tmp") { # might have been moved by movedir
                 try {

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -20,11 +20,7 @@ $status = app_status $app $global
 $manifest, $bucket = find_manifest $app $bucket
 
 if (!$manifest) {
-    if ($bucket) {
-        abort "Could not find manifest for '$bucket/$app'."
-    } else {
-        abort "Could not find manifest for '$app'."
-    }
+    abort "Could not find manifest for '$(show_app $app $bucket)'."
 }
 
 $install = install_info $app $status.version $global

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -12,10 +12,11 @@
 # When installing from your computer, you can leave the .json extension off if you like.
 #
 # Options:
-#   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
+#   -g, --global              Install the app globally
 #   -i, --independent         Don't install dependencies automatically
 #   -k, --no-cache            Don't use the download cache
-#   -g, --global              Install the app globally
+#   -s, --skip                Skip hash validation (use with caution!)
+#   -a, --arch <32bit|64bit>  Use the specified architecture, if the app supports it
 
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
@@ -46,10 +47,11 @@ function is_installed($app, $global) {
     return $false
 }
 
-$opt, $apps, $err = getopt $args 'gika:' 'global', 'independent', 'no-cache', 'arch='
+$opt, $apps, $err = getopt $args 'gfiksa:' 'global', 'force', 'independent', 'no-cache', 'skip', 'arch='
 if($err) { "scoop install: $err"; exit 1 }
 
 $global = $opt.g -or $opt.global
+$check_hash = !($opt.s -or $opt.skip)
 $independent = $opt.i -or $opt.independent
 $use_cache = !($opt.k -or $opt.'no-cache')
 $architecture = default_architecture
@@ -117,7 +119,7 @@ $skip | Where-Object { $explicit_apps -contains $_} | ForEach-Object {
 }
 
 $suggested = @{};
-$apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache }
+$apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
 
 show_suggestions $suggested
 


### PR DESCRIPTION
- Add `show_app()` function for displaying `app/bucket@version`
- Add option (`-s` | `--skip`) to skip hash validation on `scoop install` and `scoop update` to allow installation when a manifest provides an outdated hash
- Add `new_issue_msg()` function for nicer error messages with a link to the buckets repository. clicking on the link opens a new issue with a predefined title
- Show filename instead of unreadable `robocopy` output when file moving fails and use `new_issue_msg()`
- Handle hash validation errors with `new_issue_msg()`

Hm, maybe I put too much in this pull-request ... one change leads to another. 🤷‍♂️ 😁 

Example output: 

```
λ .\bin\scoop.ps1 install wox
Installing 'wox' (1.3.524) [64bit]
Wox-1.3.524-full.nupkg (5,0 MB) [===========================] 100%
Checking hash of Wox-1.3.524-full.nupkg... ERROR Hash check failed!
App:       extras/wox
URL:       https://github.com/Wox-launcher/Wox/releases/download/v1.3.524/Wox-1.3.524-full.nupkg#/dl.7z
Expected:  bfb73e46c3c054c00c24ab0f03ed441ab1308e07
Actual:    9025a4d5264b9cf73cd48a2679b91f1127e46c10

Please create a new issue by using the following link and paste your console output:
https://github.com/lukesampson/scoop-extras/issues/new?title=wox%401.3.524%3a+hash+check+failed
```

Ultimate goal: Use GitHub Issue API to find reported hash check errors and let [Excavator](https://github.com/r15ch13/Excavator) resolve them automagically.