### PR TITLE
refactor: tweak SecurityProtocol usage

### DIFF
--- a/bin/checkurls.ps1
+++ b/bin/checkurls.ps1
@@ -38,8 +38,6 @@ Get-ChildItem $Dir "$App.json" | ForEach-Object {
     $Queue += , @($_.Name, $manifest)
 }
 
-$original = use_any_https_protocol
-
 Write-Host '[' -NoNewLine
 Write-Host 'U' -NoNewLine -ForegroundColor Cyan
 Write-Host ']RLs'
@@ -130,5 +128,3 @@ foreach ($man in $Queue) {
         Write-Host "       > $_" -ForegroundColor DarkRed
     }
 }
-
-set_https_protocols $original

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -89,8 +89,6 @@ Get-Event | ForEach-Object {
     Remove-Event $_.SourceIdentifier
 }
 
-$original = use_any_https_protocol
-
 # start all downloads
 $Queue | ForEach-Object {
     $name, $json = $_
@@ -287,5 +285,3 @@ while ($in_progress -gt 0) {
         }
     }
 }
-
-set_https_protocols $original

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -20,12 +20,24 @@ $cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | Select-Object -first 1
 
 # Note: Github disabled TLS 1.0 support on 2018-02-23. Need to enable TLS 1.2
 # for all communication with api.github.com
-function enable-encryptionscheme([Net.SecurityProtocolType]$scheme) {
-    # Net.SecurityProtocolType is a [Flags] enum, binary-OR sets
-    # the specified scheme in addition to whatever scheme is already active
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor $scheme
+function Optimize-SecurityProtocol {
+    # .NET Framework 4.7+ has a default security protocol called 'SystemDefault',
+    # which allows the operating system to choose the best protocol to use.
+    # If not contains 'SystemDefault', set highest encryption for SecurityProtocol.
+    if ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'SystemDefault') {
+        # Set TLS 1.2 (3072), then TLS 1.1 (768), finially TLS 1.0 (192). Ssl3 has been superseded
+        # https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netframework-4.5
+        [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192
+    } else {
+        # else if SecurityProtocol has been changed, reset it to SystemDefault
+        if (!([System.Net.ServicePointManager]::SecurityProtocol.Equals(`
+            [System.Net.SecurityProtocolType]::SystemDefault))) {
+            # Set to SystemDefault (0)
+            [System.Net.ServicePointManager]::SecurityProtocol = 0
+        }
+    }
 }
-enable-encryptionscheme "Tls12"
+Optimize-SecurityProtocol
 
 function Get-UserAgent() {
     return "Scoop/1.0 (+http://scoop.sh/) PowerShell/$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor) (Windows NT $([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor); $(if($env:PROCESSOR_ARCHITECTURE -eq 'AMD64'){'Win64; x64; '})$(if($env:PROCESSOR_ARCHITEW6432 -eq 'AMD64'){'WOW64; '})$PSEdition)"

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -25,15 +25,16 @@ function Optimize-SecurityProtocol {
     # which allows the operating system to choose the best protocol to use.
     # If not contains 'SystemDefault', set highest encryption for SecurityProtocol.
     if ([System.Enum]::GetNames([System.Net.SecurityProtocolType]) -notcontains 'SystemDefault') {
-        # Set TLS 1.2 (3072), then TLS 1.1 (768), finially TLS 1.0 (192). Ssl3 has been superseded
+        # Set to TLS 1.2 (3072), then TLS 1.1 (768), finally TLS 1.0 (192). Ssl3 has been superseded
         # https://docs.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=netframework-4.5
         [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192
     } else {
         # else if SecurityProtocol has been changed, reset it to SystemDefault
         if (!([System.Net.ServicePointManager]::SecurityProtocol.Equals(`
             [System.Net.SecurityProtocolType]::SystemDefault))) {
-            # Set to SystemDefault (0)
-            [System.Net.ServicePointManager]::SecurityProtocol = 0
+            # Set to SystemDefault (0) first. TLS 1.2 (3072), TLS 1.1 (768) and TLS 1.0 (192)
+            # follow up to prevent "The underlying connection was closed" problem.
+            [System.Net.ServicePointManager]::SecurityProtocol = 0 -bor 3072 -bor 768 -bor 192
         }
     }
 }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -113,26 +113,7 @@ function dl_with_cache($app, $version, $url, $to, $cookies = $null, $use_cache =
     }
 }
 
-function use_any_https_protocol() {
-    $original = "$([System.Net.ServicePointManager]::SecurityProtocol)"
-    $available = [string]::join(', ', [Enum]::GetNames([System.Net.SecurityProtocolType]))
-
-    # use whatever protocols are available that the server supports
-    set_https_protocols $available
-
-    return $original
-}
-
-function set_https_protocols($protocols) {
-    try {
-        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType] $protocols
-    } catch {
-        [System.Net.ServicePointManager]::SecurityProtocol = "Tls,Tls11,Tls12"
-    }
-}
-
 function do_dl($url, $to, $cookies) {
-    $original_protocols = use_any_https_protocol
     $progress = [console]::isoutputredirected -eq $false -and
         $host.name -ne 'Windows PowerShell ISE Host'
 
@@ -143,8 +124,6 @@ function do_dl($url, $to, $cookies) {
         $e = $_.exception
         if($e.innerexception) { $e = $e.innerexception }
         throw $e
-    } finally {
-        set_https_protocols $original_protocols
     }
 }
 


### PR DESCRIPTION
reopen #3051 
Now the code logic: if `SecurityProtocol` is `SystemDefault`, don't change, else change it to `Tls1.2,Tls1.1,Tls1.0`,  never support `Ssl3` anymore.