### PR TITLE
Add support for multi-connection downloads via aria2c

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,27 @@ Scoop is very scriptable, so you can run repeatable setups to get your environme
 ```powershell
 scoop install sudo
 sudo scoop install 7zip git openssh --global
-scoop install curl grep sed less touch
+scoop install aria2 curl grep sed less touch
 scoop install python ruby go perl
 ```
 
 If you've built software that you'd like others to use, Scoop is an alternative to building an installer (e.g. MSI or InnoSetup)—you just need to zip your program and provide a JSON manifest that describes how to install it.
 
 ## [Documentation](https://github.com/lukesampson/scoop/wiki)
+
+## Multi-connection downloads with `aria2`
+Scoop can utilize [`aria2`](https://github.com/aria2/aria2) to use multi-connection downloads. Simply install `aria2` through Scoop and it will be used for all downloads afterward.
+```powershell
+scoop install aria2
+```
+
+You can tweak the following `aria2` settings with the `scoop config` command:
+
+- aria2-enabled (default: true)
+- [aria2-retry-wait](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-retry-wait) (default: 2)
+- [aria2-split](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-s) (default: 5)
+- [aria2-max-connection-per-server](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-x) (default: 5)
+- [aria2-min-split-size](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-k) (default: 5M)
 
 ### Inspiration
 

--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -41,7 +41,10 @@ function load_cfg {
     }
 }
 
-function get_config($name) {
+function get_config($name, $default) {
+    if($null -eq $cfg.$name -and $null -ne $default) {
+        return $default
+    }
     return $cfg.$name
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -117,6 +117,10 @@ function aria2_installed() {
     return ![String]::IsNullOrWhiteSpace("$(aria2_path)")
 }
 
+function aria2_enabled() {
+    return (aria2_installed) -and (get_config 'aria2-enabled' $true)
+}
+
 function app_status($app, $global) {
     $status = @{}
     $status.installed = (installed $app $global)

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -104,7 +104,7 @@ function aria2_path() {
     }
 
     # global path to executable
-    $aria2 = "$(versiondir 'aria2' 'current' $false)\aria2c.exe"
+    $aria2 = "$(versiondir 'aria2' 'current' $true)\aria2c.exe"
     if(Test-Path($aria2)) {
         return $aria2
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -96,6 +96,27 @@ function installed_apps($global) {
     }
 }
 
+function aria2_path() {
+    # normal path to executable
+    $aria2 = "$(versiondir 'aria2' 'current' $false)\aria2c.exe"
+    if(Test-Path($aria2)) {
+        return $aria2
+    }
+
+    # global path to executable
+    $aria2 = "$(versiondir 'aria2' 'current' $false)\aria2c.exe"
+    if(Test-Path($aria2)) {
+        return $aria2
+    }
+
+    # not found
+    return $null
+}
+
+function aria2_installed() {
+    return ![String]::IsNullOrWhiteSpace("$(aria2_path)")
+}
+
 function app_status($app, $global) {
     $status = @{}
     $status.installed = (installed $app $global)
@@ -574,6 +595,19 @@ function format_hash([String] $hash) {
         40 { $hash = "sha1:$hash" } # sha1
         64 { $hash = $hash } # sha256
         128 { $hash = "sha512:$hash" } # sha512
+        default { $hash = $null }
+    }
+    return $hash
+}
+
+function format_hash_aria2([String] $hash) {
+    $hash = $hash -split ':' | Select-Object -Last 1
+    switch ($hash.Length)
+    {
+        32 { $hash = "md5=$hash" } # md5
+        40 { $hash = "sha-1=$hash" } # sha1
+        64 { $hash = "sha-256=$hash" } # sha256
+        128 { $hash = "sha-512=$hash" } # sha512
         default { $hash = $null }
     }
     return $hash

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -624,5 +624,11 @@ function handle_special_urls($url)
         $url = "https://www.fosshub.com/gensLink/$name/$filename/2053434f4f5053434f4f5020"
         $url = (Invoke-WebRequest -Uri $url | Select-Object -ExpandProperty Content)
     }
+
+    # Sourceforge.net
+    if ($url -match "(?:downloads\.)?sourceforge.net\/projects?\/(?<project>[^\/]+)\/(?:files\/)?(?<file>.*)") {
+        # Reshapes the URL to avoid redirections
+        $url = "https://downloads.sourceforge.net/project/$($matches['project'])/$($matches['file'])?r=&ts="
+    }
     return $url
 }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -203,6 +203,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         "--input-file='$urlstxt'"
         "--dir='$cachedir'"
         "--user-agent='$(Get-UserAgent)'"
+        "--referer='$(strip_filename $url)'"
         "--allow-overwrite=true"
         "--auto-file-renaming=false"
         "--retry-wait=2"
@@ -212,6 +213,10 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         "--console-log-level=warn"
         "--enable-color=false"
     )
+
+    if($cookies) {
+        $options += "--header='Cookie: $(cookie_header $cookies)'"
+    }
 
     foreach($url in $urls) {
         $data.$url = @{

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -357,7 +357,9 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
         }
 
         if($extract_fn) {
-            write-host "Extracting... " -nonewline
+            Write-Host "Extracting " -NoNewline
+            Write-Host $fname -f Cyan -NoNewline
+            Write-Host " ... " -NoNewline
             $null = mkdir "$dir\_tmp"
             & $extract_fn "$dir\$fname" "$dir\_tmp"
             Remove-Item "$dir\$fname"
@@ -384,7 +386,7 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
                 }
             }
 
-            write-host "done."
+            Write-Host "done." -f Green
 
             $extracted++
         }
