### PR TITLE
Fix PowerShell core crash

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -653,7 +653,13 @@ function check_hash($file, $hash, $app_name) {
         $msg += "App:         $app_name`n"
         $msg += "URL:         $url`n"
         if(Test-Path $file) {
-            $hexbytes = Get-Content $file -Encoding byte -TotalCount 8 | ForEach-Object { $_.tostring('x2') }
+            if((Get-Command Get-Content).parameters.ContainsKey('AsByteStream')) {
+                # PowerShell Core (6.0+) '-Encoding byte' is replaced by '-AsByteStream'
+                $hexbytes = Get-Content $file -AsByteStream -TotalCount 8 | ForEach-Object { $_.tostring('x2') }
+            }
+            else {
+                $hexbytes = Get-Content $file -Encoding byte -TotalCount 8 | ForEach-Object { $_.tostring('x2') }
+            }
             $hexbytes = [string]::join(' ', $hexbytes).ToUpper()
             $msg += "First bytes: $hexbytes`n"
         }


### PR DESCRIPTION
In PowerShell Core (6.0+) '-Encoding byte' is replaced by '-AsByteStream', fixed and tested on my Windows 10 Home with PowerShell Core 6.04 stable.

This is my first attempt to contribute back into your amazing project that I highly appreciate, so if something is missing like obligatory tests, waiver, issues etc - feel free to pinpoint and I will try to conform!