### PR TITLE
Add Guetzli version 1.0.1

### DIFF
--- a/bucket/guetzli.json
+++ b/bucket/guetzli.json
@@ -1,0 +1,41 @@
+{
+    "homepage": "https://github.com/google/guetzli",
+    "description": "Perceptual JPEG encoder",
+    "version": "1.0.1",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/google/guetzli/releases/download/v1.0.1/guetzli_windows_x86-64.exe",
+            "hash": "bbac41d606c96cc57a94c802e581591647d6e1cfc83a97522509edbd392faeca",
+            "bin": [
+                [
+                    "guetzli_windows_x86-64.exe",
+                    "guetzli"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/google/guetzli/releases/download/v1.0.1/guetzli_windows_x86.exe",
+            "hash": "7fb69c00a99a9c0fd7e47f4d263b74c68a7e63405fc27784d955895e8b7f2061",
+            "bin": [
+                [
+                    "guetzli_windows_x86.exe",
+                    "guetzli"
+                ]
+            ]
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/google/guetzli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/google/guetzli/releases/download/$version/guetzli_windows_x86-64.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/google/guetzli/releases/download/$version/guetzli_windows_x86.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
> [Guetzli](https://github.com/google/guetzli) is a JPEG encoder that aims for excellent compression density at high visual quality. Guetzli-generated images are typically 20-30% smaller than images of equivalent quality generated by libjpeg. Guetzli generates only sequential (nonprogressive) JPEGs due to faster decompression speeds they offer.