### PR TITLE
Fixed sh shims

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -394,7 +394,7 @@ function shim($path, $global, $name, $arg) {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH
         "@`"$resolved_path`" $arg %*" | out-file "$shim.cmd" -encoding ascii
 
-        "#!/bin/sh`ncmd //C `"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii
+        "#!/bin/sh`ncmd.exe /C `"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii
     } elseif($path -match '\.ps1$') {
         # make ps1 accessible from cmd.exe
         "@echo off


### PR DESCRIPTION
Fixes #2740.
Adding .exe suffix to cmd is needed in WSL.
Removing MSYS' slash-escaping from //C is needed in WSL, Cygwin, or anywhere outside MSYS (or Git Bash). Doesn't break MSYS after .exe suffix is added.

See also #1949, #1951