### PR TITLE
Add version variables to autoupdate.hash.regex

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -9,7 +9,7 @@ TODO
 . "$psscriptroot/core.ps1"
 . "$psscriptroot/json.ps1"
 
-function find_hash_in_rdf([String] $url, [String] $filename) {
+function find_hash_in_rdf([String] $url, [String] $basename) {
     $data = $null
     try {
         # Download and parse RDF XML file
@@ -24,7 +24,7 @@ function find_hash_in_rdf([String] $url, [String] $filename) {
     }
 
     # Find file content
-    $digest = $data.RDF.Content | Where-Object { [String]$_.about -eq $filename }
+    $digest = $data.RDF.Content | Where-Object { [String]$_.about -eq $basename }
 
     return format_hash $digest.sha256
 }
@@ -76,7 +76,7 @@ function find_hash_in_textfile([String] $url, [Hashtable] $substitutions, [Strin
     return format_hash $hash
 }
 
-function find_hash_in_json([String] $url, [String] $basename, [String] $jsonpath) {
+function find_hash_in_json([String] $url, [Hashtable] $substitutions, [String] $jsonpath) {
     $json = $null
 
     try {
@@ -89,9 +89,9 @@ function find_hash_in_json([String] $url, [String] $basename, [String] $jsonpath
         write-host -f darkred "URL $url is not valid"
         return
     }
-    $hash = json_path $json $jsonpath $basename
+    $hash = json_path $json $jsonpath $substitutions
     if(!$hash) {
-        $hash = json_path_legacy $json $jsonpath $basename
+        $hash = json_path_legacy $json $jsonpath $substitutions
     }
     return format_hash $hash
 }
@@ -181,7 +181,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
             $hash = find_hash_in_textfile $hashfile_url $substitutions $regex
         }
         'json' {
-            $hash = find_hash_in_json $hashfile_url $basename $jsonpath
+            $hash = find_hash_in_json $hashfile_url $substitutions $jsonpath
         }
         'rdf' {
             $hash = find_hash_in_rdf $hashfile_url $basename

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -176,6 +176,12 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         $regex = $config.regex
     }
 
+    $substitutions.GetEnumerator() | ForEach-Object {
+        if ($_.Value) {
+            $regex = $regex.Replace($_.Name, [regex]::Escape($_.Value))
+        }
+    }
+
     if (!$hashfile_url -and $url -match "(?:downloads\.)?sourceforge.net\/projects?\/(?<project>[^\/]+)\/(?:files\/)?(?<file>.*)") {
         $hashmode = 'sourceforge'
         # change the URL because downloads.sourceforge.net doesn't have checksums

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -29,7 +29,7 @@ function find_hash_in_rdf([String] $url, [String] $filename) {
     return format_hash $digest.sha256
 }
 
-function find_hash_in_textfile([String] $url, [String] $basename, [String] $regex) {
+function find_hash_in_textfile([String] $url, [Hashtable] $substitutions, [String] $regex = '^([a-fA-F0-9]+)$') {
     $hashfile = $null
 
     try {
@@ -43,15 +43,8 @@ function find_hash_in_textfile([String] $url, [String] $basename, [String] $rege
         return
     }
 
-    # find single line hash in $hashfile (will be overridden by $regex)
-    if ($regex.Length -eq 0) {
-        $normalRegex = "^([a-fA-F0-9]+)$"
-    } else {
-        $normalRegex = $regex
-    }
-
-    $normalRegex = substitute $normalRegex @{'$basename' = [regex]::Escape($basename)}
-    if ($hashfile -match $normalRegex) {
+    $regex = substitute $regex $substitutions $true
+    if ($hashfile -match $regex) {
         $hash = $matches[1] -replace ' ',''
     }
 
@@ -70,7 +63,7 @@ function find_hash_in_textfile([String] $url, [String] $basename, [String] $rege
     # find hash with filename in $hashfile (will be overridden by $regex)
     if ($hash.Length -eq 0 -and $regex.Length -eq 0) {
         $filenameRegex = "([a-fA-F0-9]{32,128})[\x20\t]+.*`$basename(?:[\x20\t]+\d+)?"
-        $filenameRegex = substitute $filenameRegex @{'$basename' = [regex]::Escape($basename)}
+        $filenameRegex = substitute $filenameRegex $substitutions $true
         if ($hashfile -match $filenameRegex) {
             $hash = $matches[1]
         }
@@ -142,12 +135,12 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
     $hashmode = $config.mode
     $basename = url_remote_filename($url)
 
-    $hashfile_url = substitute $config.url @{
-        '$url' = (strip_fragment $url);
-        '$baseurl' = (strip_filename (strip_fragment $url)).TrimEnd('/')
-        '$basename' = $basename
-    }
-    $hashfile_url = substitute $hashfile_url $substitutions
+    $substitutions = $substitutions.Clone()
+    $substitutions.Add('$url', (strip_fragment $url))
+    $substitutions.Add('$baseurl', (strip_filename (strip_fragment $url)).TrimEnd('/'))
+    $substitutions.Add('$basename', $basename)
+
+    $hashfile_url = substitute $config.url $substitutions
     if($hashfile_url) {
         write-host -f DarkYellow 'Searching hash for ' -NoNewline
         write-host -f Green $(url_remote_filename $url) -NoNewline
@@ -176,22 +169,16 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         $regex = $config.regex
     }
 
-    $substitutions.GetEnumerator() | ForEach-Object {
-        if ($_.Value) {
-            $regex = $regex.Replace($_.Name, [regex]::Escape($_.Value))
-        }
-    }
-
     if (!$hashfile_url -and $url -match "(?:downloads\.)?sourceforge.net\/projects?\/(?<project>[^\/]+)\/(?:files\/)?(?<file>.*)") {
         $hashmode = 'sourceforge'
         # change the URL because downloads.sourceforge.net doesn't have checksums
         $hashfile_url = (strip_filename (strip_fragment "https://sourceforge.net/projects/$($matches['project'])/files/$($matches['file'])")).TrimEnd('/')
-        $hash = find_hash_in_textfile $hashfile_url $basename '"$basename":.*?"sha1":\s"([a-fA-F0-9]{40})"'
+        $hash = find_hash_in_textfile $hashfile_url $substitutions '"$basename":.*?"sha1":\s"([a-fA-F0-9]{40})"'
     }
 
     switch ($hashmode) {
         'extract' {
-            $hash = find_hash_in_textfile $hashfile_url $basename $regex
+            $hash = find_hash_in_textfile $hashfile_url $substitutions $regex
         }
         'json' {
             $hash = find_hash_in_json $hashfile_url $basename $jsonpath
@@ -202,7 +189,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         'metalink' {
             $hash = find_hash_in_headers $url
             if(!$hash) {
-                $hash = find_hash_in_textfile "$url.meta4"
+                $hash = find_hash_in_textfile "$url.meta4" $substitutions
             }
         }
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -612,12 +612,16 @@ function is_scoop_outdated() {
     return $last_update.AddHours(3) -lt $now.ToLocalTime()
 }
 
-function substitute($entity, [Hashtable] $params) {
+function substitute($entity, [Hashtable] $params, [Bool]$regexEscape = $false) {
     if ($entity -is [Array]) {
-        return $entity | ForEach-Object { substitute $_ $params }
+        return $entity | ForEach-Object { substitute $_ $params $regexEscape}
     } elseif ($entity -is [String]) {
         $params.GetEnumerator() | ForEach-Object {
-            $entity = $entity.Replace($_.Name, $_.Value)
+            if($regexEscape -eq $false -or $null -eq $_.Value) {
+                $entity = $entity.Replace($_.Name, $_.Value)
+            } else {
+                $entity = $entity.Replace($_.Name, [Regex]::Escape($_.Value))
+            }
         }
         return $entity
     }


### PR DESCRIPTION
Add [version variables](https://github.com/lukesampson/scoop/wiki/App-Manifest-Autoupdate#version-variables) to `autoupdate.hash.regex` for some hash extract situations.

The idea is from Atom's nupkg hash extraction. Atom's [releases page](https://github.com/atom/atom/releases/latest) provides nupkg named `atom-1.34.0-full.nupkg` (for i686) and `atom-x64-1.34.0-full.nupkg` (for x64_86), and it also provides [`RELEASES`](https://github.com/atom/atom/releases/download/v1.34.0/RELEASES) and [`RELEASES-x64`](https://github.com/atom/atom/releases/download/v1.34.0/RELEASES-x64) files that give sha1 hash of nupkg files. Unfortunately in `RELEASES-x64` the nupkg file name is `atom-1.34.0-full.nupkg` without `-x64`. 

I haven't found some method to write a regex to extract the hash without `$version`, but [`get_hash_for_app()`](../blob/master/lib/autoupdate.ps1#L133) only support `$basename$ in regex. So I add the code, and it works for the following hash extract:

```json
"url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-$version-full.nupkg#dl.7z",
"hash": {
    "url": "$baseurl/RELEASES-x64",
    "regex": "([a-fA-F0-9]+)\\s+?(?:atom-$version-full.nupkg)"
}
```