### PR TITLE
[autoupdate] base64 hash extraction length

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -58,7 +58,7 @@ function find_hash_in_textfile([String] $url, [String] $basename, [String] $rege
     # convert base64 encoded hash values
     if ($hash -match '^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$') {
         $base64 = $matches[0]
-        if(!($hash -match "^[a-fA-F0-9]+$") -and $hash.length -in @(32, 40, 64, 128)) {
+        if(!($hash -match "^[a-fA-F0-9]+$") -and $hash.length -in @(32..128)) {
             try {
                 $hash = ([System.Convert]::FromBase64String($base64) | ForEach-Object { $_.ToString('x2') }) -join ''
             } catch {

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -58,7 +58,7 @@ function find_hash_in_textfile([String] $url, [String] $basename, [String] $rege
     # convert base64 encoded hash values
     if ($hash -match '^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$') {
         $base64 = $matches[0]
-        if(!($hash -match "^[a-fA-F0-9]+$") -and $hash.length -in @(32..128)) {
+        if(!($hash -match '^[a-fA-F0-9]+$') -and $hash.length -notin @(32, 40, 64, 128)) {
             try {
                 $hash = ([System.Convert]::FromBase64String($base64) | ForEach-Object { $_.ToString('x2') }) -join ''
             } catch {


### PR DESCRIPTION
sha512 encoded hash length for [Franz](https://github.com/meetfranz/franz/releases/download/v5.0.0-beta.19/latest.yml) is 88 characters length and autoupdate just dont extract it's value.

If anyone have better fix, feel free to edit.

Relate lukesampson/scoop-extras#1487