### PR TITLE
Fix .ps1 shim parsing logic due to my prior PR

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -332,14 +332,19 @@ function get_app_name($path) {
     return ""
 }
 
+function get_app_name_from_ps1_shim($shim_ps1) {
+    if (!([System.IO.File]::Exists($shim_ps1))) {
+        return ""
+    }
+    $first_1k_text = (Get-Content $shim_ps1 -Encoding utf8 -TotalCount 1000) -join ' '
+    return get_app_name $first_1k_text
+}
+
 function warn_on_overwrite($shim_ps1, $path) {
     if (!([System.IO.File]::Exists($shim_ps1))) {
         return
     }
-    $reader = [System.IO.File]::OpenText($shim_ps1)
-    $line = $reader.ReadLine().replace("`r","").replace("`n","")
-    $reader.Close()
-    $shim_app = get_app_name $line
+    $shim_app = get_app_name_from_ps1_shim $shim_ps1
     $path_app = get_app_name $path
     if ($shim_app -eq $path_app) {
         return


### PR DESCRIPTION
Due to my prior PR #2562 which changed the content of .ps1 shims, the code that attempts to warn about shims being overwritten no longer detects app name correctly. This is to correct that. 

Since now the path of the app can be on either first line or 2nd line, my implementation just assumes shims will be utf8 files and try to find first the app name in the first 1000 characters. This works for both the old shim and the new shim, and allow for some forward flexibility towards how shim code is written going forward. 
