### PR TITLE
pshazz: Update to version 0.2018.09.25

### DIFF
--- a/bucket/pshazz.json
+++ b/bucket/pshazz.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://github.com/lukesampson/pshazz",
     "version": "0.2018.09.25",
-    "url": "https://github.com/lukesampson/pshazz/archive/master.zip",
-    "extract_dir": "pshazz-master",
-    "hash": "1a95d06daa98b165e1121f66961049a0df98aa1ba6112afeb30e5a78ba41410f",
+    "url": "https://github.com/lukesampson/pshazz/archive/8556d21b4f9eed4dc53f1e716e348b50cd921dc4.zip",
+    "extract_dir": "pshazz-8556d21b4f9eed4dc53f1e716e348b50cd921dc4",
+    "hash": "74ea403aa96b53545f254144f5c61393494f02e337408d2597b78393e029a5be",
     "bin": [
         "bin\\pshazz.ps1",
         "libexec\\askpass.exe"
@@ -13,10 +13,11 @@
     },
     "checkver": {
         "url": "https://github.com/lukesampson/pshazz",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {
-        "url": "https://github.com/lukesampson/pshazz/archive/master.zip"
+        "url": "https://github.com/lukesampson/pshazz/archive/$matchSha.zip",
+        "extract_dir": "pshazz-$matchSha"
     }
 }

--- a/bucket/pshazz.json
+++ b/bucket/pshazz.json
@@ -1,13 +1,22 @@
 {
-    "version": "0.2018.04.22",
-    "url": "https://github.com/lukesampson/pshazz/archive/4504a758b3df95d424aadb4364fa7f2030c5b906.zip",
-    "extract_dir": "pshazz-4504a758b3df95d424aadb4364fa7f2030c5b906",
-    "hash": "4ff9b6bceda97b71084db390391d0fff27aff79ccd25cee3498967b76c47b085",
+    "homepage": "https://github.com/lukesampson/pshazz",
+    "version": "0.2018.09.25",
+    "url": "https://github.com/lukesampson/pshazz/archive/master.zip",
+    "extract_dir": "pshazz-master",
+    "hash": "1a95d06daa98b165e1121f66961049a0df98aa1ba6112afeb30e5a78ba41410f",
     "bin": [
         "bin\\pshazz.ps1",
         "libexec\\askpass.exe"
     ],
     "installer": {
         "file": "bin\\install.ps1"
+    },
+    "checkver": {
+        "url": "https://github.com/lukesampson/pshazz",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://github.com/lukesampson/pshazz/archive/master.zip"
     }
 }


### PR DESCRIPTION
Since current version of pshazz in scoop is 0.2018.04.22, and it is in conflict with PowerShell Core v6.1.x. Recent commits solve this, and this is the update with checkver.