### PR TITLE
Add iperf3 version 3.1.3

### DIFF
--- a/bucket/iperf3.json
+++ b/bucket/iperf3.json
@@ -1,0 +1,40 @@
+{
+    "homepage": "https://iperf.fr/",
+    "description": "Tool for measuring the maximum achievable bandwidth on IP networks",
+    "license": "BSD-3-Clause",
+    "version": "3.1.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://iperf.fr/download/windows/iperf-3.1.3-win64.zip",
+            "hash": "3c3db693c1bdcc902ca9198fc716339373658233b3392ffe3d467f7695762cd1",
+            "extract_dir": "iperf-3.1.3-win64"
+        },
+        "32bit": {
+            "url": "https://iperf.fr/download/windows/iperf-3.1.3-win32.zip",
+            "hash": "b3f8e262c17a000a30bf4f2135dfed644587cf2ec649f878aea8e9de51ffc8f2",
+            "extract_dir": "iperf-3.1.3-win32"
+        }
+    },
+    "bin": [
+        "iperf3.exe"
+    ],
+    "checkver": {
+        "url": "https://iperf.fr/iperf-download.php",
+        "re": "iPerf ([\\d.]+)<\\/a>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://iperf.fr/download/windows/iperf-$version-win64.zip",
+                "extract_dir": "iperf-$version-win64"
+            },
+            "32bit": {
+                "url": "https://iperf.fr/download/windows/iperf-$version-win32.zip",
+                "extract_dir": "iperf-$version-win64"
+            }
+        },
+        "hash": {
+            "url": "https://iperf.fr/download/windows/sha256sum.txt"
+        }
+    }
+}


### PR DESCRIPTION
This adds the command-line network benchmarking tool [iperf3](https://iperf.fr/).