### PR TITLE
Add GNU datamash

### DIFF
--- a/bucket/datamash.json
+++ b/bucket/datamash.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.3",
+    "description": "GNU datamash is a command-line program which performs basic numeric, textual and statistical operations on input textual data files",
+    "license": "GPL-3.0-or-later",
+    "homepage": "https://www.gnu.org/software/datamash/",
+    "architecture": {
+        "64bit": {
+            "url": "http://download.savannah.gnu.org/releases/datamash/windows-binaries/datamash-1.3-no-locale-64bit.exe#/datamash.exe",
+            "hash": "4b85e619390b50898911c2c85234aa7306670541b56603d71bfc1e1969c918b8"
+        },
+        "32bit": {
+            "url": "http://download.savannah.gnu.org/releases/datamash/windows-binaries/datamash-1.3-no-locale-32bit.exe#/datamash.exe",
+            "hash": "ae6ed021819a4cc2481b4b517c25348df4f8ed15c24ba5ff5f2e7fc1b32b69dc"
+        }
+    },
+    "bin": "datamash.exe",
+    "checkver": {
+        "url": "https://www.gnu.org/software/datamash/download/",
+        "re": "wget http:\\/\\/ftp\\.gnu\\.org\\/gnu\\/datamash\\/datamash-([\\d.]+)\\.tar\\.gz"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.savannah.gnu.org/releases/datamash/windows-binaries/datamash-$version-no-locale-64bit.exe#/datamash.exe"
+            },
+            "32bit": {
+                "url": "http://download.savannah.gnu.org/releases/datamash/windows-binaries/datamash-$version-no-locale-32bit.exe#/datamash.exe"
+            }
+        }
+    }
+}

--- a/bucket/datamash.json
+++ b/bucket/datamash.json
@@ -16,7 +16,7 @@
     "bin": "datamash.exe",
     "checkver": {
         "url": "http://download-mirror.savannah.gnu.org/releases/datamash/windows-binaries/",
-        "re": "datamash-([\d.]+)-no-locale",
+        "re": "datamash-([\\d.]+)-no-locale",
         "reverse": true
     },
     "autoupdate": {

--- a/bucket/datamash.json
+++ b/bucket/datamash.json
@@ -15,8 +15,9 @@
     },
     "bin": "datamash.exe",
     "checkver": {
-        "url": "https://www.gnu.org/software/datamash/download/",
-        "re": "wget http:\\/\\/ftp\\.gnu\\.org\\/gnu\\/datamash\\/datamash-([\\d.]+)\\.tar\\.gz"
+        "url": "http://download-mirror.savannah.gnu.org/releases/datamash/windows-binaries/",
+        "re": "datamash-([\d.]+)-no-locale",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
GNU datamash is a command-line program which performs basic numeric, textual and statistical operations on input textual data files