### PR TITLE
nvs: Add version 1.5.1

### DIFF
--- a/bucket/nvs.json
+++ b/bucket/nvs.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.5.1",
+    "description": "Node Version Switcher - A cross-platform tool for switching between versions and forks of Node.js",
+    "homepage": "https://github.com/jasongin/nvs",
+    "license": {
+        "identifier": "MIT"
+    },
+    "notes": "If an \"EPERM\" error occurs, remove the error one and add it again.",
+    "url": "https://github.com/jasongin/nvs/releases/download/v1.5.1/nvs-1.5.1.msi",
+    "hash": "908ef382cd25733f3d02e92f3e73fd76bcd89c822879ffbc6f768326a040b3b7",
+    "extract_dir": "nvs",
+    "bin": "nvs.ps1",
+    "persist": "nodejs",
+    "env_set": {
+        "NVS_HOME": "$dir\\nodejs"
+    },
+    "post_install": [
+        "powershell -NoProfile -File $dir\\nvs.ps1 remote >> null",
+        "$CONF = (Get-Content \"$persist_dir\\nodejs\\settings.json\") | ConvertFrom-Json",
+        "Add-Member -NotePropertyName linkToSystem -NotePropertyValue $false -Force -InputObject $CONF",
+        "ConvertTo-Json $CONF | Out-File -encoding \"ASCII\" \"$persist_dir\\nodejs\\settings.json\""
+    ],
+    "uninstaller": {
+        "script": "nvs unlink >> null"
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/jasongin/nvs/releases/download/v$version/nvs-$version.msi"
+    }
+}


### PR DESCRIPTION
Add nvs v1.5.1, a more powerful Node.js versions tool on Windows than nvm-windows made by @jasongin.

- Name: Node Version Switcher
- Description: A cross-platform tool for switching between versions and forks of Node.js
- Version: 1.5.1
- Homepage: https://github.com/jasongin/nvs
- Basic usage
  - To add the latest version of node:
    ```powershell
    $ nvs add latest
    ```
  - Or to add the latest LTS version of node:
    ```powershell
    $ nvs add lts
    ```
  - Then run the `nvs use` command to add a version of node to your PATH for the current shell:
    ```powershell
    $ nvs use lts
    PATH += ~/.nvs/node/10.14.2/x64
    ```
  - To add it to PATH permanently, use `nvs link`:
    ```powershell
    $ nvs link lts
    ```
- Known Issue: Sometimes nvs will show an `EPERM: operation not permitted.` error during first adding some Node.js version, and it is due to JavaScript `fs.renameSync` function. The author hasn't been able to reproduce it himself (https://github.com/jasongin/nvs/issues/79#issuecomment-352277210), and in my practice, `nvs rm` and `nvs add` again should solve the problem. This only occurs in first `nvs add` run after re/install nvs. 