### PR TITLE
Redirect "global" yarn directory

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -15,9 +15,12 @@
     "persist": [
         "cache",
         "bin",
-        "mirror"
+        "mirror",
+        "global"
     ],
     "post_install": [
+        "yarn config set global-folder \"$dir\\global\"",
+        "Set-Content $env:USERPROFILE\\.yarnrc (Get-Content $env:USERPROFILE\\.yarnrc | %{ $_ -replace \"^global-folder\", \"--global-folder\" })",
         "yarn config set cache-folder \"$dir\\cache\"",
         "yarn config set yarn-offline-mirror \"$dir\\mirror\"",
         "yarn config set prefix \"$dir\""


### PR DESCRIPTION
Current installer for `yarn` redirects `bin`, `cache` and `mirror` directories to scoop's persistent storage. However, the `global` directory (used by packages that get installed globally via `yarn global add`) is still using the default `$env:LOCALAPPDATA\Yarn\Data\global`.

This pull request adds a persistent directory `global` and then updates `.yarnrc` to use it.

Unfortunately `yarn` does not currently recognize `global-folder` configuration setting, only `--global-folder` ([source](https://github.com/yarnpkg/yarn/issues/5746#issuecomment-386295014)), so I added an extra post-install PowerShell fragment that adds the `--` prefix to `global-folder` in `.yarnrc` file.

The following screenshot illustrates the difference in `yarn global dir` output when using installing the current `yarn` bundle and when installing updated bundle (as per this PR):

![yarn global dir](https://user-images.githubusercontent.com/42297/50925672-43bcf500-1410-11e9-9e8d-a588f2c293bc.png)
