### PR TITLE
Update lukesampson/concfg and several tools from lukesampson/psutils.

### DIFF
--- a/bucket/concfg.json
+++ b/bucket/concfg.json
@@ -1,9 +1,18 @@
 {
     "homepage": "https://github.com/lukesampson/concfg",
     "description": "Import / export Windows console settings",
-    "version": "0.2018.10.06",
-    "url": "https://github.com/lukesampson/concfg/archive/05e19f9279ccc7a8d5008d579f638f25cb0a05e5.zip",
-    "hash": "f24b98c258649b28903679cb4c5d265788cc7dbbae6dc62f4492fccb31797446",
-    "extract_dir": "concfg-05e19f9279ccc7a8d5008d579f638f25cb0a05e5",
-    "bin": "bin\\concfg.ps1"
+    "version": "0.2018.10.22",
+    "url": "https://github.com/lukesampson/concfg/archive/e4929075bdffe7838d329eabc8618ddd39237eee.zip",
+    "hash": "a20527f529edb05d7307321185ad0cb31d2f1e5b3a7eeaa4c9fd6c3ac85c91bc",
+    "extract_dir": "concfg-e4929075bdffe7838d329eabc8618ddd39237eee",
+    "bin": "bin\\concfg.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/concfg",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://github.com/lukesampson/concfg/archive/$matchSha.zip",
+        "extract_dir": "concfg-$matchSha"
+    }
 }

--- a/bucket/gitignore.json
+++ b/bucket/gitignore.json
@@ -1,7 +1,17 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "0.2015.08.26",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3c67dbf56a0e541bf928b9a8811dc4c627d8230c/gitignore.ps1",
-    "hash": "9a08d37386219add0bf79fe6293ab02f5dfdce6ece95173c003bdb96a8016533",
-    "bin": "gitignore.ps1"
+    "description": "Fetches .gitignore file templates from gitignore.io and writes them to standard output.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/gitignore.ps1",
+    "hash": "733e4e2bece6e84ad1d25589cc6d1f852587f2d4a6ffe74b8268435ae229487a",
+    "bin": "gitignore.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/lukesampson/psutils/$matchSha/gitignore.ps1"
+    }
 }

--- a/bucket/ln.json
+++ b/bucket/ln.json
@@ -1,7 +1,17 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "0.2015.04.25",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/4e363db/ln.ps1",
-    "hash": "81e9447d5d0108057c54380a8e49f6db9fa5806d2018e7b27bd68f3fb8332b98",
-    "bin": "ln.ps1"
+    "description": "An approximation of the Unix ln command.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/ln.ps1",
+    "hash": "2e97f2f1bacba1c403c538a80493e8c6c56203ba689f2a29a9fde6ba3576d3f7",
+    "bin": "ln.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/lukesampson/psutils/$matchSha/ln.ps1"
+    }
 }

--- a/bucket/psutils.json
+++ b/bucket/psutils.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "https://github.com/lukesampson/psutils",
+    "description": "\n\tA collection of command line utilities written in PowerShell,\n\tproudly ignoring PowerShell Verb-Noun naming conventions.",
+    "version": "0.2018.08.04",
+    "url": "https://github.com/lukesampson/psutils/archive/de1a069215c54a1cb105f3dc79f14e25570c75f2.zip",
+    "hash": "432d21448ec3ed8e95e82e6ad0b633e096b1cd1c37bed081b8dbe2fd59f9fb1b",
+    "extract_dir": "psutils-de1a069215c54a1cb105f3dc79f14e25570c75f2",
+    "bin": [
+        "gitignore.ps1",
+        "ln.ps1",
+        "runat.ps1",
+        "say.ps1",
+        "shasum.ps1",
+        "sudo.ps1",
+        "time.ps1",
+        [
+            "time.ps1",
+            "timecmd"
+        ],
+        "touch.ps1",
+        "vimtutor.ps1"
+    ],
+    "notes": "Please use 'timecmd' instead of 'time' in cmd.exe.",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://github.com/lukesampson/psutils/archive/$matchSha.zip",
+        "extract_dir": "psutils-$matchSha"
+    }
+}

--- a/bucket/runat.json
+++ b/bucket/runat.json
@@ -1,7 +1,17 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "0.2017.04.16",
-    "url": "https://raw.github.com/lukesampson/psutils/master/runat.ps1",
+    "description": "A replacement for the at command which Microsoft has deprecated and removed in Windows 2012.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/runat.ps1",
     "hash": "3a7f3cf34a9695ae607627f4d3c041543909c217f54997ebbeb3871ce6f96889",
-    "bin": "runat.ps1"
+    "bin": "runat.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/lukesampson/psutils/$matchSha/runat.ps1"
+    }
 }

--- a/bucket/say.json
+++ b/bucket/say.json
@@ -1,13 +1,20 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "0.2013.09.08",
+    "description": "An approximation of say from macOS.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
     "url": [
-        "https://raw.github.com/lukesampson/psutils/3554f2db73/say.ps1",
-        "https://raw.github.com/lukesampson/psutils/2938900e58/getopt.ps1"
+        "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/say.ps1",
+        "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/getopt.ps1"
     ],
     "hash": [
-        "75e0013ed0a60b47646f6190b523fc6986177f7360e5352a22806d7e6143bb62",
-        "452e61d92dd0eb4e4d6fe5fcd70f30b8c4f36cc9e3b618a7816ec45768d21262"
+        "b8951f0c7f54701c8775fedfb0e33a97a2fa45931d7c6571c739b82627bad73d",
+        "e3939d732ee937db60f336c2a0ed7a463874b37e213d5f42c5346b489a6edb65"
     ],
