### PR TITLE
Fix the check for ExecutionPolicy scope

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -12,7 +12,7 @@ if(($PSVersionTable.PSVersion.Major) -lt 3) {
 }
 
 # show notification to change execution policy:
-if((get-executionpolicy) -gt 'RemoteSigned') {
+if((get-executionpolicy -scope CurrentUser) -gt 'RemoteSigned') {
     Write-Output "PowerShell requires an execution policy of 'RemoteSigned' to run Scoop."
     Write-Output "To make this change please run:"
     Write-Output "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"


### PR DESCRIPTION
Under certain terminals like cmder, `Get-ExecutionPolicy` will show the scope of `Process`.  This fix explicitly checks the scope of `CurrentUser`.

Signed-off-by: Ben Dang <me@bdang.it>