### PR TITLE
buckets: Move function into lib from lib-exec

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -32,7 +32,7 @@ function known_bucket_repo($name) {
 }
 
 function known_buckets {
-	known_bucket_repos | ForEach-Object { $_.psobject.properties | Select-Object -expand 'name' }
+    known_bucket_repos | ForEach-Object { $_.psobject.properties | Select-Object -expand 'name' }
 }
 
 function apps_in_bucket($dir) {

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -31,6 +31,10 @@ function known_bucket_repo($name) {
     $buckets.$name
 }
 
+function known_buckets {
+	known_bucket_repos | ForEach-Object { $_.psobject.properties | Select-Object -expand 'name' }
+}
+
 function apps_in_bucket($dir) {
     return Get-ChildItem $dir | Where-Object { $_.Name.endswith('.json') } | ForEach-Object { $_.Name -replace '.json$', '' }
 }
@@ -55,6 +59,47 @@ function find_manifest($app, $bucket) {
         $manifest = manifest $app $bucket
         if($manifest) { return $manifest, $bucket }
     }
+}
+
+function add_bucket($name, $repo) {
+    if (!$name) { "<name> missing"; $usage_add; exit 1 }
+    if (!$repo) {
+        $repo = known_bucket_repo $name
+        if (!$repo) { "Unknown bucket '$name'. Try specifying <repo>."; $usage_add; exit 1 }
+    }
+
+    $git = try { Get-Command 'git' -ea stop } catch { $null }
+    if (!$git) {
+        abort "Git is required for buckets. Run 'scoop install git'."
+    }
+
+    $dir = bucketdir $name
+    if (test-path $dir) {
+        warn "The '$name' bucket already exists. Use 'scoop bucket rm $name' to remove it."
+        exit 0
+    }
+
+    write-host 'Checking repo... ' -nonewline
+    $out = git_ls_remote $repo 2>&1
+    if ($lastexitcode -ne 0) {
+        abort "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
+    }
+    write-host 'ok'
+
+    ensure $bucketsdir > $null
+    $dir = ensure $dir
+    git_clone "$repo" "`"$dir`"" -q
+    success "The $name bucket was added successfully."
+}
+
+function rm_bucket($name) {
+    if (!$name) { "<name> missing"; $usage_rm; exit 1 }
+    $dir = bucketdir $name
+    if (!(test-path $dir)) {
+        abort "'$name' bucket not found."
+    }
+
+    Remove-Item $dir -r -force -ea stop
 }
 
 function new_issue_msg($app, $bucket, $title, $body) {

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -29,60 +29,11 @@ reset_aliases
 $usage_add = "usage: scoop bucket add <name> [<repo>]"
 $usage_rm = "usage: scoop bucket rm <name>"
 
-function add_bucket($name, $repo) {
-    if(!$name) { "<name> missing"; $usage_add; exit 1 }
-    if(!$repo) {
-        $repo = known_bucket_repo $name
-        if(!$repo) { "Unknown bucket '$name'. Try specifying <repo>."; $usage_add; exit 1 }
-    }
-
-    $git = try { Get-Command 'git' -ea stop } catch { $null }
-    if(!$git) {
-        abort "Git is required for buckets. Run 'scoop install git'."
-    }
-
-    $dir = bucketdir $name
-    if(test-path $dir) {
-        warn "The '$name' bucket already exists. Use 'scoop bucket rm $name' to remove it."
-        exit 0
-    }
-
-    write-host 'Checking repo... ' -nonewline
-    $out = git_ls_remote $repo 2>&1
-    if($lastexitcode -ne 0) {
-        abort "'$repo' doesn't look like a valid git repository`n`nError given:`n$out"
-    }
-    write-host 'ok'
-
-    ensure $bucketsdir > $null
-    $dir = ensure $dir
-    git_clone "$repo" "`"$dir`"" -q
-    success "The $name bucket was added successfully."
-}
-
-function rm_bucket($name) {
-    if(!$name) { "<name> missing"; $usage_rm; exit 1 }
-    $dir = bucketdir $name
-    if(!(test-path $dir)) {
-        abort "'$name' bucket not found."
-    }
-
-    Remove-Item $dir -r -force -ea stop
-}
-
-function list_buckets {
-    buckets
-}
-
-function known_buckets {
-    known_bucket_repos | ForEach-Object { $_.psobject.properties | Select-Object -expand 'name' }
-}
-
 switch($cmd) {
-    "add" { add_bucket $name $repo }
-    "rm" { rm_bucket $name }
-    "list" { list_buckets }
-    "known" { known_buckets }
+    'add' { add_bucket $name $repo }
+    'rm' { rm_bucket $name }
+    'list' { buckets }
+    'known' { known_buckets }
     default { "scoop bucket: cmd '$cmd' not supported"; my_usage; exit 1 }
 }
 


### PR DESCRIPTION
There is no reason to have it inside lib-exec since, it's all internal functions, which could be used inside other code

- Remove `list_buckets` function.
    - It's only function, which call `buckets`

lib-exec scripts should be slimmed as possible, as they are only code runners with some validation