### PR TITLE
mls-software-openssh: fix tmp dir not exist

### DIFF
--- a/bucket/mls-software-openssh.json
+++ b/bucket/mls-software-openssh.json
@@ -8,7 +8,8 @@
     "post_install": [
         "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
         "Remove-Item \"$dir\\`$TEMP\" -Recurse",
-        "Remove-Item \"$dir\\uninstall.exe\""
+        "Remove-Item \"$dir\\uninstall.exe\"",
+        "if (!(test-path \"$dir\\tmp\")) { new-item \"$dir\\tmp\" -itemtype directory | out-null }"
     ],
     "bin": [
         "bin\\scp.exe",


### PR DESCRIPTION
`ssh-agent.exe` requires `tmp` directory.