### PR TITLE
aria2: Include build no in autoupdate

### DIFF
--- a/bucket/aria2.json
+++ b/bucket/aria2.json
@@ -2,7 +2,7 @@
     "homepage": "https://aria2.github.io/",
     "description": "Lightweight multi-protocol & multi-source command-line download utility",
     "license": "GPL-2.0-or-later",
-    "version": "1.34.0",
+    "version": "1.34.0-1",
     "architecture": {
         "32bit": {
             "url": "https://github.com/aria2/aria2/releases/download/release-1.34.0/aria2-1.34.0-win-32bit-build1.zip",
@@ -16,16 +16,20 @@
         }
     },
     "bin": "aria2c.exe",
-    "checkver": "<p>Download <a href=\"https://github.com/aria2/aria2[^\"]+\">version ([^<]+)</a>",
+    "checkver": {
+        "github": "https://github.com/aria2/aria2",
+        "re": "/release-(?:[\\d.]+)/aria2-(?<version>[\\d.]+)-win-64bit-build(?<build>[\\d]+).zip",
+        "replace": "${version}-${build}"
+    },
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://github.com/aria2/aria2/releases/download/release-$version/aria2-$version-win-32bit-build1.zip",
-                "extract_dir": "aria2-$version-win-32bit-build1"
+                "url": "https://github.com/aria2/aria2/releases/download/release-$matchVersion/aria2-$matchVersion-win-32bit-build$matchBuild.zip",
+                "extract_dir": "aria2-$matchVersion-win-32bit-build$matchBuild"
             },
             "64bit": {
-                "url": "https://github.com/aria2/aria2/releases/download/release-$version/aria2-$version-win-64bit-build1.zip",
-                "extract_dir": "aria2-$version-win-64bit-build1"
+                "url": "https://github.com/aria2/aria2/releases/download/release-$matchVersion/aria2-$matchVersion-win-64bit-build$matchBuild.zip",
+                "extract_dir": "aria2-$matchVersion-win-64bit-build$matchBuild"
             }
         }
     }


### PR DESCRIPTION
Build no was hard coded in url and extract_dir. Sometimes aria2 is released with build no >1, for example [1.23.0](https://github.com/aria2/aria2/releases/tag/release-1.23.0).