### PR TITLE
core.ps1: Fix url_remote_filename (edited)

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -162,7 +162,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
     debug $hashfile_url
     if ($hashfile_url) {
         write-host -f DarkYellow 'Searching hash for ' -NoNewline
-        write-host -f Green $(url_remote_filename $url) -NoNewline
+        write-host -f Green $basename -NoNewline
         write-host -f DarkYellow ' in ' -NoNewline
         write-host -f Green $hashfile_url
     }
@@ -230,7 +230,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
     }
 
     write-host -f DarkYellow 'Downloading ' -NoNewline
-    write-host -f Green $(url_remote_filename $url) -NoNewline
+    write-host -f Green $basename -NoNewline
     write-host -f DarkYellow ' to compute hashes!'
     try {
         dl_with_cache $app $version $url $null $null $true

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -222,7 +222,18 @@ function url_filename($url) {
 # URL fragment (e.g. #/dl.7z, useful for coercing a local filename),
 # this function extracts the original filename from the URL.
 function url_remote_filename($url) {
-    split-path (new-object uri $url).absolutePath -leaf
+    $uri = (New-Object URI $url)
+    $basename = Split-Path $uri.PathAndQuery -Leaf
+    If ($basename -match ".*[?=]+([\w._-]+)") {
+        $basename = $matches[1]
+    }
+    If (($basename -notlike "*.*") -or ($basename -match "^[v.\d]+$")) {
+        $basename = Split-Path $uri.AbsolutePath -Leaf
+    }
+    If (($basename -notlike "*.*") -and ($uri.Fragment -ne "")) {
+        $basename = $uri.Fragment.Trim('/', '#')
+    }
+    return $basename
 }
 
 function ensure($dir) { if(!(test-path $dir)) { mkdir $dir > $null }; resolve-path $dir }


### PR DESCRIPTION
EDITED: No WebRequest, Local URL Treatment

Current `url_remote_filename()` cannot handle redirected urls like "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-9/v9.0.14/bin/apache-tomcat-9.0.14-windows-x64.zip", this modified one works in most cases.

- Get filename from PathAndQuery instead of AbsolutePath
- Throw away leading `?=`
- If got `vxx.xx.xx`, fallback to AbsolutePath
- Use fragment name if all above failed