### PR TITLE
make shim support PS 2.0

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -367,7 +367,9 @@ function shim($path, $global, $name, $arg) {
     if($relative_path -match "^(.\\[\w]:).*$") {
         write-output "`$path = `"$path`"" | out-file "$shim.ps1" -encoding utf8
     } else {
-        write-output "`$path = join-path `"`$psscriptroot`" `"$relative_path`"" | out-file "$shim.ps1" -encoding utf8
+        # Setting PSScriptRoot in Shim if it is not defined, so the shim doesn't break in PowerShell 2.0
+        Write-Output "if (!(Test-Path Variable:PSScriptRoot)) { `$PSScriptRoot = Split-Path `$MyInvocation.MyCommand.Path -Parent }" | Out-File "$shim.ps1" -Encoding utf8
+        write-output "`$path = join-path `"`$psscriptroot`" `"$relative_path`"" | out-file "$shim.ps1" -Encoding utf8 -Append
     }
 
     if($path -match '\.jar$') {


### PR DESCRIPTION
### Background ###

PowerShell on Windows comes with both 2.0 and 3.0+ installed. This is a feature inherited from .NET --  PowerShell 2.0 is based on .NET 2.0 which is installed side-by-side with .NET 3.0-4.7. It is possible to run PowerShell 2.0 by invoking the command `powershell.exe -Version 2.0 -NoProfile`. 

### Use case ###
This is fairly useful feature for PowerShell scripters, as one can use PowerShell 2.0 to check for the basic compatibility of scripts without having to run a VM. As such, a user can have scoop apps installed via PowerShell 3.0+, and then launch PowerShell 2.0 for casual testing. 

Currently the scoop shims are broken in PowerShell 2.0, as they use `$PSScriptRoot`. In addition, since PowerShell picks up `{command}.ps1` before `{command}.exe` when looking for `{command}`, this makes using scoop-installed app difficult in PowerShell 2.0. 

While Scoop command itself doesn't support PowerShell 2.0, and there is no point in doing so, it is fairly easy to make the shims support PowerShell 2.0, so this is what this patch does. 

