### PR TITLE
dotnet-sdk: fix hashes (2.2.100-sdk-sha.txt has bad shas)

### DIFF
--- a/bucket/dotnet-sdk.json
+++ b/bucket/dotnet-sdk.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.100/dotnet-sdk-2.2.100-win-x64.zip",
-            "hash": "sha512:950dc685294c6423438ba5b38d444c08e492e25a630a552cb5d3a170775ed6e6247ea8c06e6b1c26df90e91e3b9041e87e93db2a59349b814f6b2cfba59629a5"
+            "hash": "853862506aae8a57db2985302fa753f70896659eb147521393c75b733c860a8d"
         },
         "32bit": {
             "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/2.2.100/dotnet-sdk-2.2.100-win-x86.zip",
-            "hash": "sha512:f007b3912f265f5ca5397cbb7aa55fc2d34788adb77cac53b45643d76088c01e47a70576417957de75ba4543be298dbc8c31dc82a33aefdae9490f6e64c9ab6a"
+            "hash": "b786a492c0fca8ee399ffb89bc022ae8f55b60affc5ae45f43f429577f5fd9e4"
         }
     },
     "env_add_path": ".",


### PR DESCRIPTION
fixes #2843 fixes #2846 fixes #2847 fixes #2848 fixes #2853 fixes #2854 fixes #2855 