### PR TITLE
Allowed underscores in package names.

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -610,7 +610,7 @@ function applist($apps, $global) {
 }
 
 function parse_app([string] $app) {
-    if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>.*.json$|[a-zA-Z0-9-.]+)(?:@(?<version>.*))?') {
+    if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>.*.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?') {
         return $matches['app'], $matches['bucket'], $matches['version']
     }
     return $app, $null, $null

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -327,5 +327,23 @@ describe 'app' -Tag 'Scoop' {
         $app | should -be "test-app"
         $bucket | should -be "test-bucket"
         $version | should -be "1.8.0-rc2"
+
+        $query = "test-bucket/test_app"
+        $app, $bucket, $version = parse_app $query
+        $app | should -be "test_app"
+        $bucket | should -be "test-bucket"
+        $version | should -benullorempty
+
+        $query = "test-bucket/test_app@1.8.0"
+        $app, $bucket, $version = parse_app $query
+        $app | should -be "test_app"
+        $bucket | should -be "test-bucket"
+        $version | should -be "1.8.0"
+
+        $query = "test-bucket/test_app@1.8.0-rc2"
+        $app, $bucket, $version = parse_app $query
+        $app | should -be "test_app"
+        $bucket | should -be "test-bucket"
+        $version | should -be "1.8.0-rc2"
     }
 }


### PR DESCRIPTION
For example: `gcc-x86_64` (this is not host architecture, which can be expressed by `-a`, but target one).