-    "bin": "say.ps1"
+    "bin": "say.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)",
+        "replace": "0.${1}.${2}.${3}"
+    }
 }

--- a/bucket/shasum.json
+++ b/bucket/shasum.json
@@ -1,13 +1,20 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "0.2013.09.29",
+    "description": "An approximation of the Unix shasum command.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
     "url": [
-        "https://raw.github.com/lukesampson/psutils/4fa05b1c9b/shasum.ps1",
-        "https://raw.github.com/lukesampson/psutils/4fa05b1c9b/getopt.ps1"
+        "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/shasum.ps1",
+        "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/getopt.ps1"
     ],
     "hash": [
-        "002ed0928a9d80f2d603e8de12bcd922fcdff5acfc4c6f6c67c2e2ace8728b08",
-        "452e61d92dd0eb4e4d6fe5fcd70f30b8c4f36cc9e3b618a7816ec45768d21262"
+        "569cd02dd49cff0c92c93a609e58cc902d850fe0c312ee86c3dc3fba0976e596",
+        "e3939d732ee937db60f336c2a0ed7a463874b37e213d5f42c5346b489a6edb65"
     ],
-    "bin": "shasum.ps1"
+    "bin": "shasum.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)",
+        "replace": "0.${1}.${2}.${3}"
+    }
 }

--- a/bucket/sudo.json
+++ b/bucket/sudo.json
@@ -1,7 +1,17 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "0.2017.03.24",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/593af41c3c40153112cf9d428e8042ad1fec5dbc/sudo.ps1",
-    "hash": "c4baeeca6146c0ecef33842552e7f85c8c93fd51ae33f6a336d8345e35fa7b2e",
-    "bin": "sudo.ps1"
+    "description": "An approximation of the Unix sudo command. Shows a UAC popup window unfortunately.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/sudo.ps1",
+    "hash": "7c124e37f3f15e200a651cec5c5f58d05b5e347d8697f2204d0a40c4181b3642",
+    "bin": "sudo.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/lukesampson/psutils/$matchSha/sudo.ps1"
+    }
 }

--- a/bucket/time.json
+++ b/bucket/time.json
@@ -1,13 +1,24 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "2013-08-10",
-    "url": "https://raw.github.com/lukesampson/psutils/598331a7e2b6d4bb60d8a458f8212d349b383e7c/time.ps1",
-    "hash": "66f8e31d76d0c1e8bf89bd5f73f6404c384ddcf0bd2069c5a40c331fbca4a63b",
+    "description": "An approximation of the Unix time command.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/time.ps1",
+    "hash": "250413758eb4845973cfd0778b58e40ec52b881f17cbe13b22afac440fb26d93",
     "bin": [
         "time.ps1",
         [
             "time.ps1",
             "timecmd"
         ]
-    ]
+    ],
+    "notes": "Please use 'timecmd' instead of 'time' in cmd.exe.",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/lukesampson/psutils/$matchSha/time.ps1"
+    }
 }

--- a/bucket/touch.json
+++ b/bucket/touch.json
@@ -1,7 +1,17 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
-    "version": "0.2013.07.02",
-    "url": "https://raw.github.com/lukesampson/psutils/767c019fc81f60a990342103cbf75db6703d3593/touch.ps1",
-    "hash": "1cedd53b77583d94264274ca8617f4ff5da535fc15d29274d3b12e5f72f7c2f5",
-    "bin": "touch.ps1"
+    "description": "A port of the Unix touch command.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/touch.ps1",
+    "hash": "11eeb18ca3143929b5ace9a838a88d9b1c5bc657bcc8dd46708ba7e50ba331d9",
+    "bin": "touch.ps1",
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/lukesampson/psutils/$matchSha/touch.ps1"
+    }
 }

--- a/bucket/vimtutor.json
+++ b/bucket/vimtutor.json
@@ -1,11 +1,20 @@
 {
-    "version": "3653063",
-    "license": "MIT",
-    "url": "https://raw.github.com/lukesampson/psutils/3653063/vimtutor.ps1",
     "homepage": "https://github.com/lukesampson/psutils",
-    "hash": "f6081071fa95a6f49c049e9d2aed2d2a2632ec47635b4b497a97bab5f5add498",
+    "description": "The vimtutor that comes with Vim for Windows doesn't work with Scoop. This one does.",
+    "version": "0.2018.08.04",
+    "license": "MIT",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/vimtutor.ps1",
+    "hash": "1df57e3bf4139ca096acd71896cc1797ae539ed3ab77185c0ed93846b3c60790",
     "bin": "vimtutor.ps1",
     "suggest": {
         "vim": "vim"
+    },
+    "checkver": {
+        "url": "https://github.com/lukesampson/psutils",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/lukesampson/psutils/$matchSha/vimtutor.ps1"
     }
 }


### PR DESCRIPTION
lukesampson/concfg: Update to version 0.2018.10.22.

lukesampson/psutils: Update to version 0.2018.08.04. (gitignore, ln, runat, say, shasum, sudo, time, touch, vimtutor)

For convenience, I add a new bucket called 'psutils' to install all these scripts, since I didn't find such one.