### PR TITLE
Add traefik 

### DIFF
--- a/bucket/traefik.json
+++ b/bucket/traefik.json
@@ -1,0 +1,43 @@
+{
+    "homepage": "https://traefik.io/",
+    "description": "HTTP reverse proxy and load balancer",
+    "version": "1.6.6",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/containous/traefik/releases/download/v1.6.6/traefik_windows-amd64.exe",
+            "hash": "256a1e35aa2ec372990f6bf504886aaf6c9fa9a8cdc0fa4857f42acaecb4ffa7",
+            "bin": [
+                [
+                    "traefik_windows-amd64.exe",
+                    "traefik"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/containous/traefik/releases/download/v1.6.6/traefik_windows-386.exe",
+            "hash": "4ee54515f02200c54e812767c4c60ea0f54be6864bacbb447d6690a311a19629",
+            "bin": [
+                [
+                    "traefik_windows-386.exe",
+                    "traefik"
+                ]
+            ]
+        }
+    },
+    "notes": "Run with a configuration file 'traefik -c <yourconfig.toml>' or 'traefik --help' for all options.",
+    "checkver": {
+        "github": "https://github.com/containous/traefik"
+    },
+    "autoupdate": {
+        "url": "https://github.com/cmderdev/cmder/releases/download/v$version/cmder_mini.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/containous/traefik/releases/download/v$version/traefik_windows-amd64.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/containous/traefik/releases/download/v$version/traefik_windows-386.exe"
+            }
+        }
+    }
+}

--- a/bucket/traefik.json
+++ b/bucket/traefik.json
@@ -5,26 +5,15 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/containous/traefik/releases/download/v1.6.6/traefik_windows-amd64.exe",
-            "hash": "256a1e35aa2ec372990f6bf504886aaf6c9fa9a8cdc0fa4857f42acaecb4ffa7",
-            "bin": [
-                [
-                    "traefik_windows-amd64.exe",
-                    "traefik"
-                ]
-            ]
+            "url": "https://github.com/containous/traefik/releases/download/v1.6.6/traefik_windows-amd64.exe#/traefik.exe",
+            "hash": "256a1e35aa2ec372990f6bf504886aaf6c9fa9a8cdc0fa4857f42acaecb4ffa7"
         },
         "32bit": {
-            "url": "https://github.com/containous/traefik/releases/download/v1.6.6/traefik_windows-386.exe",
-            "hash": "4ee54515f02200c54e812767c4c60ea0f54be6864bacbb447d6690a311a19629",
-            "bin": [
-                [
-                    "traefik_windows-386.exe",
-                    "traefik"
-                ]
-            ]
+            "url": "https://github.com/containous/traefik/releases/download/v1.6.6/traefik_windows-386.exe#/traefik.exe",
+            "hash": "4ee54515f02200c54e812767c4c60ea0f54be6864bacbb447d6690a311a19629"
         }
     },
+    "bin": "traefik.exe",
     "notes": "Run with a configuration file 'traefik -c <yourconfig.toml>' or 'traefik --help' for all options.",
     "checkver": {
         "github": "https://github.com/containous/traefik"
@@ -32,10 +21,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/containous/traefik/releases/download/v$version/traefik_windows-amd64.exe"
+                "url": "https://github.com/containous/traefik/releases/download/v$version/traefik_windows-amd64.exe#/traefik.exe"
             },
             "32bit": {
-                "url": "https://github.com/containous/traefik/releases/download/v$version/traefik_windows-386.exe"
+                "url": "https://github.com/containous/traefik/releases/download/v$version/traefik_windows-386.exe#/traefik.exe"
             }
         }
     }

--- a/bucket/traefik.json
+++ b/bucket/traefik.json
@@ -30,7 +30,6 @@
         "github": "https://github.com/containous/traefik"
     },
     "autoupdate": {
-        "url": "https://github.com/cmderdev/cmder/releases/download/v$version/cmder_mini.zip",
         "architecture": {
             "64bit": {
                 "url": "https://github.com/containous/traefik/releases/download/v$version/traefik_windows-amd64.exe"


### PR DESCRIPTION
This pull-request adds an app manifest for traefik (https://github.com/containous/traefik).

- Releases from Github.
- Separate binaries for each environment.