### PR TITLE
Create tcc.json

### DIFF
--- a/tcc.json
+++ b/tcc.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://bellard.org/tcc/",
+    "description": "The Tiny C Compiler (a.k.a. TCC, tCc, or TinyCC) is an x86, X86-64 and ARM processor C compiler created by Fabrice Bellard. It is designed to work for slow computers with little disk space (e.g. on rescue disks).",
+    "license": "LGPL",
+    "version": "0.9.27",
+    "architecture": {
+        "64bit": {
+            "url": "http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win64-bin.zip",
+            "extract_dir": "tcc"
+        },
+        "32bit": {
+            "url": "http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.27-win32-bin.zip",
+            "hash": "02e2bfe8c272a549b15e4bfa4507bd7e05304692af1761db6c1e8e88af675651"
+        }
+    },
+    "env_add_path": "tcc",
+    "checkver": "tcc-([\\d.]+)-win64-bin.zip",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.savannah.gnu.org/releases/tinycc/tcc-$version-win64-bin.zip"
+            },
+            "32bit": {
+                "url": "http://download.savannah.gnu.org/releases/tinycc/tcc-$version-win32-bin.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The Tiny C Compiler (a.k.a. TCC, tCc, or TinyCC) is an x86, X86-64 and ARM processor C compiler created by Fabrice Bellard. It is designed to work for slow computers with little disk space (e.g. on rescue disks).