### PR TITLE
update sqlite url and hash from 3.5.3 to 3.6.0

### DIFF
--- a/bucket/sqlite.json
+++ b/bucket/sqlite.json
@@ -2,8 +2,8 @@
     "homepage": "https://www.sqlite.org/",
     "version": "3.26.0",
     "license": "Public Domain",
-    "url": "https://www.sqlite.org/2018/sqlite-tools-win32-x86-3250300.zip",
-    "hash": "d2df1ef9f31e4d4e159e3afac87088f8614ad157e62f627c6317482744823b1f",
+    "url": "https://www.sqlite.org/2018/sqlite-tools-win32-x86-3260000.zip",
+    "hash": "0218b458495affe108e63e0786bbe7418dcd2da3d28c07207c466a16cded8793",
     "extract_dir": "sqlite-tools-win32-x86-3250300",
     "bin": [
         "sqlite3.exe",

--- a/bucket/sqlite.json
+++ b/bucket/sqlite.json
@@ -4,7 +4,7 @@
     "license": "Public Domain",
     "url": "https://www.sqlite.org/2018/sqlite-tools-win32-x86-3260000.zip",
     "hash": "0218b458495affe108e63e0786bbe7418dcd2da3d28c07207c466a16cded8793",
-    "extract_dir": "sqlite-tools-win32-x86-3250300",
+    "extract_dir": "sqlite-tools-win32-x86-3260000",
     "bin": [
         "sqlite3.exe",
         "sqldiff.exe",


### PR DESCRIPTION
sqlite's version is 3.26.0 insqlite.json.
But sqlite's download url still is "sqli...-3250300.zip"
3250300.zip means version 3.25.3
I update it to "sqli...-3260000.zip" also update it sha256sum(hash value)