### PR TITLE
scoop-info: Make manifest file path looks better

### DIFF
--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -62,6 +62,7 @@ if ($manifest.license) {
 }
 
 # Manifest file
+$manifest_file = fullpath $manifest_file
 Write-Output "Manifest:`n  $manifest_file"
 
 if($status.installed) {


### PR DESCRIPTION
before:
```
Manifest:
  C:\Users\<omitted>\scoop\apps\scoop\current\lib\..\bucket\go.json
```

after: 
```
Manifest:
  C:\Users\<omitted>\scoop\apps\scoop\current\bucket\go.json
```