### PR TITLE
json schema: Add bracket-notation in jsonpath pattern

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -35,12 +35,12 @@
                     "type": "string"
                 },
                 "jp": {
-                    "pattern": "^\\$\\..*$",
+                    "pattern": "^\\$[.[].*$",
                     "type": "string",
                     "description": "Same as 'jsonpath'"
                 },
                 "jsonpath": {
-                    "pattern": "^\\$\\..*$",
+                    "pattern": "^\\$[.[].*$",
                     "type": "string"
                 },
                 "mode": {
@@ -226,12 +226,12 @@
                             "type": "string"
                         },
                         "jp": {
-                            "pattern": "^\\$\\..*$",
+                            "pattern": "^\\$[.[].*$",
                             "type": "string",
                             "description": "Same as 'jsonpath'"
                         },
                         "jsonpath": {
-                            "pattern": "^\\$\\..*$",
+                            "pattern": "^\\$[.[].*$",
                             "type": "string"
                         },
                         "reverse": {


### PR DESCRIPTION
Add bracket-notation pattern check to schema.json (Why not?)