### PR TITLE
Add JArray::Parse() to json_path in lib/json.ps1

### DIFF
--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -108,7 +108,11 @@ function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitution
     }
 
     try {
-        $result = $obj.SelectToken($jsonpath, $true)
+        try {
+            $result = $obj.SelectToken($jsonpath, $true)
+        } catch [Newtonsoft.Json.JsonException] {
+            return $null
+        }
         return $result.ToString()
     } catch [System.Management.Automation.MethodInvocationException] {
         write-host -f DarkRed $_

--- a/lib/json.ps1
+++ b/lib/json.ps1
@@ -100,7 +100,11 @@ function json_path([String] $json, [String] $jsonpath, [Hashtable] $substitution
     try {
         $obj = [Newtonsoft.Json.Linq.JObject]::Parse($json)
     } catch [Newtonsoft.Json.JsonReaderException] {
-        return $null
+        try {
+            $obj = [Newtonsoft.Json.Linq.JArray]::Parse($json)
+        } catch [Newtonsoft.Json.JsonReaderException] {
+            return $null
+        }
     }
 
     try {


### PR DESCRIPTION
Some JSON file ([example](https://mranapi.azurewebsites.net/api/download)) is surrounded by brackets ("[", "]") and cannot be parsed using `[Newtonsoft.Json.Linq.JObject]::Parse()` in `json_path()`. Instead, they could be parsed by `[Newtonsoft.Json.Linq.JArray]::Parse()` and then be treated as normal, e.g., applies a filter (script) expression.

- Add `[Newtonsoft.Json.Linq.JArray]::Parse()` after `[Newtonsoft.Json.Linq.JObject]::Parse()` failed
- Some JArray are handled by `json_path_legacy()` when `json_path()` throw error before, and the JSONPath is illegal when parsed with `JArray::Parse()`. To keep compatibility, add try-catch in this situation and let `json_path_legacy()` handle them still.
- In the above situation, manifest maintainer should use double dots after `$`, i.e., use `$..NODE` instead of `$.NODE` since it is a JArray contained the JObject.