### PR TITLE
Perl: Fix install when using PowerShell 6 (fixes #2349)

### DIFF
--- a/bucket/perl.json
+++ b/bucket/perl.json
@@ -16,7 +16,7 @@
         "# enable standard idiomatic access to user's home directory",
         "## remove HomeDir section from portable.perl (disables Portable.pm override of File::HomeDir)",
         "## NOTE: conversion to byte[] avoids adding an extra trailing newline to the output file",
-        "[byte[]][char[]]((Get-Content -raw \"$dir\\portable.perl\") -replace \"(?ms)^HomeDir:.*?^(?=\\S)\",\"\") | Set-Content \"$dir\\portable.perl\" -encoding byte"
+        "[System.IO.File]::WriteAllBytes(\"$dir\\portable.perl\", ([byte[]][char[]]((Get-Content -Raw \"$dir\\portable.perl\") -replace \"(?ms)^HomeDir:.*?^(?=\\S)\",\"\")))"
     ],
     "env_add_path": [
         "perl\\site\\bin",


### PR DESCRIPTION
This PR fixes issue #2349.

Use `[System.IO.File]::WriteAllBytes()` instead of `Set-Content -Encoding Byte` to fix compatibility issue with PowerShell 6 which has removed `-Encoding Byte` in favor of a new `-AsByteStream` switch.