### PR TITLE
Adding C collate on initdb

### DIFF
--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -25,7 +25,7 @@
         "PGDATA": "$dir\\data"
     },
     "post_install": "
-        if (!(Test-Path \"$dir\\data\\pg_hba.conf\")) { iex \"initdb --username=postgres --encoding=UTF8 --locale=en\" }
+        if (!(Test-Path \"$dir\\data\\pg_hba.conf\")) { iex \"initdb --username=postgres --encoding=UTF8 --locale=en --lc-collate=c\" }
     ",
     "notes": "To start/stop service, run `pg_ctl start`, `pg_ctl stop`.",
     "checkver": {


### PR DESCRIPTION
PostgreSQL has a problem to sort some non-latin characters using `ORDER BY` and the known solution is setting `LC_COLLATE` to C.[1][2] Because `LC_COLLATE` is fixed when running `initdb`, it is preclusive to set collation on post installation script for new user.

[1]: https://stackoverflow.com/questions/14191848/postgresql-order-by-is-very-weird
[2]: https://stackoverflow.com/questions/43745639/sort-order-in-postgresql-for-japanese-words-in-hiragana