@@ -449,7 +451,9 @@ function check_hash($file, $hash, $app_name) {
         return $true, $null
     }
 
-    write-host "Checking hash of $(url_remote_filename $url)... " -nonewline
+    Write-Host "Checking hash of " -NoNewline
+    Write-Host $(url_remote_filename $url) -f Cyan -NoNewline
+    Write-Host " ... " -nonewline
     $type, $expected = $hash.split(':')
     if(!$expected) {
         # no type specified, assume sha256
@@ -478,7 +482,7 @@ function check_hash($file, $hash, $app_name) {
         }
         return $false, $msg
     }
-    write-host "ok."
+    Write-Host "ok." -f Green
     return $true, $null
 }
 
@@ -536,7 +540,7 @@ function run($exe, $arg, $msg, $continue_exit_codes) {
         write-host -f darkred $_.exception.tostring()
         return $false
     }
-    if($msg) { write-host "done." }
+    if($msg) { Write-Host "done." -f Green }
     return $true
 }
 
@@ -554,7 +558,7 @@ function unpack_inno($fname, $manifest, $dir) {
     Remove-Item -r -force "$dir\_scoop_unpack"
 
     Remove-Item "$dir\$fname"
-    write-host "done."
+    Write-Host "done." -f Green
 }
 
 function run_installer($fname, $manifest, $architecture, $dir, $global) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -147,6 +147,48 @@ function do_dl($url, $to, $cookies) {
     }
 }
 
+function aria_exit_code($exitcode) {
+    $codes = @{
+        0='All downloads were successful'
+        1='An unknown error occurred'
+        2='Timeout'
+        3='Resource was not found'
+        4='Aria2 saw the specified number of "resource not found" error. See --max-file-not-found option'
+        5='Download aborted because download speed was too slow. See --lowest-speed-limit option'
+        6='Network problem occurred.'
+        7='There were unfinished downloads. This error is only reported if all finished downloads were successful and there were unfinished downloads in a queue when aria2 exited by pressing Ctrl-C by an user or sending TERM or INT signal'
+        8='Remote server did not support resume when resume was required to complete download'
+        9='There was not enough disk space available'
+        10='Piece length was different from one in .aria2 control file. See --allow-piece-length-change option'
+        11='Aria2 was downloading same file at that moment'
+        12='Aria2 was downloading same info hash torrent at that moment'
+        13='File already existed. See --allow-overwrite option'
+        14='Renaming file failed. See --auto-file-renaming option'
+        15='Aria2 could not open existing file'
+        16='Aria2 could not create new file or truncate existing file'
+        17='File I/O error occurred'
+        18='Aria2 could not create directory'
+        19='Name resolution failed'
+        20='Aria2 could not parse Metalink document'
+        21='FTP command failed'
+        22='HTTP response header was bad or unexpected'
+        23='Too many redirects occurred'
+        24='HTTP authorization failed'
+        25='Aria2 could not parse bencoded file (usually ".torrent" file)'
+        26='".torrent" file was corrupted or missing information that aria2 needed'
+        27='Magnet URI was bad'
+        28='Bad/unrecognized option was given or unexpected option argument was given'
+        29='The remote server was unable to handle the request due to a temporary overloading or maintenance'
+        30='Aria2 could not parse JSON-RPC request'
+        31='Reserved. Not used'
+        32='Checksum validation failed'
+    }
+    if($null -eq $codes[$exitcode]) {
+        return 'An unknown error occurred'
+    }
+    return $codes[$exitcode]
+}
+
 function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $cookies = $null, $use_cache = $true, $check_hash = $true) {
     $data = @{}
     $urls = @(url $manifest $architecture)
@@ -217,9 +259,9 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         }
 
         if($lastexitcode -gt 0) {
-            error 'Download failed!'
-            debug($urlstxt_content)
-            debug($aria2)
+            error "Download failed! (Error $lastexitcode) $(aria_exit_code $lastexitcode)"
+            debug $urlstxt_content
+            debug $aria2
             abort $(new_issue_msg $app $bucket "download via aria2 failed")
         }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -254,7 +254,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
             } elseif($_.StartsWith('[') -and $_.EndsWith(']')) {
                 Write-Host $_ -f Cyan
             } else {
-                Write-Host $_
+                Write-Host $_ -f Gray
             }
         }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -468,10 +468,8 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
     $extract_tos = @(extract_to $manifest $architecture)
     $extracted = 0;
 
