### PR TITLE
Add basic WSL support by appending .exe to powershell

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -326,7 +326,7 @@ set invalid=`"='
 if !args! == !invalid! ( set args= )
 powershell -noprofile -ex unrestricted `"& '$resolved_path' $arg %args%;exit `$lastexitcode`"" | out-file "$shim.cmd" -encoding ascii
 
-        "#!/bin/sh`npowershell -ex unrestricted `"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii
+        "#!/bin/sh`npowershell.exe -ex unrestricted `"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii
     } elseif($path -match '\.jar$') {
         "@java -jar `"$resolved_path`" $arg %*" | out-file "$shim.cmd" -encoding ascii
         "#!/bin/sh`njava -jar `"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii


### PR DESCRIPTION
# Basic WSL Support
**Problem**: Scoop uses a hardcoded `powershell -ex unrestricted` call to launch itself. As the WSL needs native end with `.exe`, the script fails.

**Fix**
Just added the `.exe`-extension to the script, as this has no impact on the windows side but enables the usage of scoop inside of the WSL