### PR TITLE
Update strip_filename skips

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -152,7 +152,7 @@ function dl($url, $to, $cookies, $progress) {
     $wreq = [net.webrequest]::create($url)
     if($wreq -is [net.httpwebrequest]) {
         $wreq.useragent = Get-UserAgent
-        if (-not ($url -imatch "downloads\.sourceforge\.net" -or $url -imatch "portableapps\.com")) {
+        if (-not ($url -imatch "sourceforge\.net")) {
             $wreq.referer = strip_filename $url
         }
         if($cookies) {


### PR DESCRIPTION
Portableapps.com has switched to portableapps.duckduckgo.com as their freeware host and skipping strip_filename is no longer required.
Remove downloads subdomain from sourceforge.net to also support mirror redirect urls (e.g. https://sourceforge.net/projects/portableapps/files/GIMP%20Portable/GIMPPortable_2.10.2.paf.exe/download).