### PR TITLE
Revert rsync to version 5.5.0 and disable autoupdate

### DIFF
--- a/bucket/rsync.json
+++ b/bucket/rsync.json
@@ -1,20 +1,13 @@
 {
     "homepage": "https://www.itefix.net/cwrsync",
-    "version": "5.7.2",
+    "version": "5.5.0",
     "license": "https://www.itefix.net/content/cwrsync-licenseversion",
-    "url": "https://www.itefix.net/dl/cwrsync_5.7.2_x86_free.zip",
-    "hash": "c61258fe6d1ab9af7b0a45fb166b0c69ee13bdf971d4a3b486b8d1e33425fcf5",
-    "extract_dir": "cwrsync_5.7.2_x86_Free",
+    "url": "https://web.archive.org/web/20160613105413if_/https://www.itefix.net/dl/cwRsync_5.5.0_x86_Free.zip",
+    "hash": "37e8ef21ac975d4ee86c9d3be40c8935e8b9d0ba84e9302fc106b9452296cb85",
+    "extract_dir": "cwRsync_5.5.0_x86_Free",
     "bin": "bin\\rsync.exe",
     "checkver": {
         "url": "https://www.itefix.net/content/cwrsync-free-edition",
         "re": "cwrsync_([\\d.]+)_x86"
-    },
-    "autoupdate": {
-        "url": "https://www.itefix.net/dl/cwrsync_$version_x86_free.zip",
-        "extract_dir": "cwrsync_$version_x86_Free",
-        "hash": {
-            "url": "https://www.itefix.net/dl/cwrsync_$version_x86_free.zip.sha256.asc"
-        }
     }
 }


### PR DESCRIPTION
Fix #2295 