### PR TITLE
Add bat.exe to scoop

### DIFF
--- a/bucket/bat.json
+++ b/bucket/bat.json
@@ -1,0 +1,20 @@
+{
+    "homepage": "https://github.com/sharkdp/bat",
+    "license": "MIT",
+    "version": "0.6.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sharkdp/bat/releases/download/v0.6.1/bat-v0.6.1-x86_64-pc-windows-msvc.zip",
+            "hash": "76910a2f0f022938353b085cf7257528561cd9dd42b5c42e5aa85e4f50e0afa6"
+        }
+    },
+    "bin": "bat.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sharkdp/bat/releases/download/v$version/bat-v$version-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
bat is a replacement for cat
it has:

- support for multiple files
- syntax highlighting
- line numbering by default.

It is written by the same person that maintains fd(which is in scoop). 

atm bat does not have a 32-bit binary.