### PR TITLE
R - add library folder to persistent data

### DIFF
--- a/bucket/r.json
+++ b/bucket/r.json
@@ -20,6 +20,7 @@
         "bin\\curr_arch\\rterm.exe",
         "bin\\curr_arch\\rscript.exe"
     ],
+    "persist": "library",
     "notes": [
         "You'll need to type 'r.ps1' or 'r.cmd' to run R, because in Powershell 'r' runs the last command. Alternatively 'rterm' can be used to start the interactive R terminal session.",
         "",


### PR DESCRIPTION
I've got no deep knowledge of R, but as far as I know all downloaded packages data goes into the "library" folder, so should be safe to add it to persist, in order to preserve downloaded packages when updating to a new version.

EDIT: can anybody check the error? The manifest installs fine on my system.