### PR TITLE
scoop-search: add config.ps1 to load proxy settings

### DIFF
--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -9,6 +9,7 @@ param($query)
 . "$psscriptroot\..\lib\buckets.ps1"
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\versions.ps1"
+. "$psscriptroot\..\lib\config.ps1"
 
 reset_aliases
 


### PR DESCRIPTION
Fix #2818 and close #2750 