### PR TITLE
Add SCons version 3.0.1

### DIFF
--- a/bucket/scons.json
+++ b/bucket/scons.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://scons.org/",
+    "description": "A software construction tool",
+    "license": "MIT",
+    "version": "3.0.1",
+    "url": "https://downloads.sourceforge.net/project/scons/scons-local/3.0.1/scons-local-3.0.1.zip",
+    "hash": "4ab1f274015287744a497dcbd522ff1446f28d3de9aad630aac37042a16f7bde",
+    "pre_install": "echo \"python $dir\\scons.py @args\" | out-file $dir\\scons.ps1",
+    "bin": [
+        "scons.ps1"
+    ],
+    "suggest": {
+        "Python": "python"
+    },
+    "checkver": {
+        "url": "https://scons.org/pages/download.html",
+        "re": "<strong>The current production release</strong> of SCons is <strong>([\\d.]+)</strong>"
+    },
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/scons/scons-local/$version/scons-local-$version.zip"
+    }
+}


### PR DESCRIPTION
As SCons cannot be cleanly installed using `pip install` (especially on Python 3), this is a more reliable installation method that is just as easy to use as pip.