### PR TITLE
catch unzip failures from bad file names

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -255,6 +255,13 @@ function unzip($path, $to) {
         } else {
             abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
         }
+    } catch [system.io.ioexception] {
+        if (7zip_installed) {
+            extract_7zip $path $to $false
+            return
+        } else {
+            abort "Unzip failed: Windows can't handle the file names in this zip file.`nRun 'scoop install 7zip' and try again."
+        }
     } catch {
         abort "Unzip failed: $_"
     }


### PR DESCRIPTION
Currently `scoop install exercism-cli` (with the extras bucket added) will fail, because the downloaded .zip file contains files that would be extracted outside of the target directory:

- ../shell/README.md
- ../shell/exercism_completion.bash 
- ../shell/exercism_completion.zsh

This PR adds 7zip fallback functionality when the System.IO.IOException occurs, almost exactly like the handling for System.IO.PathTooLongException. 7zip will safely handle those files by moving them into the target directory.