### PR TITLE
Add zookeeper app manifest

### DIFF
--- a/bucket/zookeeper.json
+++ b/bucket/zookeeper.json
@@ -10,6 +10,10 @@
         [
             "bin\\zkServer.cmd",
             "zkServer"
+        ],
+        [
+            "bin\\zkCli.cmd",
+            "zkCli"
         ]
     ],
     "persist": [

--- a/bucket/zookeeper.json
+++ b/bucket/zookeeper.json
@@ -1,0 +1,43 @@
+{
+    "homepage": "https://zookeeper.apache.org/",
+    "description": "High-performance coordination service for distributed applications",
+    "version": "3.4.13",
+    "license": "Apache-2.0",
+    "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz#/zookeeper-3.4.13.tar.gz",
+    "hash": "sha1:a989b527f3f990d471e6d47ee410e57d8be7620b",
+    "extract_dir": "zookeeper-3.4.13",
+    "bin": [
+        [
+            "bin\\zkServer.cmd",
+            "zkServer"
+        ]
+    ],
+    "persist": [
+        "data"
+    ],
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/oraclejdk8",
+            "java/openjdk"
+        ]
+    },
+    "post_install": [
+        "Copy-Item \"$dir/conf/zoo_sample.cfg\" -Destination \"$dir/conf/zoo.cfg\"",
+        "$dataDirPath = (\"$persist_dir\\data\").replace('\\', '\\\\')",
+        "(Get-Content \"$dir/conf/zoo.cfg\") -Replace '^dataDir=(.+)$', \"dataDir=$dataDirPath\" | Set-Content \"$dir/conf/zoo.cfg\""
+    ],
+    "checkver": {
+        "url": "https://www.apache.org/dist/zookeeper/",
+        "re": "zookeeper-([\\d.]+)/",
+        "reverse": true
+    },
+    "autoupdate": {
+        "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=zookeeper/zookeeper-$version/zookeeper-$version.tar.gz#/zookeeper-$version.tar.gz",
+        "hash": {
+            "url": "https://www.apache.org/dist/zookeeper/zookeeper-$version/zookeeper-$version.tar.gz.sha1",
+            "find": "(\\w+) "
+        },
+        "extract_dir": "zookeeper-$version"
+    }
+}


### PR DESCRIPTION
Hi, great work! Scoop is amazing! Please consider adding an app manifest for Apache Zookeeper.

> ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.

Copies distributed `zoo_sample.cfg` to `zoo.cfg` and sets the `dataDir` to `$persist_dir/data`.