### PR TITLE
Add -v option to checkver.ps1

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -29,10 +29,13 @@
     Check manifest MAN.json inside default directory.
 .EXAMPLE
     PS BUCKETDIR > .\bin\checkver.ps1 MAN -u
-    Check manifest MAN.json and update, if there is newer vesion.
+    Check manifest MAN.json and update, if there is newer version.
 .EXAMPLE
     PS BUCKETDIR > .\bin\checkver.ps1 MAN -f
-    Check manifest MAN.json and update, even if there is no new vesion.
+    Check manifest MAN.json and update, even if there is no new version.
+.EXAMPLE
+    PS BUCKETDIR > .\bin\checkver.ps1 MAN -u -v VER
+    Check manifest MAN.json and update, using version VER
 .EXAMPLE
     PS BUCKETDIR > .\bin\checkver.ps1 MAN DIR
     Check manifest MAN.json inside ./DIR directory.
@@ -54,7 +57,8 @@ param(
     [String] $Dir = "$psscriptroot\..\bucket",
     [Switch] $Update,
     [Switch] $ForceUpdate,
-    [Switch] $SkipUpdated
+    [Switch] $SkipUpdated,
+    [String] $Version = ""
 )
 
 . "$psscriptroot\..\lib\core.ps1"
@@ -274,6 +278,9 @@ while ($in_progress -gt 0) {
             Write-Host 'Forcing autoupdate!' -ForegroundColor DarkMagenta
         }
         try {
+            if ($Version -ne "") {
+                $ver = $Version
+            }
             autoupdate $App $Dir $json $ver $matchesHashtable
         } catch {
             error $_.Exception.Message


### PR DESCRIPTION
Here's where this came in useful: 

Jdupes's latest binary release is [1.11](https://github.com/jbruchon/jdupes/releases), but they created a 1.11.1 tag for documentation purposes.

To have checkver grab the 1.11 release, we can now do this:
```
checkver.ps1 jdupes -u -v 1.11
```