### PR TITLE
Remove missing files

### DIFF
--- a/bucket/nim.json
+++ b/bucket/nim.json
@@ -19,8 +19,6 @@
         "Copy-Item -Recurse \"$dir\\dist\\nimble\\src\\nimblepkg\" \"$dir\\bin\""
     ],
     "bin": [
-        "bin\\c2nim.exe",
-        "bin\\makelink.exe",
         "bin\\nim.exe",
         "bin\\nimble.exe",
         "bin\\nimgrab.exe",


### PR DESCRIPTION
Installation fails on missing files c2nim and makelink.  Installation completes with these two lines removed.