### PR TITLE
Fixed issue with buffalo binary name in archive

### DIFF
--- a/bucket/buffalo.json
+++ b/bucket/buffalo.json
@@ -7,7 +7,7 @@
     "hash": "b3edf61de66d42f947414b0e1664a90487c1a7f40fd714a4c77cf9c21b1dfd76",
     "bin": [
         [
-            "buffalo-no-sqlite.exe",
+            "buffalo.exe",
             "buffalo"
         ]
     ],


### PR DESCRIPTION
```
$ scoop install buffalo
Installing 'buffalo' (0.12.7) [64bit]
Loading buffalo_0.12.7_windows_amd64.tar.gz from cache
Checking hash of buffalo_0.12.7_windows_amd64.tar.gz ... ok.
Extracting buffalo_0.12.7_windows_amd64.tar.gz ... done.
Linking ~\scoop\apps\buffalo\current => ~\scoop\apps\buffalo\0.12.7
Creating shim for 'buffalo'.
Can't shim 'buffalo-no-sqlite.exe': File doesn't exist.
```

```
$ 7z.exe l buffalo_0.12.7_windows_amd64.tar

7-Zip 18.05 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2018-04-30

Scanning the drive for archives:
1 file, 15499776 bytes (15 MiB)

Listing archive: buffalo_0.12.7_windows_amd64.tar

--
Path = buffalo_0.12.7_windows_amd64.tar
Type = tar
Physical Size = 15499776
Headers Size = 2560
Code Page = UTF-8

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2018-09-20 15:19:49 .....         1076         1536  LICENSE.txt
2018-10-03 15:32:41 .....         6503         6656  README.md
2018-10-03 15:53:04 .....     15489024     15489024  buffalo.exe
------------------- ----- ------------ ------------  ------------------------
2018-10-03 15:53:04           15496603     15497216  3 files
```