### PR TITLE
Use innosetup for GraphicsMagick

### DIFF
--- a/bucket/graphicsmagick-q16.json
+++ b/bucket/graphicsmagick-q16.json
@@ -12,21 +12,7 @@
             "hash": "sha1:3eb4e6b12540e64bd1d78913e221ec5f3573fb55"
         }
     },
-    "installer": {
-        "args": [
-            "/SILENT",
-            "/SUPPRESSMSHBOXES",
-            "/DIR=$dir"
-        ]
-    },
-    "uninstaller": {
-        "file": "unins000.exe",
-        "args": [
-            "/SILENT",
-            "/SUPPRESSMSHBOXES",
-            "/NOCANCEL"
-        ]
-    },
+    "innosetup": true,
     "bin": [
         "gm.exe",
         [

--- a/bucket/graphicsmagick-q8.json
+++ b/bucket/graphicsmagick-q8.json
@@ -12,21 +12,7 @@
             "hash": "sha1:e72483764d1d3989551d942814e3e6b4e957d6af"
         }
     },
-    "installer": {
-        "args": [
-            "/SILENT",
-            "/SUPPRESSMSHBOXES",
-            "/DIR=$dir"
-        ]
-    },
-    "uninstaller": {
-        "file": "unins000.exe",
-        "args": [
-            "/SILENT",
-            "/SUPPRESSMSHBOXES",
-            "/NOCANCEL"
-        ]
-    },
+    "innosetup": true,
     "bin": [
         "gm.exe",
         [


### PR DESCRIPTION
GraphicsMagick installers are InnoSetup packages. Use scoop's innosetup extractor to install it, so we don't need to ask for administrative permission. 

Ref: http://hg.code.sf.net/p/graphicsmagick/code/file/5262d45f6dc6/VisualMagick/installer/README.txt