### PR TITLE
Fix winpython's checkver and switch to innosetup

### DIFF
--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -17,7 +17,7 @@
     "installer": {
         "script": [
             "Get-ChildItem \"$dir\" -Exclude 'python-*' | Remove-Item -Force -Recurse",
-            "$fold = (Get-ChildItem \"$dir\")[0] | Select-Object -ExpandProperty FullName",
+            "$fold = \"$dir\\\" + (Get-ChildItem \"$dir\")[0]",
             "Move-Item \"$fold\\*\" \"$dir\" -Force",
             "Remove-Item $fold -Recurse"
         ]

--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -17,7 +17,7 @@
     "installer": {
         "script": [
             "Get-ChildItem \"$dir\" -Exclude 'python-*' | Remove-Item -Force -Recurse",
-            "$fold = \"$dir\\\" + (Get-ChildItem \"$dir\")[0]",
+            "$fold = \"$dir\\\" + ((Get-ChildItem \"$dir\")[0])",
             "Move-Item \"$fold\\*\" \"$dir\" -Force",
             "Remove-Item $fold -Recurse"
         ]

--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -17,9 +17,8 @@
     "installer": {
         "script": [
             "Get-ChildItem \"$dir\" -Exclude 'python-*' | Remove-Item -Force -Recurse",
-            "$fold = \"$dir\\\" + ((Get-ChildItem \"$dir\")[0])",
-            "Move-Item \"$fold\\*\" \"$dir\" -Force",
-            "Remove-Item $fold -Recurse"
+            "Move-Item \"$dir\\python-*\\*\" \"$dir\" -Force",
+            "Remove-Item \"$dir\\python-*\""
         ]
     },
     "bin": [

--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -1,19 +1,20 @@
 {
     "description": "Free, open-source and portable Python distribution for Windows",
-    "version": "3.6.7.0",
+    "version": "3.7.1.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.6/3.6.7.0/WinPython64-3.6.7.0Zero.exe#/dl.7z",
-            "hash": "e52e2606f3a2f7d79fd9eac0701b144efe0832ecdcf7c5a2f3bf3aebba4e70c6",
-            "extract_dir": "python-3.6.7.amd64"
+            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.1.0/WinPython64-3.7.1.0Zero.exe",
+            "hash": "4e81abd373c089cd9b6687393bb3d179e6792a97d8f088f77d35b9067f118c0f",
+            "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-3.7.1.amd64\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-3.7.1.amd64\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-3.7.1.amd64\\*\" \"$dir\"; Remove-Item \"$dir\\python-3.7.1.amd64\""
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.6/3.6.7.0/WinPython32-3.6.7.0Zero.exe#/dl.7z",
-            "hash": "8b6b22f36aecb80ce8b13212deb4bbba0e9a902ddd081d7c6288cf0f44e419be",
-            "extract_dir": "python-3.6.7"
+            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.1.0/WinPython32-3.7.1.0Zero.exe",
+            "hash": "a09c79c7630278f831d257c03bab99f76d3a0e23f8b4362a3e1e2495a3aa088f",
+            "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-3.7.1\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-3.7.1\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-3.7.1\\*\" \"$dir\"; Remove-Item \"$dir\\python-3.7.1\""
         }
     },
+    "innosetup": true,
     "homepage": "https://winpython.github.io/",
     "bin": [
         "python.exe",
@@ -23,22 +24,21 @@
             "python3"
         ]
     ],
-    "env_add_path": [
-        "scripts"
-    ],
+    "env_add_path": "scripts",
     "checkver": {
-        "url": "https://winpython.github.io/md5_sha1.txt",
-        "re": "-([\\d.]+)Zero.exe"
+        "url": "https://github.com/winpython/winpython/releases",
+        "re": "-([\\d.]+)Zero\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe#/dl.7z",
-                "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion.amd64"
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe",
+                "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-$matchHead.amd64\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-$matchHead.amd64\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-$matchHead.amd64\\*\" \"$dir\"; Remove-Item \"$dir\\python-$matchHead.amd64\""
+
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe#/dl.7z",
-                "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion"
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe",
+                "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-$matchHead\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-$matchHead\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-$matchHead\\*\" \"$dir\"; Remove-Item \"$dir\\python-$matchHead\""
             }
         },
         "hash": {

--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -32,8 +32,9 @@
     ],
     "env_add_path": "scripts",
     "checkver": {
-        "url": "https://github.com/winpython/winpython/releases",
-        "regex": "-([\\d.]+)Zero\\.exe"
+        "github": "https://github.com/winpython/winpython/",
+        "regex": "-([\\d.]+)Zero\\.exe",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/winpython.json
+++ b/bucket/winpython.json
@@ -2,20 +2,26 @@
     "description": "Free, open-source and portable Python distribution for Windows",
     "version": "3.7.1.0",
     "license": "MIT",
+    "homepage": "https://winpython.github.io/",
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.1.0/WinPython64-3.7.1.0Zero.exe",
-            "hash": "4e81abd373c089cd9b6687393bb3d179e6792a97d8f088f77d35b9067f118c0f",
-            "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-3.7.1.amd64\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-3.7.1.amd64\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-3.7.1.amd64\\*\" \"$dir\"; Remove-Item \"$dir\\python-3.7.1.amd64\""
+            "hash": "4e81abd373c089cd9b6687393bb3d179e6792a97d8f088f77d35b9067f118c0f"
         },
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.1.0/WinPython32-3.7.1.0Zero.exe",
-            "hash": "a09c79c7630278f831d257c03bab99f76d3a0e23f8b4362a3e1e2495a3aa088f",
-            "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-3.7.1\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-3.7.1\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-3.7.1\\*\" \"$dir\"; Remove-Item \"$dir\\python-3.7.1\""
+            "hash": "a09c79c7630278f831d257c03bab99f76d3a0e23f8b4362a3e1e2495a3aa088f"
         }
     },
     "innosetup": true,
