### PR TITLE
Add exercism

### DIFF
--- a/bucket/exercism.json
+++ b/bucket/exercism.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://github.com/exercism/cli",
+    "description": "A Go based command line tool for exercism.io.",
+    "version": "3.0.9",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/exercism/cli/releases/download/v3.0.9/exercism-windows-64bit.zip",
+            "hash": "4ec5f100155efa100e1bf6f4d0e2920a8ffddd053a713cb3085181f6737308e8"
+        },
+        "32bit": {
+            "url": "https://github.com/exercism/cli/releases/download/v3.0.9/exercism-windows-32bit.zip",
+            "hash": "383a75b4a12119c69bf1f1206609a717f93cf1e31a440332a0723d767017b2d1"
+        }
+    },
+    "bin": "exercism.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/exercism/cli/releases/download/v$version/exercism-windows-64bit.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/exercism/cli/releases/download/v$version/exercism-windows-32bit.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull-request adds an app manifest for [exercism](https://github.com/exercism/cli).

- Releases from Github;
- Separate binaries for each environment.
