### PR TITLE
Fix lc-collate for postgresql

### DIFF
--- a/bucket/postgresql.json
+++ b/bucket/postgresql.json
@@ -25,7 +25,7 @@
         "PGDATA": "$dir\\data"
     },
     "post_install": "
-        if (!(Test-Path \"$dir\\data\\pg_hba.conf\")) { iex \"initdb --username=postgres --encoding=UTF8 --locale=en --lc-collate=c\" }
+        if (!(Test-Path \"$dir\\data\\pg_hba.conf\")) { iex \"initdb --username=postgres --encoding=UTF8 --locale=en --lc-collate=C\" }
     ",
     "notes": "To start/stop service, run `pg_ctl start`, `pg_ctl stop`.",
     "checkver": {


### PR DESCRIPTION
The current post_install script fails and doesn't create a database cluster because the locale "c" is unknown.