### PR TITLE
Add manifest for git-istage

### DIFF
--- a/bucket/git-istage.json
+++ b/bucket/git-istage.json
@@ -17,13 +17,13 @@
     "license": "MIT",
     "installer": {
         "script": [
-            "Move-Item $dir\\$version $dir\\git-istage.$version.nupkg",
+            "Move-Item \"$dir\\$version\" \"$dir\\git-istage.$version.nupkg\"",
             "$nugetConfig = \"<?xml version=`\"1.0`\" encoding=`\"utf-8`\"?><configuration><packageSources><clear /><add key=`\"Local`\" value=`\"$dir`\" /></packageSources></configuration>\"",
             "$nugetConfigFile = \"$dir\\nuget.config\"",
-            "$nugetConfig | Out-File -Encoding UTF8 $nugetConfigFile",
-            "dotnet tool install git-istage --tool-path $dir --configfile $nugetConfigFile",
+            "$nugetConfig | Out-File -Encoding UTF8 \"$nugetConfigFile\"",
+            "dotnet tool install git-istage --tool-path \"$dir\" --configfile \"$nugetConfigFile\"",
             "$runCommand = \"if (-not (Test-Path env:DOTNET_ROOT)) { `$env:DOTNET_ROOT=Split-Path -Parent (Get-Command dotnet).Path } & `\"$dir\\git-istage.exe`\" `$args\"",
-            "$runCommand | Out-File -Encoding UTF8 $dir\\run.ps1"
+            "$runCommand | Out-File -Encoding UTF8 \"$dir\\run.ps1\""
         ]
     },
     "bin": [

--- a/bucket/git-istage.json
+++ b/bucket/git-istage.json
@@ -22,7 +22,7 @@
             "$nugetConfigFile = \"$dir\\nuget.config\"",
             "$nugetConfig | Out-File -Encoding UTF8 \"$nugetConfigFile\"",
             "dotnet tool install git-istage --tool-path \"$dir\" --configfile \"$nugetConfigFile\"",
-            "$runCommand = \"if (-not (Test-Path env:DOTNET_ROOT)) { `$env:DOTNET_ROOT=Split-Path -Parent (Get-Command dotnet).Path } & `\"$dir\\git-istage.exe`\" `$args\"",
+            "$runCommand = \"if ($env:DOTNET_ROOT -eq $null) { `$env:DOTNET_ROOT=Split-Path -Parent (Get-Command dotnet).Path } & `\"$dir\\git-istage.exe`\" `$args\"",
             "$runCommand | Out-File -Encoding UTF8 \"$dir\\run.ps1\""
         ]
     },

--- a/bucket/git-istage.json
+++ b/bucket/git-istage.json
@@ -1,0 +1,35 @@
+{
+    "homepage": "https://github.com/terrajobst/git-istage",
+    "version": "0.2.29",
+    "url": "https://www.nuget.org/api/v2/package/git-istage/0.2.29",
+    "checkver": {
+        "url": "https://api.nuget.org/v3-flatcontainer/git-istage/index.json",
+        "jsonpath": "$.versions[-1:]"
+    },
+    "autoupdate": {
+        "url": "https://www.nuget.org/api/v2/package/git-istage/$version"
+    },
+    "hash": "8b40c12f05be9793fcd3977c691e0a77b55ef86db5e498524f499e535fa38141",
+    "depends": [
+        "dotnet-sdk"
+    ],
+    "description": "A better git add -p",
+    "license": "MIT",
+    "installer": {
+        "script": [
+            "Move-Item $dir\\$version $dir\\git-istage.$version.nupkg",
+            "$nugetConfig = \"<?xml version=`\"1.0`\" encoding=`\"utf-8`\"?><configuration><packageSources><clear /><add key=`\"Local`\" value=`\"$dir`\" /></packageSources></configuration>\"",
+            "$nugetConfigFile = \"$dir\\nuget.config\"",
+            "$nugetConfig | Out-File -Encoding UTF8 $nugetConfigFile",
+            "dotnet tool install git-istage --tool-path $dir --configfile $nugetConfigFile",
+            "$runCommand = \"if (-not (Test-Path env:DOTNET_ROOT)) { `$env:DOTNET_ROOT=Split-Path -Parent (Get-Command dotnet).Path } & `\"$dir\\git-istage.exe`\" `$args\"",
+            "$runCommand | Out-File -Encoding UTF8 $dir\\run.ps1"
+        ]
+    },
+    "bin": [
+        [
+            "run.ps1",
+            "git-istage"
+        ]
+    ]
+}


### PR DESCRIPTION
git-istage is a [dotnet tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools) that improves the staging experience for git on the command line.

dotnet tools are distributed as platform-independent NuGet packages. The client then creates platform-specific executables out of the NuGet package. This manifest describes exactly that: it's just a wrapper around installing the package with `dotnet tool` (with some quirks I must admit). The advantage is that I can manage git-istage with scoop, as most of my other software. So I don't have to think about which package I installed with which package manager.

There are already [a lot of dotnet tools](https://github.com/natemcmaster/dotnet-tools) that I would like to install with scoop instead and I might imagine that scoop manifests could be automatically generated for those. However I'm not sure what the scoop maintainers think about that.