-    "homepage": "https://winpython.github.io/",
+    "installer": {
+        "script": [
+            "Get-ChildItem \"$dir\" -Exclude 'python-*' | Remove-Item -Force -Recurse",
+            "$fold = (Get-ChildItem \"$dir\")[0] | Select-Object -ExpandProperty FullName",
+            "Move-Item \"$fold\\*\" \"$dir\" -Force",
+            "Remove-Item $fold -Recurse"
+        ]
+    },
     "bin": [
         "python.exe",
         "pythonw.exe",
@@ -27,18 +33,16 @@
     "env_add_path": "scripts",
     "checkver": {
         "url": "https://github.com/winpython/winpython/releases",
-        "re": "-([\\d.]+)Zero\\.exe"
+        "regex": "-([\\d.]+)Zero\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe",
-                "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-$matchHead.amd64\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-$matchHead.amd64\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-$matchHead.amd64\\*\" \"$dir\"; Remove-Item \"$dir\\python-$matchHead.amd64\""
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe"
 
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe",
-                "pre_install": "Get-ChildItem -Path \"$dir\" -Recurse -Exclude \"python-$matchHead\" | Select -ExpandProperty FullName | Where {$_ -notlike \"$dir\\python-$matchHead\\*\"} | sort length -Descending | Remove-Item -Force; Move-Item \"$dir\\python-$matchHead\\*\" \"$dir\"; Remove-Item \"$dir\\python-$matchHead\""
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
I had to change the checkver url to get it updated.
Also, since Python 3.7, Winpython switched to innosetup, so I updated the manifest accordingly.

To remove all optional stuff I wanted to use the "extract_dir" as before, but with innosetup I had to write a pre_install script which, I'm afraid, it may not be the best in terms of efficiency... so please be welcome to edit it if you think there's a better way to accomplish that.