### PR TITLE
add jfrog-cli-go to bucket

### DIFF
--- a/bucket/jfrog.json
+++ b/bucket/jfrog.json
@@ -1,9 +1,18 @@
 {
-    "homepage": "https://bintray.com/jfrog/jfrog-cli-go",
-    "license": "Apache License 2.0: https://github.com/jfrog/jfrog-cli-go/blob/master/LICENSE",
+    "homepage": "https://jfrog.com/getcli/",
+    "license": "Apache-2.0",
     "description": "Command Line Interface for Artifactory and Bintray",
-    "version": "1.16.1",
-    "url": "https://jfrog.bintray.com/jfrog-cli-go/1.16.1/jfrog-cli-windows-amd64/jfrog.exe",
-    "hash": "76f39e01bb081fe92795dc34d0bbc8441b29e2f7668ea5c22b542fdcc2357d1c",
-    "bin": "jfrog.exe"
+    "version": "1.16.2",
+    "url": "https://jfrog.bintray.com/jfrog-cli-go/1.16.2/jfrog-cli-windows-amd64/jfrog.exe",
+    "hash": "a650ff3ae1d61ba5fea01c5c4b664467f1691e83e3bea164ef99a95ae5833ef2",
+    "bin": "jfrog.exe",
+    "checkver": {
+        "github": "https://github.com/jfrog/jfrog-cli-go"
+    },
+    "autoupdate": {
+        "url": "https://jfrog.bintray.com/jfrog-cli-go/$version/jfrog-cli-windows-amd64/jfrog.exe",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
 }

--- a/bucket/jfrog.json
+++ b/bucket/jfrog.json
@@ -1,5 +1,7 @@
 {
     "homepage": "https://bintray.com/jfrog/jfrog-cli-go",
+    "license": "Apache License 2.0: https://github.com/jfrog/jfrog-cli-go/blob/master/LICENSE",
+    "description": "Command Line Interface for Artifactory and Bintray",
     "version": "1.16.1",
     "url": "https://jfrog.bintray.com/jfrog-cli-go/1.16.1/jfrog-cli-windows-amd64/jfrog.exe",
     "hash": "76f39e01bb081fe92795dc34d0bbc8441b29e2f7668ea5c22b542fdcc2357d1c",

--- a/bucket/jfrog.json
+++ b/bucket/jfrog.json
@@ -1,0 +1,7 @@
+{
+    "homepage": "https://bintray.com/jfrog/jfrog-cli-go",
+    "version": "1.16.1",
+    "url": "https://jfrog.bintray.com/jfrog-cli-go/1.16.1/jfrog-cli-windows-amd64/jfrog.exe",
+    "hash": "76f39e01bb081fe92795dc34d0bbc8441b29e2f7668ea5c22b542fdcc2357d1c",
+    "bin": "jfrog.exe"
+}


### PR DESCRIPTION
jFrog makes Artifactory, Bintray, and a few other products in the Binary Repository management space. This cli tool is a go executable that interacts with their products.