### PR TITLE
[Buffalo] Fix executable file name

### DIFF
--- a/bucket/buffalo.json
+++ b/bucket/buffalo.json
@@ -7,7 +7,7 @@
     "hash": "4bc420c0ceb9bf8fce6f1ab79d809538ef9da52727e3c158cb390cb244517453",
     "bin": [
         [
-            "buffalo.exe",
+            "buffalo-no-sqlite.exe",
             "buffalo"
         ]
     ],

--- a/bucket/buffalo.json
+++ b/bucket/buffalo.json
@@ -7,7 +7,7 @@
     "hash": "b3edf61de66d42f947414b0e1664a90487c1a7f40fd714a4c77cf9c21b1dfd76",
     "bin": [
         [
-            "buffalo-no-sqlite.exe",
+            "buffalo.exe",
             "buffalo"
         ]
     ],


### PR DESCRIPTION
```
$ scoop update buffalo
buffalo: 0.12.7 -> 0.13.0
Updating one outdated app:
Updating 'buffalo' (0.12.7 -> 0.13.0)
Uninstalling 'buffalo' (0.12.7)
Removing shim for 'buffalo'.
Unlinking ~\scoop\apps\buffalo\current
Installing 'buffalo' (0.13.0) [64bit]
buffalo_0.13.0_windows_amd64.tar.gz (5.9 MB) [===========================================================================================] 100%
Checking hash of buffalo_0.13.0_windows_amd64.tar.gz ... ok.
Extracting buffalo_0.13.0_windows_amd64.tar.gz ... done.
Linking ~\scoop\apps\buffalo\current => ~\scoop\apps\buffalo\0.13.0
Creating shim for 'buffalo'.
Can't shim 'buffalo.exe': File doesn't exist.
```

```
$ 7z.exe l buffalo_0.13.0_windows_amd64.tar

7-Zip 18.05 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2018-04-30

Scanning the drive for archives:
1 file, 16471552 bytes (16 MiB)

Listing archive: buffalo_0.13.0_windows_amd64.tar

--
Path = buffalo_0.13.0_windows_amd64.tar
Type = tar
Physical Size = 16471552
Headers Size = 2560
Code Page = UTF-8

   Date      Time    Attr         Size   Compressed  Name
------------------- ----- ------------ ------------  ------------------------
2018-09-20 15:19:49 .....         1076         1536  LICENSE.txt
2018-10-15 12:17:31 .....         4877         5120  README.md
2018-10-15 12:21:46 .....     16462336     16462336  buffalo-no-sqlite.exe
------------------- ----- ------------ ------------  ------------------------
2018-10-15 12:21:46           16468289     16468992  3 files
```