### PR TITLE
moving winpython from extras to main bucket

### DIFF
--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -1,6 +1,6 @@
 {
     "description": "Free, open-source and portable Python distribution for Windows",
-	"version": "3.6.5.0",
+    "version": "3.6.5.0",
     "license": "MIT",
     "architecture": {
         "64bit": {

--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -1,0 +1,49 @@
+{
+    "description": "Free, open-source and portable Python distribution for Windows",
+	"version": "3.6.5.0",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython64-3.6.5.0Zero.exe#/dl.7z",
+            "hash": "83cb7ccf519a7fffc0cf6b00f0cb2d45f8d4cbf55b6e9b463fcd2534fa6f450a",
+            "extract_dir": "python-3.6.5.amd64"
+        },
+        "32bit": {
+            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython32-3.6.5.0Zero.exe#/dl.7z",
+            "hash": "83cb7ccf519a7fffc0cf6b00f0cb2d45f8d4cbf55b6e9b463fcd2534fa6f450a",
+            "extract_dir": "python-3.6.5"
+        }
+    },
+    "homepage": "https://winpython.github.io/",
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts"
+    ],
+    "checkver": {
+        "url": "https://winpython.github.io/md5_sha1.txt",
+        "re": "-([\\d.]+)Zero.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe#/dl.7z",
+                "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion.amd64"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe#/dl.7z",
+                "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion"
+            }
+        },
+        "hash": {
+            "url": "https://winpython.github.io/md5_sha1.txt",
+            "find": "([a-fA-F\\d]{64})\\s|\\s$basename"
+        }
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/lukesampson/scoop-extras/pull/978, moving this manifest to main bucket. Also, added a short description.