### PR TITLE
Add TrID

### DIFF
--- a/bucket/trid.json
+++ b/bucket/trid.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "http://mark0.net/soft-trid-e.html",
+    "version": "v2.24-19.07.18",
+    "url": [
+        "http://mark0.net/download/triddefs.zip",
+        "http://mark0.net/download/trid_w32.zip"
+    ],
+    "hash": [
+        "7327767055e3bfe546ea3456f51c3dce15708e3fdfc51871fed73b9309934145",
+        "ea7f82363912f5b3c79217ba8716425ec3f2514887f788dcd5a2821d0b1fc83f"
+    ],
+    "bin": [
+        "trid.exe"
+    ],
+    "checkver": {
+        "url": "http://mark0.net/soft-trid-e.html",
+        "re": "(?smi)Win32.*?TrID v([\\d\\.]*).*?(\\d{2})\\/(\\d{2})\\/(\\d{2})",
+        "replace": "v${1}-${2}.${3}.${4}"
+    },
+    "autoupdate": {
+        "note": "Autoupdate only updates TrID Definitions. If the main program updates, please change hashes manually",
+        "url": "http://mark0.net/download/triddefs.zip"
+    }
+}

--- a/bucket/trid.json
+++ b/bucket/trid.json
@@ -1,6 +1,6 @@
 {
     "homepage": "http://mark0.net/soft-trid-e.html",
-    "version": "v2.24-19.07.18",
+    "version": "2.24-18.07.19",
     "url": [
         "http://mark0.net/download/triddefs.zip",
         "http://mark0.net/download/trid_w32.zip"
@@ -15,7 +15,7 @@
     "checkver": {
         "url": "http://mark0.net/soft-trid-e.html",
         "re": "(?smi)Win32.*?TrID v([\\d\\.]*).*?(\\d{2})\\/(\\d{2})\\/(\\d{2})",
-        "replace": "v${1}-${2}.${3}.${4}"
+        "replace": "${1}-${4}.${3}.${2}"
     },
     "autoupdate": {
         "note": "Autoupdate only updates TrID Definitions. If the main program updates, please change hashes manually",


### PR DESCRIPTION
As this is CLI-only tool, I hope it's correct to assume it belongs to main bucket.

>  TrID is an utility designed to identify file types from their binary signatures. While there are similar utilities with hard coded logic, TrID has no fixed rules. Instead, it's extensible and can be trained to recognize new formats in a fast and automatic way. TrID has many uses: identify what kind of file was sent to you via e-mail, aid in forensic analysis, support in file recovery, etc.

http://mark0.net/soft-trid-e.html

Sadly I couldn't manage to make autoupdate to update both the main application AND definitions, as `autoupdate` accepts only single URL (hence the note). Perhaps there could be a helper function to fix this, but the main program seems to not be updated very often, so I don't think it's necessary.