### PR TITLE
[auto-pr] Fix table syntax, allow help without hub, format

### DIFF
--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -24,32 +24,32 @@ $dir = resolve-path $dir
 . "$psscriptroot\..\lib\json.ps1"
 . "$psscriptroot\..\lib\unix.ps1"
 
-if(is_unix) {
-    if (!(which hub)) {
-        Write-Host -f yellow "Please install hub ('brew install hub' or visit: https://hub.github.com/)"
-        exit 1
-    }
-} else {
-    if (!(scoop which hub)) {
-        Write-Host -f yellow "Please install hub 'scoop install hub'"
-        exit 1
-    }
+if ((!$push -and !$request) -or $help) {
+    Write-Host @"
+Usage: auto-pr.ps1 [OPTION]
+
+Mandatory options:
+  -p,  -push                       push updates directly to 'origin master'
+  -r,  -request                    create pull-requests on 'upstream master' for each update
+
+Optional options:
+  -u,  -upstream                   upstream repository with target branch
+                                     only used if -r is set (default: lukesampson/scoop:master)
+  -h,  -help
+"@
+    exit 0
 }
 
-if ((!$push -and !$request) -or $help) {
-    Write-Host ""
-    Write-Host "Usage: auto-pr.ps1 [OPTION]"
-    Write-Host ""
-    Write-Host "Mandatory options:"
-    Write-Host "  -p,  -push                       push updates directly to 'origin master'"
-    Write-Host "  -r,  -request                    create pull-requests on 'upstream master' for each update"
-    Write-Host ""
-    Write-Host "Optional options:"
-    Write-Host "  -u,  -upstream                   upstream repository with target branch"
-    Write-Host "                                     only used if -r is set (default: lukesampson/scoop:master)"
-    Write-Host "  -h,  -help"
-    Write-Host ""
-    exit 0
+if (is_unix) {
+	if (!(which hub)) {
+		Write-Host -f yellow "Please install hub ('brew install hub' or visit: https://hub.github.com/)"
+		exit 1
+	}
+} else {
+	if (!(scoop which hub)) {
+		Write-Host -f yellow "Please install hub 'scoop install hub'"
+		exit 1
+	}
 }
 
 if(!($upstream -match "^(.*)\/(.*):(.*)$")) {

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -23,22 +23,22 @@
     Update all manifests inside 'bucket/' directory.
 #>
 param(
-    [String]$upstream = "lukesampson/scoop:master",
-    [String]$dir,
-    [Switch]$push = $false,
-    [Switch]$request = $false,
-    [Switch]$help = $false,
-    [string[]]$specialSnowflakes
+    [String] $Upstream = "lukesampson/scoop:master",
+    [String] $Dir,
+    [Switch] $Push,
+    [Switch] $Request,
+    [Switch] $Help,
+    [string[]] $SpecialSnowflakes
 )
 
-if (!$dir) { $dir = "$psscriptroot\..\bucket" }
-$dir = resolve-path $dir
+if (!$Dir) { $Dir = "$psscriptroot\..\bucket" }
+$Dir = resolve-path $Dir
 
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\json.ps1"
 . "$psscriptroot\..\lib\unix.ps1"
 
-if ((!$push -and !$request) -or $help) {
+if ((!$Push -and !$Request) -or $Help) {
     Write-Host @"
 Usage: auto-pr.ps1 [OPTION]
 
@@ -66,7 +66,7 @@ if (is_unix) {
     }
 }
 
-if (!($upstream -match "^(.*)\/(.*):(.*)$")) {
+if (!($Upstream -match "^(.*)\/(.*):(.*)$")) {
     abort "Upstream must have this format: <user>/<repo>:<branch>"
 }
 
@@ -129,7 +129,7 @@ a new version of [$app]($homepage) is available.
 }
 
 Write-Host -f DarkCyan "Updating ..."
-if ($push -eq $true) {
+if ($Push) {
     execute("hub pull origin master")
     execute "hub checkout master"
 } else {
@@ -137,11 +137,11 @@ if ($push -eq $true) {
     execute("hub push origin master")
 }
 
-. "$psscriptroot\checkver.ps1" * -update -dir $dir
-if ($specialSnowflakes) {
-    write-host -f DarkCyan "Forcing update on our special snowflakes: $($specialSnowflakes -join ',')"
-    $specialSnowflakes -split ',' | ForEach-Object {
-        . "$psscriptroot\checkver.ps1" $_ -update -forceUpdate -dir $dir
+. "$psscriptroot\checkver.ps1" * -update -dir $Dir
+if ($SpecialSnowflakes) {
+    write-host -f DarkCyan "Forcing update on our special snowflakes: $($SpecialSnowflakes -join ',')"
+    $SpecialSnowflakes -split ',' | ForEach-Object {
+        . "$psscriptroot\checkver.ps1" $_ -update -forceUpdate -dir $Dir
     }
 }
 
@@ -159,7 +159,7 @@ hub diff --name-only | ForEach-Object {
     }
     $version = $json.version
 
-    if ($push -eq $true) {
+    if ($Push) {
         Write-Host -f DarkCyan "Creating update $app ($version) ..."
         execute "hub add $manifest"
 
@@ -172,11 +172,11 @@ hub diff --name-only | ForEach-Object {
             Write-Host -f Yellow "Skipping $app because only LF/CRLF changes were detected ..."
         }
     } else {
-        pull_requests $json $app $upstream $manifest
+        pull_requests $json $app $Upstream $manifest
     }
 }
 
-if ($push -eq $true) {
+if ($Push) {
     Write-Host -f DarkCyan "Pushing updates ..."
     execute "hub push origin master"
 } else {

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -4,18 +4,18 @@
 .DESCRIPTION
     Updates manifests and pushes them directly to the master branch or creates pull-requests for upstream.
 .PARAMETER Upstream
-    Upstream repository with target branch.
+    Upstream repository with the target branch.
     Must be in format '<user>/<repo>:<branch>'
 .PARAMETER Dir
-    Directory where to search for manifests.
+    The directory where to search for manifests.
 .PARAMETER Push
     Push updates directly to 'origin master'.
 .PARAMETER Request
     Create pull-requests on 'upstream master' for each update.
 .PARAMETER Help
     Print help to console.
-.PARAMETER SpecialSnoflakes
-    Array of manifests, which should be updated all the time. (-ForceUpdate paramter to checkver)
+.PARAMETER SpecialSnowflakes
+    An array of manifests, which should be updated all the time. (-ForceUpdate parameter to checkver)
 .EXAMPLE
     PS REPODIR > .\bin\auto-pr.ps1 'someUsername/repository:branch' -Request
 .EXAMPLE

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -23,16 +23,28 @@
     Update all manifests inside 'bucket/' directory.
 #>
 param(
-    [String] $Upstream = "lukesampson/scoop:master",
-    [String] $Dir,
+    [ValidateScript( {
+        if (!($_ -match '^(.*)\/(.*):(.*)$')) {
+            throw 'Upstream must be in this format: <user>/<repo>:<branch>'
+        } else {
+            $true
+        }
+    })]
+    [String] $Upstream = 'lukesampson/scoop:master',
+    [ValidateScript( {
+        if (!(Test-Path $_ -Type Container)) {
+            throw "$_ is not a directory!"
+        }
+        $true
+    })]
+    [String] $Dir = "$PSScriptRoot\..\bucket",
     [Switch] $Push,
     [Switch] $Request,
     [Switch] $Help,
     [string[]] $SpecialSnowflakes
 )
 
-if (!$Dir) { $Dir = "$psscriptroot\..\bucket" }
-$Dir = resolve-path $Dir
+$Dir = Resolve-Path $Dir
 
 . "$psscriptroot\..\lib\manifest.ps1"
 . "$psscriptroot\..\lib\json.ps1"
@@ -64,10 +76,6 @@ if (is_unix) {
         Write-Host -f yellow "Please install hub 'scoop install hub'"
         exit 1
     }
-}
-
-if (!($Upstream -match "^(.*)\/(.*):(.*)$")) {
-    abort "Upstream must have this format: <user>/<repo>:<branch>"
 }
 
 function execute($cmd) {

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -26,9 +26,8 @@ param(
     [ValidateScript( {
         if (!($_ -match '^(.*)\/(.*):(.*)$')) {
             throw 'Upstream must be in this format: <user>/<repo>:<branch>'
-        } else {
-            $true
         }
+        $true
     })]
     [String] $Upstream = 'lukesampson/scoop:master',
     [ValidateScript( {
@@ -44,14 +43,14 @@ param(
     [string[]] $SpecialSnowflakes
 )
 
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\json.ps1"
+. "$PSScriptRoot\..\lib\unix.ps1"
+
 $Dir = Resolve-Path $Dir
 
-. "$psscriptroot\..\lib\manifest.ps1"
-. "$psscriptroot\..\lib\json.ps1"
-. "$psscriptroot\..\lib\unix.ps1"
-
 if ((!$Push -and !$Request) -or $Help) {
-    Write-Host @"
+    Write-Host @'
 Usage: auto-pr.ps1 [OPTION]
 
 Mandatory options:
@@ -62,61 +61,63 @@ Optional options:
   -u,  -upstream                   upstream repository with target branch
                                      only used if -r is set (default: lukesampson/scoop:master)
   -h,  -help
-"@
+'@
     exit 0
 }
 
 if (is_unix) {
     if (!(which hub)) {
-        Write-Host -f yellow "Please install hub ('brew install hub' or visit: https://hub.github.com/)"
+        Write-Host "Please install hub ('brew install hub' or visit: https://hub.github.com/)" -ForegroundColor Yellow
         exit 1
     }
 } else {
     if (!(scoop which hub)) {
-        Write-Host -f yellow "Please install hub 'scoop install hub'"
+        Write-Host "Please install hub 'scoop install hub'" -ForegroundColor Yellow
         exit 1
     }
 }
 
 function execute($cmd) {
-    Write-Host -f Green $cmd
+    Write-Host $cmd -ForegroundColor Green
     $output = Invoke-Expression $cmd
 
     if ($LASTEXITCODE -gt 0) {
         abort "^^^ Error! See above ^^^ (last command: $cmd)"
     }
+
     return $output
 }
 
-function pull_requests($json, [String]$app, [String]$upstream, [String]$manifest) {
+function pull_requests($json, [String] $app, [String] $upstream, [String] $manifest) {
     $version = $json.version
     $homepage = $json.homepage
     $branch = "manifest/$app-$version"
 
-    execute "hub checkout master"
-    Write-Host -f Green "hub rev-parse --verify $branch"
+    execute 'hub checkout master'
+    Write-Host "hub rev-parse --verify $branch" -ForegroundColor Green
     hub rev-parse --verify $branch
 
     if ($LASTEXITCODE -eq 0) {
-        Write-Host -f Yellow "Skipping update $app ($version) ..."
+        Write-Host "Skipping update $app ($version) ..." -ForegroundColor Yellow
         return
     }
 
-    Write-Host -f DarkCyan "Creating update $app ($version) ..."
+    Write-Host "Creating update $app ($version) ..." -ForegroundColor DarkCyan
     execute "hub checkout -b $branch"
     execute "hub add $manifest"
     execute "hub commit -m '${app}: Update to version $version'"
-    Write-Host -f DarkCyan "Pushing update $app ($version) ..."
+    Write-Host "Pushing update $app ($version) ..." -ForegroundColor DarkCyan
     execute "hub push origin $branch"
 
     if ($LASTEXITCODE -gt 0) {
         error "Push failed! (hub push origin $branch)"
-        execute "hub reset"
+        execute 'hub reset'
         return
     }
+
     Start-Sleep 1
-    Write-Host -f DarkCyan "Pull-Request update $app ($version) ..."
-    Write-Host -f green "hub pull-request -m '<msg>' -b '$upstream' -h '$branch'"
+    Write-Host "Pull-Request update $app ($version) ..." -ForegroundColor DarkCyan
+    Write-Host "hub pull-request -m '<msg>' -b '$upstream' -h '$branch'" -ForegroundColor Green
 
     $msg = @"
 $app`: Update to version $version
@@ -124,38 +125,38 @@ $app`: Update to version $version
 Hello lovely humans,
 a new version of [$app]($homepage) is available.
 
-| State | Update :rocket: |
-| :---: | :-------------: |
-| New Version | $version  |
+| State       | Update :rocket: |
+| :---------- | :-------------- |
+| New version | $version        |
 "@
 
     hub pull-request -m "$msg" -b '$upstream' -h '$branch'
     if ($LASTEXITCODE -gt 0) {
-        execute "hub reset"
+        execute 'hub reset'
         abort "Pull Request failed! (hub pull-request -m '${app}: Update to version $version' -b '$upstream' -h '$branch')"
     }
 }
 
-Write-Host -f DarkCyan "Updating ..."
+Write-Host 'Updating ...' -ForegroundColor DarkCyan
 if ($Push) {
-    execute("hub pull origin master")
-    execute "hub checkout master"
+    execute 'hub pull origin master'
+    execute 'hub checkout master'
 } else {
-    execute("hub pull upstream master")
-    execute("hub push origin master")
+    execute 'hub pull upstream master'
+    execute 'hub push origin master'
 }
 
-. "$psscriptroot\checkver.ps1" * -update -dir $Dir
+. "$PSScriptRoot\checkver.ps1" -Dir $Dir -Update
 if ($SpecialSnowflakes) {
-    write-host -f DarkCyan "Forcing update on our special snowflakes: $($SpecialSnowflakes -join ',')"
+    Write-Host "Forcing update on our special snowflakes: $($SpecialSnowflakes -join ',')" -ForegroundColor DarkCyan
     $SpecialSnowflakes -split ',' | ForEach-Object {
-        . "$psscriptroot\checkver.ps1" $_ -update -forceUpdate -dir $Dir
+        . "$PSScriptRoot\checkver.ps1" $_ -Dir $Dir -ForceUpdate
     }
 }
 
 hub diff --name-only | ForEach-Object {
     $manifest = $_
-    if (!$manifest.EndsWith(".json")) {
+    if (!$manifest.EndsWith('.json')) {
         return
     }
 
@@ -168,16 +169,16 @@ hub diff --name-only | ForEach-Object {
     $version = $json.version
 
     if ($Push) {
-        Write-Host -f DarkCyan "Creating update $app ($version) ..."
+        Write-Host "Creating update $app ($version) ..." -ForegroundColor DarkCyan
         execute "hub add $manifest"
 
         # detect if file was staged, because it's not when only LF or CRLF have changed
-        $status = Invoke-Expression "hub status --porcelain -uno"
-        $status = $status | select-object -first 1
+        $status = Invoke-Expression 'hub status --porcelain -uno'
+        $status = $status | Select-Object -First 1
         if ($status -and $status.StartsWith('M  ') -and $status.EndsWith("$app.json")) {
             execute "hub commit -m '${app}: Update to version $version'"
         } else {
-            Write-Host -f Yellow "Skipping $app because only LF/CRLF changes were detected ..."
+            Write-Host "Skipping $app because only LF/CRLF changes were detected ..." -ForegroundColor Yellow
         }
     } else {
         pull_requests $json $app $Upstream $manifest
@@ -185,11 +186,11 @@ hub diff --name-only | ForEach-Object {
 }
 
 if ($Push) {
-    Write-Host -f DarkCyan "Pushing updates ..."
-    execute "hub push origin master"
+    Write-Host 'Pushing updates ...' -ForegroundColor DarkCyan
+    execute 'hub push origin master'
 } else {
-    Write-Host -f DarkCyan "Returning to master branch and removing unstaged files ..."
-    execute "hub checkout -f master"
+    Write-Host 'Returning to master branch and removing unstaged files ...' -ForegroundColor DarkCyan
+    execute 'hub checkout -f master'
 }
 
-execute "hub reset"
+execute 'hub reset'

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -96,13 +96,18 @@ function pull_requests($json, [String]$app, [String]$upstream, [String]$manifest
     Start-Sleep 1
     Write-Host -f DarkCyan "Pull-Request update $app ($version) ..."
     Write-Host -f green "hub pull-request -m '<msg>' -b '$upstream' -h '$branch'"
-    $msg = "${app}: Update to version $version`n`n"
-    $msg += "Hello lovely humans,`n"
-    $msg += "a new version of [$app]($homepage) is available.`n"
-    $msg += "<table>"
-    $msg += "<tr><th align=left>State</th><td>Update :rocket:</td></tr>"
-    $msg += "<tr><th align=left>New version</td><td>$version</td></tr>"
-    $msg += "</table>"
+
+    $msg = @"
+$app`: Update to version $version
+
+Hello lovely humans,
+a new version of [$app]($homepage) is available.
+
+| State | Update :rocket: |
+| :---: | :-------------: |
+| New Version | $version  |
+"@
+
     hub pull-request -m "$msg" -b '$upstream' -h '$branch'
     if($LASTEXITCODE -gt 0) {
         execute "hub reset"


### PR DESCRIPTION
- Add synopsis
- Add Native parameter validation
- Help parameter never worked if you do not have hub installed
    - Moved check for hub after help parameter check
    - You can now run `auto-pr -Help` without installed hub
- Use heredoc instead of string gluing
- Use markdown syntax for commit message
    - Table produced was wrong rendered due to element mismatch
        - ![wrong syntax](https://i.imgur.com/CgoXlvo.png)
- Format