### PR TITLE
Update innounp to version 0.47

### DIFF
--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,8 +1,8 @@
 {
     "homepage": "http://innounp.sourceforge.net",
-    "version": "0.46",
-    "url": "https://r15ch13.keybase.pub/scoop/innounp/innounp046.rar",
-    "hash": "3c056e2fc46ca9e92405f13ddf1f250cfe4bd66cb83b6647d87c74bc7242b121",
+    "version": "0.47",
+    "url": "https://sourceforge.net/projects/innounp/files/innounp/innounp%200.47/innounp047.rar",
+    "hash": "sha1:ba0cebf7e3003847d5ed5811620c54d7576146e7",
     "bin": "innounp.exe",
     "checkver": "Version\\s+([\\d.]+)\\s*<br>"
 }


### PR DESCRIPTION
Also: 
- moved `url` back to sourceforge
- changed `hash` algorithm to `SHA1`, since that's provided at the sourceforge release page