### PR TITLE
sass: rename dart-sass to sass

### DIFF
--- a/bucket/sass.json
+++ b/bucket/sass.json
@@ -14,7 +14,10 @@
     },
     "extract_dir": "dart-sass",
     "bin": [
-        "dart-sass.bat"
+        [
+            "sass.bat",
+            "sass"
+        ]
     ],
     "checkver": {
         "url": "https://github.com/sass/dart-sass/releases/latest",


### PR DESCRIPTION
```powershell
$ dart-sass
"WARNING: The dart-sass executable is deprecated, use sass instead."
Compile Sass to CSS.
```

And uniform the app name

```sh
npm install -g sass
choco install sass
```
