### PR TITLE
lua: rename to 'lua-for-windows' and fix env

### DIFF
--- a/bucket/lua-for-windows.json
+++ b/bucket/lua-for-windows.json
@@ -1,4 +1,5 @@
 {
+    "description": "A 'batteries included environment' for the Lua scripting language on Windows.",
     "version": "5.1.5-52",
     "url": "https://github.com/rjpcomputing/luaforwindows/releases/download/v5.1.5-52/LuaForWindows_v5.1.5-52.exe",
     "homepage": "https://github.com/rjpcomputing/luaforwindows",
@@ -9,6 +10,9 @@
         "luac.exe",
         "luarocks.bat"
     ],
+    "env_set": {
+        "LUA_DEV": "$dir"
+    },
     "depends": [
         "innounp"
     ],


### PR DESCRIPTION
There are three full Lua installations that provide Lua binary for windows users, Lua-for-Windows (this one), LuaDist, and LuaRocks. Changing this bucket's name to lua-for-windows is more appropriate. 

Besides, luarocks doesn't work if `$env:LUA_DEV` is not set, so there is a fix.