### PR TITLE
scons: Fix pre_install step by using escaped double quotes

### DIFF
--- a/bucket/scons.json
+++ b/bucket/scons.json
@@ -5,7 +5,7 @@
     "version": "3.0.1",
     "url": "https://downloads.sourceforge.net/project/scons/scons-local/3.0.1/scons-local-3.0.1.zip",
     "hash": "4ab1f274015287744a497dcbd522ff1446f28d3de9aad630aac37042a16f7bde",
-    "pre_install": "echo \"python '$dir\\scons.py' @args\" | out-file '$dir\\scons.ps1'",
+    "pre_install": "echo \"python `\"$dir\\scons.py`\" @args\" | out-file \"$dir\\scons.ps1\"",
     "bin": [
         "scons.ps1"
     ],


### PR DESCRIPTION
Installing `scons` resulted in an error as `$dir` wasn't being expanded (due to the use of single quotes instead of double quotes). PowerShell provides a way to escape nested double quotes (while still being embeddable in JSON), so let's use it :slightly_smiling_face:

This fixes a regression from https://github.com/lukesampson/scoop/commit/5c1e9ba0c54e434f26491f1e33c2381601c38534.