### PR TITLE
Make AppVeyor run tests in PowerShell Core as well

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,17 @@ branches:
   except:
     - gh-pages
 
+build: off
+
 init:
   - ps: (get-psprovider 'FileSystem').Home = $(pwd)
   - ps: Install-PackageProvider Nuget -Force
   - ps: Install-Module -Name Pester -Repository PSGallery -Force
   - ps: Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Force
-
-build: off
+  - pwsh: (get-psprovider 'FileSystem').Home = $(pwd)
+  - pwsh: Install-Module -Name Pester -Repository PSGallery -Force
+  - pwsh: Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Force
 
 test_script:
-  - ps: $result = invoke-pester -path test/ -outputfile TestResults.xml -outputformat NUnitXML -passthru; $env:failedcount = $result.failedcount
-  - ps: (new-object net.webclient).uploadfile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (resolve-path ./TestResults.xml))
-  - ps: if($env:failedcount -gt 0) { exit $env:failedcount }
+  - ps: ./appveyor/test_script.ps1; if($env:failedcount -gt 0) { exit $env:failedcount }
+  - pwsh: ./appveyor/test_script.ps1; if($env:failedcount -gt 0) { exit $env:failedcount }

--- a/appveyor/test_script.ps1
+++ b/appveyor/test_script.ps1
@@ -1,0 +1,6 @@
+Write-Output $PSVersionTable
+$env:failedcount = 0
+$PesterOutputFile = "$TEMP\TestResults-{0}.xml" -f $PSVersionTable.PSVersion
+$result = Invoke-Pester -Path test/ -OutputFile $PesterOutputFile -OutputFormat NUnitXML -PassThru
+$env:failedcount = $result.failedcount
+(New-Object Net.WebClient).UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $PesterOutputFile))


### PR DESCRIPTION
Make AppVeyor run tests in PowerShell Core as well. 

AppVeyor images (at least [Visual Studio 2015](https://www.appveyor.com/docs/build-environment/#pre-installed-software)) are bundled with both PowerShell and PowerShell Core, this change runs all the tests in both environments. 

Might be an issue in the long run when test takes a long time to run, but right now its only 3 minutes. 