### PR TITLE
exiftool: add bin file without -k option

### DIFF
--- a/bucket/exiftool.json
+++ b/bucket/exiftool.json
@@ -7,11 +7,10 @@
     },
     "url": "https://downloads.sourceforge.net/project/exiftool/exiftool-11.22.zip",
     "hash": "sha1:3a4bcbb92d3da536cfa09fc57d6dbf9e73e6bf45",
+    "pre_install": "Copy-Item \"$dir/exiftool(-k).exe\" \"$dir/exiftool.exe\"",
     "bin": [
-        [
-            "exiftool(-k).exe",
-            "exiftool"
-        ]
+        "exiftool.exe",
+        "exiftool(-k).exe"
     ],
     "checkver": "exiftool-([\\d.]+).zip",
     "autoupdate": {


### PR DESCRIPTION
There is no way to stop `exiftool(-k).exe` from pausing without renaming the executable to `exiftool.exe`