### PR TITLE
Change imagemagick to not add its directory to PATH. Fix #2275

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -15,7 +15,6 @@
     "depends": [
         "ffmpeg"
     ],
-    "env_add_path": ".",
     "bin": [
         "compare.exe",
         "composite.exe",


### PR DESCRIPTION
Imagemagick doesn't need to be added to PATH because all its .exe files are already shimmed.