### PR TITLE
Fixed sh shims (path escaping in MSYS2 and Git bash)

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -394,7 +394,7 @@ function shim($path, $global, $name, $arg) {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH
         "@`"$resolved_path`" $arg %*" | out-file "$shim.cmd" -encoding ascii
 
-        "#!/bin/sh`ncmd.exe /C `"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii
+        "#!/bin/sh`nMSYS2_ARG_CONV_EXCL=/C cmd.exe /C `"$resolved_path`" $arg `"$@`"" | out-file $shim -encoding ascii
     } elseif($path -match '\.ps1$') {
         # make ps1 accessible from cmd.exe
         "@echo off


### PR DESCRIPTION
#2741 broke sh shims in MSYS2 environments (includes Git bash). MSYS2's path escaping is bizzare!
`cmd /C hyper` => `cmd.exe C:/ hyper`
`cmd.exe /C hyper` => `cmd.exe /C hyper`
`cmd.exe /C hyper ls` => `cmd.exe C:/ hyper ls`

This commit excludes `/C` from MSYS2's path conversion inside sh shims.
Alternatively path conversion can be disabled completely by using `MSYS2_ARG_CONV_EXCL=\*` prefix instead, but that would be a bad idea for shim's that handle path arguments (atom, gcloud?).