### PR TITLE
Normalize multi-line strings to string arrays on format

### DIFF
--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -9,6 +9,9 @@ Function ConvertToPrettyJson {
     )
 
     Process  {
+        $data = normalize_values $data
+
+        # convert to string
         [String]$json = $data | ConvertTo-Json -Depth 8 -Compress
         [String]$output = ""
 
@@ -131,4 +134,26 @@ function json_path_legacy([String] $json, [String] $jsonpath, [String] $basename
         $result = $result.$el
     }
     return $result
+}
+
+function normalize_values([psobject] $json) {
+    # Iterate Through Manifest Properties
+    $json.PSObject.Properties | ForEach-Object {
+
+        # Process String Values
+        if ($_.Value -is [string]) {
+
+            # Split on new lines
+            [array] $parts = ($_.Value -split '\r?\n').Trim()
+
+            # Replace with string array if result is multiple lines
+            if ($parts.Count -gt 1) {
+                $_.Value = $parts
+            }
+        }
+
+        # Process other values as needed...
+    }
+
+    return $json
 }


### PR DESCRIPTION
Per https://github.com/lukesampson/scoop-extras/commit/ce566dfd2901b854ee7495f5a4c1951df3cc1dc7#r29870321 this PR updates the format script to convert multi-line strings into string arrays.