### PR TITLE
Expose resharper cleanupcode binary

### DIFF
--- a/bucket/resharper-clt.json
+++ b/bucket/resharper-clt.json
@@ -8,6 +8,7 @@
     "url": "https://download.jetbrains.com/resharper/JetBrains.ReSharper.CommandLineTools.2018.1.3.zip",
     "hash": "6f6b06f16d885a0c9f7795b20c60446464f230444ce7119ec1b114b1438ddd55",
     "bin": [
+        "cleanupcode.exe",
         "dupfinder.exe",
         "inspectcode.exe"
     ],


### PR DESCRIPTION
Jetbrains [added](https://blog.jetbrains.com/dotnet/2018/03/01/code-cleanup-resharper-command-line-tools/) a code cleanup binary `cleanupcode.exe` to their command line tools. This PR adds this binary to the list of scoop binaries.