### PR TITLE
Removed the bucket from the app name when checking directories.

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -118,7 +118,10 @@ function app_status($app, $global) {
     }
 
     $status.missing_deps = @()
-    $deps = @(runtime_deps $manifest) | Where-Object { !(installed $_) }
+    $deps = @(runtime_deps $manifest) | Where-Object {
+        $app, $bucket, $null = parse_app $_
+        return !(installed $app)
+    }
     if($deps) {
         $status.missing_deps += ,$deps
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -83,6 +83,10 @@ function cache_path($app, $version, $url) { "$cachedir\$app#$version#$($url -rep
 function sanitary_path($path) { return [regex]::replace($path, "[/\\?:*<>|]", "") }
 function installed($app, $global=$null) {
     if($null -eq $global) { return (installed $app $true) -or (installed $app $false) }
+    # Dependencies of the format "bucket/dependency" install in a directory of form
+    # "dependency". So we need to extract the bucket from the name and only give the app
+    # name to is_directory
+    $app = $app.split("/")[-1]
     return is_directory (appdir $app $global)
 }
 function installed_apps($global) {


### PR DESCRIPTION
In the app manifest, specifying dependencies with the bucket on which to find that dependency is supported (see the [flutter](https://github.com/lukesampson/scoop-extras/blob/master/flutter.json) manifest for an example). The problem, however, is that when running `scoop status` after installing an app such as flutter, we get an error message that some dependencies are supposedly missing:

![image](https://user-images.githubusercontent.com/9417983/43159278-9505c38e-8f8a-11e8-9242-fd32cd701205.png)

This message is however wrong, since oraclejdk8 was successfully installed. The problem is that flutter checks if a dependency is installed by checking whether a directory with the name of that dependency exists in the apps folder. In this case it checks for the folder `java/oraclejdk8`, doesn't find it, since it actually exists as `oraclejdk8` and marks the dependency as being not satisfied.

This small pull request fixes that:

![image](https://user-images.githubusercontent.com/9417983/43159757-efacd57e-8f8b-11e8-8fad-e2eef0c190fb.png)

