### PR TITLE
Add rcedit version 1.1.1

### DIFF
--- a/bucket/rcedit.json
+++ b/bucket/rcedit.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://github.com/electron/rcedit",
+    "description": "Command-line tool for editing resources of PE executables",
+    "license": "MIT",
+    "version": "1.1.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe#/rcedit.exe",
+            "hash": "02e8e8c5d430d8b768980f517b62d7792d690982b9ba0f7e04163cbc1a6e7915"
+        },
+        "32bit": {
+            "url": "https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x86.exe#/rcedit.exe",
+            "hash": "1733e4b7e532c99b6a4ddeca1b9fff7bb1c5fd0ba7dbeb5f3520b6da03a5284f"
+        }
+    },
+    "bin": "rcedit.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/electron/rcedit/releases/download/v$version/rcedit-x64.exe#/rcedit.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/electron/rcedit/releases/download/v$version/rcedit-x86.exe#/rcedit.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[rcedit](https://github.com/electron/rcedit) is a command-line tool that can be used to edit resources embedded in PE executables (such as icons).