### PR TITLE
[auto-pr] Use regex instead of Starts|EndsWith

### DIFF
--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -175,7 +175,7 @@ hub diff --name-only | ForEach-Object {
         # detect if file was staged, because it's not when only LF or CRLF have changed
         $status = execute 'hub status --porcelain -uno'
         $status = $status | Select-Object -First 1
-        if ($status -and $status -match "\s*M\s+.*$app.json") {
+        if ($status -and $status -match "^\x20*M\x20+.*$app.json") {
             execute "hub commit -m '${app}: Update to version $version'"
         } else {
             Write-Host "Skipping $app because only LF/CRLF changes were detected ..." -ForegroundColor Yellow

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -173,9 +173,9 @@ hub diff --name-only | ForEach-Object {
         execute "hub add $manifest"
 
         # detect if file was staged, because it's not when only LF or CRLF have changed
-        $status = Invoke-Expression 'hub status --porcelain -uno'
+        $status = execute 'hub status --porcelain -uno'
         $status = $status | Select-Object -First 1
-        if ($status -and $status.StartsWith('M  ') -and $status.EndsWith("$app.json")) {
+        if ($status -and $status -match "\s*M\s+.*$app.json") {
             execute "hub commit -m '${app}: Update to version $version'"
         } else {
             Write-Host "Skipping $app because only LF/CRLF changes were detected ..." -ForegroundColor Yellow


### PR DESCRIPTION
On my end result of `hub status --porcelain -uno` is prefixed with space on left for some reason, which failed test for `startsWith('M  ')` since it's strict match

![Auto-PR](https://i.imgur.com/3FKQZOg.png)

Alternatively $status could be Trimed before condition

![Trimed](https://i.imgur.com/1DRUlv4.png)