### PR TITLE
Reset $errorActionPreference to original value

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -2,6 +2,7 @@
 
 # remote install:
 #   iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+$old_erroractionpreference = $erroractionpreference
 $erroractionpreference = 'stop' # quit if anything goes wrong
 
 if(($PSVersionTable.PSVersion.Major) -lt 3) {
@@ -50,3 +51,5 @@ ensure_robocopy_in_path
 ensure_scoop_in_path
 success 'Scoop was installed successfully!'
 Write-Output "Type 'scoop help' for instructions."
+
+$erroractionpreference = $old_erroractionpreference # Reset $erroractionpreference to original value


### PR DESCRIPTION
For AppVeyor CI the `$errorActionPreference` setting is persisting after I install scoop, subsequently causing issues with installing scoop apps (e.g. failing the whole build because an installer executable outputs what looks like an error).