### PR TITLE
Allure: update distribution url to Maven Central

### DIFF
--- a/bucket/allure.json
+++ b/bucket/allure.json
@@ -3,7 +3,7 @@
     "description": "A flexible lightweight multi-language test report tool",
     "version": "2.9.0",
     "license": "Apache-2.0",
-    "url": "https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline/2.9.0/allure-commandline-2.9.0.zip",
+    "url": "https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/2.9.0/allure-commandline-2.9.0.zip",
     "hash": "c1e4ae56c8be2ceef83cc5da83d8071e91cdcdf3e6ce88f8fcd2a250e3914076",
     "extract_dir": "allure-2.9.0",
     "bin": "bin\\allure.bat",
@@ -12,7 +12,7 @@
     },
     "checkver": "github",
     "autoupdate": {
-        "url": "https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline/$version/allure-commandline-$version.zip",
+        "url": "https://repo.maven.apache.org/maven2/io/qameta/allure/allure-commandline/$version/allure-commandline-$version.zip",
         "extract_dir": "allure-$version"
     }
 }


### PR DESCRIPTION
Allure distributions are moved to Maven Central. For more details please see https://github.com/allure-framework/allure2/issues/832