### PR TITLE
expose xxd.exe from vim

### DIFF
--- a/bucket/vim.json
+++ b/bucket/vim.json
@@ -70,7 +70,8 @@
             "gvim.exe",
             "gvimdiff",
             "-d"
-        ]
+        ],
+        "xxd.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
`xxd` (a hexdump tool) is a tool bundled with `vim`. Unlike other tools bundled with vim (e.g. `diff`). It is a first party vim tool. So even if we were to setup `xxd` as a separate package, we would have to download vim. 

Ref: https://packages.ubuntu.com/source/bionic/vim