### PR TITLE
Fix pshazz manifest

### DIFF
--- a/bucket/pshazz.json
+++ b/bucket/pshazz.json
@@ -4,10 +4,7 @@
     "url": "https://github.com/lukesampson/pshazz/archive/f40bfabb011e38215f66610e5dce432fa67ba393.zip",
     "extract_dir": "pshazz-f40bfabb011e38215f66610e5dce432fa67ba393",
     "hash": "e93999abb13008348fef0c12a61bc17b35cb0addb7dc44fba7c4a22e2fe9adc1",
-    "bin": [
-        "bin\\pshazz.ps1",
-        "libexec\\askpass.exe"
-    ],
+    "bin": "bin\\pshazz.ps1",
     "installer": {
         "file": "bin\\install.ps1"
     },


### PR DESCRIPTION
As of version 0.2019.01.12 (specifically, https://github.com/lukesampson/pshazz/commit/32bce43fcb13aa28c377a084626e5294c2bbf2b6), pshazz does no longer have an askpass.exe binary, which results in an error while shimming:
```
Creating shim for 'askpass'.
Can't shim 'libexec\askpass.exe': File doesn't exist.
```

This PR removes the binary from the manifest.