### PR TITLE
Show bucket url when installation failed even it's not in buckets.json

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -54,7 +54,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
         Push-Location $bucket_path
         $remote = git config --get remote.origin.url
         $remote -match 'git@(?<url>.*):(?<username>.*)/(?<repository>.*)\.git' | Out-Null # match git@github.com:lukesampson/scoop-extras.git
-        $url = "https://www.$($matches.url)/$($matches.username)/$($matches.repository)"
+        $url = "https://$($matches.url)/$($matches.username)/$($matches.repository)"
         Pop-Location
     }
     if(!$url) {

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -46,11 +46,19 @@ function find_manifest($app, $bucket) {
 function new_issue_msg($app, $bucket, $title, $body) {
     $app, $manifest, $bucket, $url = locate $app $bucket
     $url = known_bucket_repo $bucket
-    if($manifest -and $null -eq $url -and $null -eq $bucket) {
+    $bucket_path = "$bucketsdir\$bucket"
+
+    if($manifest -and ($null -eq $url) -and ($null -eq $bucket)) {
         $url = 'https://github.com/lukesampson/scoop'
+    } elseif (Test-Path $bucket_path) {
+        Push-Location $bucket_path
+        $alfa = git config --get remote.origin.url
+        $alfa -match 'git@(?<url>.*):(?<username>.*)/(?<repository>.*)\.git' | Out-Null # match git@github.com:lukesampson/scoop-extras.git
+        $url = "https://www.$($matches.url)/$($matches.username)/$($matches.repository)"
+        Pop-Location
     }
     if(!$url) {
-        return "Please contact the bucket maintainer!"
+        return 'Please contact the bucket maintainer!'
     }
 
     $title = [System.Web.HttpUtility]::UrlEncode("$app@$($manifest.version): $title")

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -52,8 +52,8 @@ function new_issue_msg($app, $bucket, $title, $body) {
         $url = 'https://github.com/lukesampson/scoop'
     } elseif (Test-Path $bucket_path) {
         Push-Location $bucket_path
-        $alfa = git config --get remote.origin.url
-        $alfa -match 'git@(?<url>.*):(?<username>.*)/(?<repository>.*)\.git' | Out-Null # match git@github.com:lukesampson/scoop-extras.git
+        $remote = git config --get remote.origin.url
+        $remote -match 'git@(?<url>.*):(?<username>.*)/(?<repository>.*)\.git' | Out-Null # match git@github.com:lukesampson/scoop-extras.git
         $url = "https://www.$($matches.url)/$($matches.username)/$($matches.repository)"
         Pop-Location
     }


### PR DESCRIPTION
When you install app, installation failed and your bucket is not in buckets.json you will get default bucket url (lukesampson/scoop) or just none link for creating issue.

## Pure powershell

![Now](https://i.imgur.com/K8xVDDm.png)

## pwsh

![Now](https://i.imgur.com/0rpEv2H.png)