### PR TITLE
hugo-extended - Add the "extended" version of hugo

### DIFF
--- a/bucket/hugo-extended.json
+++ b/bucket/hugo-extended.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.52",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/gohugoio/hugo/releases/download/v0.52/hugo_extended_0.52_windows-64bit.zip",
+            "hash": "1d915df9e20fb51cc93da9593ea881765aba1a9e20c7530a5aa82fca997e1e4c"
+        },
+    },
+    "bin": "hugo.exe",
+    "homepage": "https://gohugo.io",
+    "checkver": {
+        "github": "https://github.com/gohugoio/hugo"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/gohugoio/hugo/releases/download/v$version/hugo_extended_$version_windows-64bit.zip"
+            },
+        },
+        "hash": {
+            "url": "https://github.com/gohugoio/hugo/releases/download/v$version/hugo_extended_$version_checksums.txt"
+        }
+    }
+}

--- a/bucket/hugo-extended.json
+++ b/bucket/hugo-extended.json
@@ -5,7 +5,7 @@
         "64bit": {
             "url": "https://github.com/gohugoio/hugo/releases/download/v0.52/hugo_extended_0.52_windows-64bit.zip",
             "hash": "1d915df9e20fb51cc93da9593ea881765aba1a9e20c7530a5aa82fca997e1e4c"
-        },
+        }
     },
     "bin": "hugo.exe",
     "homepage": "https://gohugo.io",
@@ -16,7 +16,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/gohugoio/hugo/releases/download/v$version/hugo_extended_$version_windows-64bit.zip"
-            },
+            }
         },
         "hash": {
             "url": "https://github.com/gohugoio/hugo/releases/download/v$version/hugo_extended_$version_checksums.txt"


### PR DESCRIPTION
This change adds the configuration to install the extended version of the hugo static site generator.

Hugo comes in two flavors. The base package (which is currently installable through scoop) and the "extended" version.

The extended version adds (among other things) support for using Sass/Cscc, resource minification, fingerprinting, and bundling - [See docs of more](https://gohugo.io/hugo-pipes/).

Note, this is a simple edit of the current hugo.json to pick up a slightly different file name and hash file. Also, the extended version is only supported on 64bit.