### PR TITLE
Support nested bucket folder in external buckets

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -1,9 +1,23 @@
 $bucketsdir = "$scoopdir\buckets"
 
+<#
+.DESCRIPTION
+    Return full path for bucket with given name.
+    Main bucket will be returned as default.
+.PARAMETER name
+    Name of bucket
+#>
 function bucketdir($name) {
-    if(!$name) { return relpath "..\bucket" } # main bucket
+    $bucket = relpath '..\bucket' # main bucket
 
-    "$bucketsdir\$name"
+    if ($name) {
+        $bucket = "$bucketsdir\$name"
+    }
+    if (Test-Path "$bucket\bucket") {
+        $bucket = "$bucket\bucket"
+    }
+
+    return Resolve-Path $bucket
 }
 
 function known_bucket_repos {


### PR DESCRIPTION
- Closes #2531 

Actual behaviour is kept and nothing is broken.

If external bucket contains `bucket` folder it's used for finding manifests. This should keep external repositories more friendly for new users to see Readme without additional scrolling.

Feel free to suggest directory name change. I kept same as main bucket.

How to test:

1. Create folder `TestBucket` in `$env:SCOOP\buckets`
1. Create manifest `CosiTest.json` with hello manifest # Or some other name which definitely cannot exists❗
1. execute `.\bin\scoop.ps1 install CosiTest` within this branch
1. Installing done
1. `.\bin\scoop.ps1 uninstall CosiTest`
1. Create folder `bucket` in `TestBucket` directory and copy CosiTest.json as `bucket\CosiTestBucket.json`
1. `.\bin\scoop.ps1 install CosiTest`
1. Installation will failed with `Couldn't find manifest for 'CosiTest'.`
1. `.\bin\scoop.ps1 install CosiTestBucket`
1. Installation Done
1. `.\bin\scoop.ps1 uninstall CosiTestBucket`
1. Uninstallation Done

For external buckets sanitizing:

1. Adopt .vscode Folder for settings
1. Adopt bin folder
1. Fix tests
1. Move manifests

[Already fixed bins and tests](https://github.com/Ash258/scoop-Ash258/commits/bucket-support) or my already adopted template which i used for training [Generic bucket repo](https://github.com/Ash258/GenericBucket)
