### PR TITLE
haskell: Fix hash (closes #2422)

### DIFF
--- a/bucket/haskell.json
+++ b/bucket/haskell.json
@@ -4,7 +4,7 @@
     "architecture": {
         "64bit": {
             "url": "https://haskell.org/platform/download/8.4.3/HaskellPlatform-8.4.3-core-x86_64-setup.exe",
-            "hash": "a5eecc051085a535049e18e9ddf7390f16edbdbc2327feada39d62b496f0b79b"
+            "hash": "a8a0eed4c19bed251c46e9d31a1668469275ba592f55261a53da91c306093557"
         }
     },
     "installer": {


### PR DESCRIPTION
The hash can be verified by comparing it with the hash listed on
https://www.haskell.org/platform/windows.html.