### PR TITLE
Update poppler.json

### DIFF
--- a/bucket/poppler.json
+++ b/bucket/poppler.json
@@ -17,7 +17,7 @@
     ],
     "checkver": "Latest.*uploads/(?<date>\\d{4}/\\d{2})/poppler-(?<version>[\\d.]+)_x86.7z",
     "description": "PDF rendering library",
-    "extract_dir": "poppler-0.51",
+    "extract_dir": "poppler-0.67.0",
     "hash": "71763bfef42aa161c052a667139daeb81b69beabda3c4861a1c25e8f28ab65a6",
     "homepage": "http://blog.alivate.com.au/poppler-windows/",
     "license": "GPL-3.0",


### PR DESCRIPTION
Modify `extract_dir` to correct error 16. (See output below.)

```
-------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows
-------------------------------------------------------------------------------

  Started : August 10, 2018 1:11:53 PM
   Source : C:\Users\iain.gillis\scoop\apps\poppler\0.67.0\_tmp\poppler-0.51\
     Dest : C:\Users\iain.gillis\scoop\apps\poppler\0.67.0\

    Files : *.*

  Options : *.* /S /E /DCOPY:DA /COPY:DAT /MOVE /R:1000000 /W:30

------------------------------------------------------------------------------

2018/08/10 13:11:53 ERROR 2 (0x00000002) Accessing Source Directory C:\Users\iain.gillis\scoop\apps\poppler\0.67.0\_tmp\
poppler-0.51\
The system cannot find the file specified.

ERROR Could not find 'poppler-0.51'! (error 16)

Please create a new issue by using the following link and paste your console output:
https://github.com/lukesampson/scoop/issues/new?title=poppler%400.67.0%3a+extract_dir+error
```