### PR TITLE
[Autoupdate] Substitute $hash variables for easier maintaining

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -1,13 +1,10 @@
 <#
 TODO
- - add a github release autoupdate type
  - tests (single arch, without hashes etc.)
  - clean up
 #>
-. "$psscriptroot\..\lib\json.ps1"
-
-. "$psscriptroot/core.ps1"
-. "$psscriptroot/json.ps1"
+. "$PSScriptRoot\core.ps1"
+. "$PSScriptRoot\json.ps1"
 
 function find_hash_in_rdf([String] $url, [String] $basename) {
     $data = $null
@@ -146,6 +143,12 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
     $substitutions.Add('$url', (strip_fragment $url))
     $substitutions.Add('$baseurl', (strip_filename (strip_fragment $url)).TrimEnd('/'))
     $substitutions.Add('$basename', $basename)
+
+    $substitutions.Add('$hashMD5', $hashMD5)
+    $substitutions.Add('$hashSHA1', $hashSHA1)
+    $substitutions.Add('$hashSHA256', $hashSHA256)
+    $substitutions.Add('$hashSHA512', $hashSHA512)
+    $substitutions.Add('$hashBASE64', $hashBASE64)
 
     $hashfile_url = substitute $config.url $substitutions
     if ($hashfile_url) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -18,6 +18,12 @@ $globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | Select-Object -first 
 #       Use at your own risk.
 $cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | Select-Object -first 1
 
+$hashMD5 = '[A-Fa-f\d]{32}'
+$hashsha1 = '[A-Fa-f\d]{40}'
+$hashsha256 = '[A-Fa-f\d]{64}'
+$hashsha512 = '[A-Fa-f\d]{128}'
+$hashBASE64 = '(?:[A-Za-z\d+\/]{4})*(?:[A-Za-z\d+\/]{2}==|[A-Za-z\d+\/]{3}=|[A-Za-z\d+\/]{4})'
+
 # Note: Github disabled TLS 1.0 support on 2018-02-23. Need to enable TLS 1.2
 # for all communication with api.github.com
 function Optimize-SecurityProtocol {
@@ -637,7 +643,12 @@ function substitute($entity, [Hashtable] $params, [Bool]$regexEscape = $false) {
             if($regexEscape -eq $false -or $null -eq $_.Value) {
                 $entity = $entity.Replace($_.Name, $_.Value)
             } else {
-                $entity = $entity.Replace($_.Name, [Regex]::Escape($_.Value))
+                $rep = [Regex]::Escape($_.Value)
+                # If regex contains $hash variables, value cannot be escaped
+                if ($_.Name.StartsWith('$hash')) {
+                    $rep = $_.Value
+                }
+                $entity = $entity.Replace($_.Name, $rep)
             }
         }
         return $entity


### PR DESCRIPTION
There is no need to always write regex for each hash type, when they could be automatically substituted.

Now it's possible to use something like:

```json
"autoupdate": {
    "hash": "MD5:\\s*($hashMD5)",
    "hash": "SHA1:\\s*($hashSHA1)",
    "hash": "SHA256:\\s*($hashSHA256)",
    "hash": "SHA512:\\s*($hashSHA512)",
    "hash": "base64encodedHash:\\s*($hashBASE64)"
}
```

Best example i found are base64 hashes, because it's regex is pretty overkill. Rambox pro for example:

```json
{
    "autoupdate": {
        "url": "https://github.com/ramboxapp/download/releases/download/v$version/RamboxPro-$version-win.exe#/cosi.7z",
        "hash": {
            "url": "https://github.com/ramboxapp/download/releases/download/v$version/latest.yml",
            "find": "sha512:\\s+($hashBASE64)"
        }
    }
}
```

![Proof](https://i.imgur.com/nHJIfvl.png)