### PR TITLE
add qrencode

### DIFF
--- a/bucket/qrencode.json
+++ b/bucket/qrencode.json
@@ -1,0 +1,26 @@
+{
+    "version": "3.4.4",
+    "description": "Based on popular libqrencode library, provides executable tool to create QR Code images",
+    "license": "LGPL-2.1",
+    "url": "http://khudob.in.s3-website-us-west-2.amazonaws.com/releases/qrcodegui_setup-3.4.4.exe",
+    "homepage": "https://code.google.com/archive/p/qrencode-win32/",
+    "hash": "b313ee945b8388071ad13e97df2c1072e6adc1315471169c6276ec31ea79b3a2",
+    "innosetup": true,
+    "pre_install": "echo \"if(`$MyInvocation.ExpectingInput) { `$input | & $dir\\qrcode.exe @args | Out-String } else { & $dir\\qrcode.exe @args | Out-String }\" | Out-File -Encoding ASCII \"$dir\\qrencode.ps1\"",
+    "bin": [
+        "qrencode.ps1",
+        "qrcodegui.exe"
+    ],
+    "notes": [
+        "Due to the fact bundled console .exe files do not call SetConsoleMode() to enable",
+        "ANSI mode, the origin two console executables qrcode.exe and qrcodecon.exe are",
+        "not exposed. A custom shim 'qrencode' has been provided that tries to work",
+        "around some of the incompatibilities. However, output UTF8 to stdout is still",
+        "non-functional, as that requires changing Windows code page.",
+        "> Usages:",
+        ">     qrencode -t ANSI 'Hello World'",
+        ">     echo 'Hello World' | qrencode -t ANSI",
+        ">     qrencode -t UTF8 'Hello World' -o QR.txt",
+        ""
+    ]
+}


### PR DESCRIPTION
Windows port of `qrencode` command. Unfortunately the guy who ported it hasn't update it for sometime. 

The compiled .exe files are rough-around-the-edges to use, it has encoding issues with Windows Console (ANSI color and UTF8). I wrote a small shim that works around ANSI color.  

Maybe when we get to the point of having our own build stack like Homebrew, we will build it from source. 