### PR TITLE
Add empty-recycle-bin 1.0.0

### DIFF
--- a/bucket/empty-recycle-bin.json
+++ b/bucket/empty-recycle-bin.json
@@ -1,0 +1,13 @@
+{
+    "version":  "1.0.0",
+    "description": "Empty the Windows recycle bin",
+    "homepage":  "https://github.com/sindresorhus/empty-recycle-bin",
+    "license":  "MIT",
+    "url":  "https://github.com/sindresorhus/empty-recycle-bin/releases/download/1.0.0/empty-recycle-bin.exe",
+    "hash":  "B5C939A5747AFA4D43F2342705726602E34D9CF46FE6664C2A7D0DEA39E64560",
+    "bin":  "empty-recycle-bin.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/sindresorhus/empty-recycle-bin/releases/download/$version/empty-recycle-bin.exe"
+    }
+}


### PR DESCRIPTION
Command-line tool to empty the Windows recycle bin. This is complement to the existing [recycle-bin](https://github.com/lukesampson/scoop/blob/master/bucket/recycle-bin.json) tool by the same author.