### PR TITLE
Fix cloc url and add alias

### DIFF
--- a/bucket/cloc.json
+++ b/bucket/cloc.json
@@ -3,13 +3,18 @@
     "description": "Counts blank lines, comment lines, and physical lines of source code in many programming languages",
     "version": "1.80",
     "license": "GPL-2.0",
-    "url": "https://github.com/AlDanial/cloc/releases/download/v1.80/cloc-1.80.exe#/cloc.exe",
+    "url": "https://github.com/AlDanial/cloc/releases/download/1.80/cloc-1.80.exe#/cloc.exe",
     "hash": "9e547b01c946aa818ffad43b9ebaf05d3da08ed6ca876ef2b6847be3bf1cf8be",
-    "bin": "cloc.exe",
+    "bin": [
+        [
+            "cloc.exe",
+            "cloc"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/AlDanial/cloc"
     },
     "autoupdate": {
-        "url": "https://github.com/AlDanial/cloc/releases/download/v$version/cloc-$version.exe#/cloc.exe"
+        "url": "https://github.com/AlDanial/cloc/releases/download/$version/cloc-$version.exe#/cloc.exe"
     }
 }

--- a/bucket/cloc.json
+++ b/bucket/cloc.json
@@ -5,12 +5,7 @@
     "license": "GPL-2.0",
     "url": "https://github.com/AlDanial/cloc/releases/download/1.80/cloc-1.80.exe#/cloc.exe",
     "hash": "9e547b01c946aa818ffad43b9ebaf05d3da08ed6ca876ef2b6847be3bf1cf8be",
-    "bin": [
-        [
-            "cloc.exe",
-            "cloc"
-        ]
-    ],
+    "bin": "cloc.exe",
     "checkver": {
         "github": "https://github.com/AlDanial/cloc"
     },


### PR DESCRIPTION
Fixes the [`cloc`](https://github.com/AlDanial/cloc/releases/) url. While there still seem to be version tags around for versions including the `v`, the binaries are only attached to the version tags without `v`.