### PR TITLE
Fix #2745 Workaround microsofts syntactic PSModulePath

### DIFF
--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -47,7 +47,7 @@ function uninstall_psmodule($manifest, $dir, $global) {
 function ensure_in_psmodulepath($dir, $global) {
     $path = env 'psmodulepath' $global
     if(!$global -and $null -eq $path) {
-        $path = "$home\Documents\WindowsPowerShell\Modules"
+        $path = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules"
     }
     $dir = fullpath $dir
     if($path -notmatch [regex]::escape($dir)) {

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -46,6 +46,9 @@ function uninstall_psmodule($manifest, $dir, $global) {
 
 function ensure_in_psmodulepath($dir, $global) {
     $path = env 'psmodulepath' $global
+    if(!$global -and $null -eq $path) {
+        $path = "$home\Documents\WindowsPowerShell\Modules"
+    }
     $dir = fullpath $dir
     if($path -notmatch [regex]::escape($dir)) {
         write-output "Adding $(friendly_path $dir) to $(if($global){'global'}else{'your'}) PowerShell module path."


### PR DESCRIPTION
The default user PSModulePath is "$home\Documents\WindowsPowerShell\Modules". If the user env variable PSModulePath actually exists the default path is omitted - so we need to explicitly add it.

Related issue #2745 