-    $enable_aria2 = get_config 'aria2-enabled' $true
-
     # download first
-    if((aria2_installed) -and $enable_aria2) {
+    if(aria2_enabled) {
         dl_with_cache_aria2 $app $version $manifest $architecture $dir $cookies $use_cache $check_hash
     } else {
         foreach($url in $urls) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -219,6 +219,11 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         $options += "--header='Cookie: $(cookie_header $cookies)'"
     }
 
+    $more_options = get_config 'aria2-options'
+    if($more_options) {
+        $options += $more_options
+    }
+
     foreach($url in $urls) {
         $data.$url = @{
             'filename' = url_filename $url

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -206,12 +206,13 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         "--referer='$(strip_filename $url)'"
         "--allow-overwrite=true"
         "--auto-file-renaming=false"
-        "--retry-wait=2"
-        "--split=5"
-        "--max-connection-per-server=5"
-        "--min-split-size=5M"
+        "--retry-wait=$(get_config 'aria2-retry-wait' 2)"
+        "--split=$(get_config 'aria2-split' 5)"
+        "--max-connection-per-server=$(get_config 'aria2-max-connection-per-server' 5)"
+        "--min-split-size=$(get_config 'aria2-min-split-size' '5M')"
         "--console-log-level=warn"
         "--enable-color=false"
+        "--no-conf=true"
     )
 
     if($cookies) {
@@ -447,10 +448,7 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
     $extract_tos = @(extract_to $manifest $architecture)
     $extracted = 0;
 
-    $enable_aria2 = get_config 'enable_aria2'
-    if($null -eq $enable_aria2) {
-        $enable_aria2 = $true
-    }
+    $enable_aria2 = get_config 'aria2-enabled' $true
 
     # download first
     if((aria2_installed) -and $enable_aria2) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -207,7 +207,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
                 return
             }
             Write-Host $prefix -NoNewline
-            if($_.EndsWith('download completed.')) {
+            if($_.StartsWith('(OK):')) {
                 Write-Host $_ -f Green
             } elseif($_.StartsWith('[') -and $_.EndsWith(']')) {
                 Write-Host $_ -f Cyan

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -201,9 +201,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
     # aria2 options
     $options = @(
         "--input-file='$urlstxt'"
-        "--dir='$cachedir'"
         "--user-agent='$(Get-UserAgent)'"
-        "--referer='$(strip_filename $url)'"
         "--allow-overwrite=true"
         "--auto-file-renaming=false"
         "--retry-wait=$(get_config 'aria2-retry-wait' 2)"
@@ -249,6 +247,8 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
             $has_downloads = $true
             # create aria2 input file content
             $urlstxt_content += "$url`n"
+            $urlstxt_content += "    referer=$(strip_filename $url)`n"
+            $urlstxt_content += "    dir=$cachedir`n"
             $urlstxt_content += "    out=$($data.$url.cachename)`n"
         } else {
             Write-Host "Loading " -NoNewline

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -247,7 +247,9 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
             $has_downloads = $true
             # create aria2 input file content
             $urlstxt_content += "$url`n"
-            $urlstxt_content += "    referer=$(strip_filename $url)`n"
+            if(!$url.Contains('sourceforge.net')) {
+                $urlstxt_content += "    referer=$(strip_filename $url)`n"
+            }
             $urlstxt_content += "    dir=$cachedir`n"
             $urlstxt_content += "    out=$($data.$url.cachename)`n"
         } else {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -219,6 +219,19 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         $options += "--header='Cookie: $(cookie_header $cookies)'"
     }
 
+    $proxy = get_config 'proxy'
+    if($proxy -ne 'none') {
+        if([Net.Webrequest]::DefaultWebProxy.Address) {
+            $options += "--all-proxy='$([Net.Webrequest]::DefaultWebProxy.Address.Authority)'"
+        }
+        if([Net.Webrequest]::DefaultWebProxy.Credentials.UserName) {
+            $options += "--all-proxy-user='$([Net.Webrequest]::DefaultWebProxy.Credentials.UserName)'"
+        }
+        if([Net.Webrequest]::DefaultWebProxy.Credentials.Password) {
+            $options += "--all-proxy-passwd='$([Net.Webrequest]::DefaultWebProxy.Credentials.Password)'"
+        }
+    }
+
     $more_options = get_config 'aria2-options'
     if($more_options) {
         $options += $more_options

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -40,6 +40,9 @@ switch($cmd) {
     'rm' {
         if(!$app) { 'ERROR: <app> missing'; my_usage; exit 1 }
         Remove-Item "$cachedir\$app#*"
+        if(test-path("$cachedir\$app.txt")) {
+            Remove-Item "$cachedir\$app.txt"
+        }
     }
     'show' {
         show $app

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -119,6 +119,10 @@ $skip | Where-Object { $explicit_apps -contains $_} | ForEach-Object {
 }
 
 $suggested = @{};
+if(aria2_enabled) {
+    warn "Scoop uses 'aria2c' for multi-connection downloads."
+    warn "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
+}
 $apps | ForEach-Object { install_app $_ $architecture $global $suggested $use_cache $check_hash }
 
 show_suggestions $suggested

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -57,10 +57,7 @@ function update_scoop() {
 
     write-host "Updating Scoop..."
     $last_update = $(last_scoop_update).ToString('s')
-    $show_update_log = get_config "show_update_log"
-    if($null -eq $show_update_log) {
-        $show_update_log = $true
-    }
+    $show_update_log = get_config 'show_update_log' $true
     $currentdir = fullpath $(versiondir 'scoop' 'current')
     if(!(test-path "$currentdir\.git")) {
         $newdir = fullpath $(versiondir 'scoop' 'new')

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -209,6 +209,10 @@ if(!$apps) {
 
     $suggested = @{};
     # # $outdated is a list of ($app, $global) tuples
+    if(aria2_enabled) {
+        warn "Scoop uses 'aria2c' for multi-connection downloads."
+        warn "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
+    }
     $outdated | ForEach-Object { update @_ $quiet $independent $suggested $use_cache $check_hash }
 }
 

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -2,7 +2,7 @@
 . "$psscriptroot\..\lib\config.ps1"
 
 describe "hashtable" {
-    $json = '{ "one": 1, "two": [ { "a": "a" }, "b", 2 ], "three": { "four": 4 } }'
+    $json = '{ "one": 1, "two": [ { "a": "a" }, "b", 2 ], "three": { "four": 4 }, "five": true, "six": false, "seven": "\/Date(1529917395805)\/" }'
 
     it "converts pscustomobject to hashtable" {
         $obj = convertfrom-json $json
@@ -13,5 +13,8 @@ describe "hashtable" {
         $ht.two[1] | should be "b"
         $ht.two[2] | should beexactly 2
         $ht.three.four | should beexactly 4
+        $ht.five | should beexactly $true
+        $ht.six | should beexactly $false
+        [System.DateTime]::Equals($ht.seven, $(New-Object System.DateTime (2018, 06, 25, 09, 03, 15, 805))) | should be $true
     }
 }


### PR DESCRIPTION
This change adds support for multi-connection downloads via aria2c. (requested in https://github.com/lukesampson/scoop/issues/2306)
Scoop will use aria2 by default if it's installed locally or globally to speed all downloads.

- [x] Support current cache behaviour
- [x] Disable aria2 via scoops config (`scoop config enable_aria2 false`)
- [x] Added some color to the installation output
- [x] Proxy support (need someone who can test which [proxy settings](https://aria2.github.io/manual/en/html/aria2c.html#http-ftp-sftp-options) are required)
- [x] Change aria2 parameters via scoops config

The output changes from the previous progress bar to simply writing the aria2 output.

![aria2-scoop-demo](https://user-images.githubusercontent.com/432127/41479495-a1a0cf90-70cb-11e8-9d08-5cb5540260d5.gif)
[still image](https://user-images.githubusercontent.com/432127/41479688-45b3abac-70cc-11e8-8ddb-a26b4995e0a7.png)


Use the following command for constant tests:
`.\bin\scoop.ps1 uninstall godot; .\bin\scoop.ps1 cache rm godot; .\bin\scoop.ps1 install godot`
