### PR TITLE
cmder: Add hash extraction

### DIFF
--- a/bucket/cmder-full.json
+++ b/bucket/cmder-full.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "http://cmder.net",
+    "description": "Portable console emulator for Windows",
+    "version": "1.3.6",
+    "license": "MIT",
+    "persist": "config",
+    "url": "https://github.com/cmderdev/cmder/releases/download/v1.3.6/cmder.7z",
+    "hash": "4ad3f927932feb6754683a4db1a4984db8ee662d45b7bde57ef8e206e8749711",
+    "bin": "Cmder.exe",
+    "shortcuts": [
+        [
+            "Cmder.exe",
+            "Cmder"
+        ]
+    ],
+    "env_set": {
+        "CMDER_ROOT": "$dir",
+        "ConEmuDir": "$dir\\vendor\\conemu-maximus5"
+    },
+    "checkver": {
+        "github": "https://github.com/cmderdev/cmder"
+    },
+    "autoupdate": {
+        "url": "https://github.com/cmderdev/cmder/releases/download/v$version/cmder.7z",
+        "hash": {
+            "url": "https://github.com/cmderdev/cmder/releases/download/v$version/hashes.txt",
+            "find": "$basename\\s+([A-Fa-f\\d]{64})"
+        }
+    }
+}

--- a/bucket/cmder.json
+++ b/bucket/cmder.json
@@ -3,9 +3,7 @@
     "description": "Portable console emulator for Windows",
     "version": "1.3.6",
     "license": "MIT",
-    "persist": [
-        "config"
-    ],
+    "persist": "config",
     "url": "https://github.com/cmderdev/cmder/releases/download/v1.3.6/cmder_mini.zip",
     "hash": "d151bd1e6293dce24b86a1170674661f573a40e346622fa524e57a1aee4e3ab7",
     "bin": "Cmder.exe",
@@ -23,6 +21,10 @@
         "github": "https://github.com/cmderdev/cmder"
     },
     "autoupdate": {
-        "url": "https://github.com/cmderdev/cmder/releases/download/v$version/cmder_mini.zip"
+        "url": "https://github.com/cmderdev/cmder/releases/download/v$version/cmder_mini.zip",
+        "hash": {
+            "url": "https://github.com/cmderdev/cmder/releases/download/v$version/hashes.txt",
+            "find": "$basename\\s+([A-Fa-f\\d]{64})"
+        }
     }
 }


### PR DESCRIPTION
- Closes #2628 

Runing something like `Remove-Item \"$dir\\vendor\\git-for-windows\" -Force -Recurse` would save some space.