### PR TITLE
[scoop-update] Checkout to branch on change

### DIFF
--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -26,3 +26,11 @@ function git_fetch {
 function git_log {
     git_proxy_cmd --no-pager log $args
 }
+
+function git_checkout {
+    git_proxy_cmd checkout $args
+}
+
+function git_branch {
+    git_proxy_cmd branch $args
+}

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -45,7 +45,7 @@ if(!$repo) {
 }
 
 $branch = $(scoop config SCOOP_BRANCH)
-if(!$branch) {
+if (!$branch) {
     $branch = "master"
     scoop config SCOOP_BRANCH "$branch"
 }
@@ -78,6 +78,14 @@ function update_scoop() {
     }
     else {
         Push-Location $currentdir
+
+        # Check if user configured other branch
+        $branch = $(get_config SCOOP_BRANCH)
+        if ((git_branch) -notlike "*$branch") {
+            git_fetch --all -q
+            git_checkout -B $branch -q
+        }
+
         git_pull -q
         $res = $lastexitcode
         if($show_update_log) {


### PR DESCRIPTION
There is not possible to 'hot' change branches. 

If you want to change branch now, you need to delete `.git` folder inside `$env:SCOOP_HOME` to proc clonning of new branch

https://github.com/lukesampson/scoop/blob/4197fa98a5b2b513c627734e3b4aef3df5827e3b/libexec/scoop-update.ps1#L64-L68

Actual behaviour, which is desired I think:

1. `scoop config SCOOP_BRANCH somebranch`
1. `scoop update`  This will checkout to branch and download changes