### PR TITLE
Update hub to 2.5.0

### DIFF
--- a/bucket/hub.json
+++ b/bucket/hub.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://hub.github.com/",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/github/hub/releases/download/v2.4.0/hub-windows-amd64-2.4.0.zip",
-            "hash": "82fbf1cab8f6470f0a212ecfc96074dcb65c4af5a4bec0d3578c5a4fcc7a7c44"
+            "url": "https://github.com/github/hub/releases/download/v2.5.0/hub-windows-amd64-2.5.0.zip",
+            "hash": "d66d6e57cec07f5f304e56870008b013bcbb4cce957aea0812f1cb292b428bfd"
         },
         "32bit": {
-            "url": "https://github.com/github/hub/releases/download/v2.4.0/hub-windows-386-2.4.0.zip",
-            "hash": "5554336e54205b22a97368f8b07061c4c7eeea26f4d63979921a912974f2fa31"
+            "url": "https://github.com/github/hub/releases/download/v2.5.0/hub-windows-386-2.5.0.zip",
+            "hash": "63dfd3c01ff2cf73fa2216ad6d499adf43f68bf66bbffd6f15108f250488378b"
         }
     },
     "bin": [


### PR DESCRIPTION
https://github.com/github/hub/releases/tag/v2.5.0