### PR TITLE
Cygwin: how about creating a shim for using of cygwin installer only?

### DIFF
--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -31,6 +31,14 @@
             "root\\bin\\bash.exe",
             "cygwin",
             "--login -i"
+        ],
+        [
+            "setup-x86_64.exe",
+            "Cygwin-Setup"
+        ],
+        [
+            "setup-x86.exe",
+            "Cygwin-Setup"
         ]
     ],
     "installer": {

--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -5,11 +5,35 @@
     "architecture": {
         "64bit": {
             "url": "https://cygwin.com/setup-x86_64.exe",
-            "hash": "01794f55fab26842c12e2a67fc218ad9c1a9201ccf0bf2fbd9f5815d6f20182f"
+            "hash": "01794f55fab26842c12e2a67fc218ad9c1a9201ccf0bf2fbd9f5815d6f20182f",
+            "bin": [
+                [
+                    "setup-x86_64.exe",
+                    "Setup-Cygwin"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "setup-x86_64.exe",
+                    "Setup Cygwin64"
+                ]
+            ]
         },
         "32bit": {
             "url": "https://cygwin.com/setup-x86.exe",
-            "hash": "3da0b1a5a14418abc8bb04bcbd475fe8cf25648526302dfee563de9e5c0b5ff2"
+            "hash": "3da0b1a5a14418abc8bb04bcbd475fe8cf25648526302dfee563de9e5c0b5ff2",
+            "bin": [
+                [
+                    "setup-x86.exe",
+                    "Setup-Cygwin"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "setup-x86.exe",
+                    "Setup Cygwin"
+                ]
+            ]
         }
     },
     "autoupdate": {
@@ -31,14 +55,6 @@
             "root\\bin\\bash.exe",
             "cygwin",
             "--login -i"
-        ],
-        [
-            "setup-x86_64.exe",
-            "Setup-Cygwin"
-        ],
-        [
-            "setup-x86.exe",
-            "Setup-Cygwin"
         ]
     ],
     "installer": {
@@ -59,24 +75,6 @@
         "root"
     ],
     "pre_install": "new-item -itemtype directory \"$dir\\root\"; new-item -itemtype directory \"$dir\\packages\"",
-    "post_install": [
-        "$customShortcut = (New-Object -ComObject (\"WScript.Shell\")).CreateShortcut(",
-        "   $( if ($global) {",
-        "           Join-Path ([Environment]::GetFolderPath('CommonStartMenu')) '\\Scoop Apps\\Setup Cygwin.lnk'",
-        "      } else {",
-        "           Join-Path ([Environment]::GetFolderPath('StartMenu')) '\\Scoop Apps\\Setup Cygwin.lnk'",
-        "      }",
-        "   )",
-        ")",
-        "If (Test-Path $dir\\setup-x86_64.exe) {",
-        "   $customShortcut.targetPath = Join-Path $dir '\\setup-x86_64.exe'",
-        "   $customShortcut.save()",
-        "}",
-        "If (Test-Path $dir\\setup-x86.exe) {",
-        "   $customShortcut.targetPath = Join-Path $dir '\\setup-x86.exe'",
-        "   $customShortcut.save()",
-        "}"
-    ],
     "shortcuts": [
         [
             "root\\Cygwin.bat",

--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -8,11 +8,20 @@
             "hash": "01794f55fab26842c12e2a67fc218ad9c1a9201ccf0bf2fbd9f5815d6f20182f",
             "bin": [
                 [
+                    "root\\bin\\bash.exe",
+                    "cygwin",
+                    "--login -i"
+                ],
+                [
                     "setup-x86_64.exe",
                     "Setup-Cygwin"
                 ]
             ],
             "shortcuts": [
+                [
+                    "root\\Cygwin.bat",
+                    "Cygwin"
+                ],
                 [
                     "setup-x86_64.exe",
                     "Setup Cygwin64"
@@ -24,11 +33,20 @@
             "hash": "3da0b1a5a14418abc8bb04bcbd475fe8cf25648526302dfee563de9e5c0b5ff2",
             "bin": [
                 [
+                    "root\\bin\\bash.exe",
+                    "cygwin",
+                    "--login -i"
+                ],
+                [
                     "setup-x86.exe",
                     "Setup-Cygwin"
                 ]
             ],
             "shortcuts": [
+                [
+                    "root\\Cygwin.bat",
+                    "Cygwin"
+                ],
                 [
                     "setup-x86.exe",
                     "Setup Cygwin"
@@ -50,13 +68,6 @@
         "re": "<a.*href=\"/git/\\?p=cygwin-apps/setup\\.git;a=tag.*\">([\\d.]+)</a>",
         "url": "https://cygwin.com/git/?p=cygwin-apps/setup.git;a=tags"
     },
-    "bin": [
-        [
-            "root\\bin\\bash.exe",
-            "cygwin",
-            "--login -i"
-        ]
-    ],
     "installer": {
         "args": [
             "--no-admin",
@@ -74,11 +85,5 @@
         "packages",
         "root"
     ],
-    "pre_install": "new-item -itemtype directory \"$dir\\root\"; new-item -itemtype directory \"$dir\\packages\"",
-    "shortcuts": [
-        [
-            "root\\Cygwin.bat",
-            "Cygwin"
-        ]
-    ]
+    "pre_install": "new-item -itemtype directory \"$dir\\root\"; new-item -itemtype directory \"$dir\\packages\""
 }

--- a/bucket/cygwin.json
+++ b/bucket/cygwin.json
@@ -34,11 +34,11 @@
         ],
         [
             "setup-x86_64.exe",
-            "Cygwin-Setup"
+            "Setup-Cygwin"
         ],
         [
             "setup-x86.exe",
-            "Cygwin-Setup"
+            "Setup-Cygwin"
         ]
     ],
     "installer": {
@@ -59,6 +59,24 @@
         "root"
     ],
     "pre_install": "new-item -itemtype directory \"$dir\\root\"; new-item -itemtype directory \"$dir\\packages\"",
+    "post_install": [
+        "$customShortcut = (New-Object -ComObject (\"WScript.Shell\")).CreateShortcut(",
+        "   $( if ($global) {",
+        "           Join-Path ([Environment]::GetFolderPath('CommonStartMenu')) '\\Scoop Apps\\Setup Cygwin.lnk'",
+        "      } else {",
+        "           Join-Path ([Environment]::GetFolderPath('StartMenu')) '\\Scoop Apps\\Setup Cygwin.lnk'",
+        "      }",
+        "   )",
+        ")",
+        "If (Test-Path $dir\\setup-x86_64.exe) {",
+        "   $customShortcut.targetPath = Join-Path $dir '\\setup-x86_64.exe'",
+        "   $customShortcut.save()",
+        "}",
+        "If (Test-Path $dir\\setup-x86.exe) {",
+        "   $customShortcut.targetPath = Join-Path $dir '\\setup-x86.exe'",
+        "   $customShortcut.save()",
+        "}"
+    ],
     "shortcuts": [
         [
             "root\\Cygwin.bat",


### PR DESCRIPTION
For example I already have an installation of cygwin at C:\cygwin64, just only want to use setup-x86(_64).exe installed by scoop.