### PR TITLE
Allow letters in github version s

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -101,7 +101,7 @@ $Queue | ForEach-Object {
     }
     Register-ObjectEvent $wc downloadstringcompleted -ErrorAction Stop | Out-Null
 
-    $githubRegex = '\/releases\/tag\/(?:v)?([\d.]+)'
+    $githubRegex = '\/releases\/tag\/(?:v)?([\w.]+)'
 
     $url = $json.homepage
     if ($json.checkver.url) {


### PR DESCRIPTION
There are project which include letters in their version names. E.g. _Fritzing_ (https://github.com/fritzing/fritzing-app/releases/latest) is now on `0.9.3b`. When only looking for numbers, the version is not extracted correctly.