### PR TITLE
Fix sccache

### DIFF
--- a/bucket/sccache.json
+++ b/bucket/sccache.json
@@ -5,9 +5,11 @@
     "license": "Apache-2.0",
     "url": "https://github.com/mozilla/sccache/releases/download/0.2.8/sccache-0.2.8-x86_64-pc-windows-msvc.tar.gz",
     "hash": "b11e56854efc61960bef2b926b8ed4da72625bd64be7eb2e29e9a1df02e69b2f",
+    "extract_dir": "sccache-0.2.8-x86_64-pc-windows-msvc",
     "bin": "sccache.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mozilla/sccache/releases/download/$version/sccache-$version-x86_64-pc-windows-msvc.tar.gz"
+        "url": "https://github.com/mozilla/sccache/releases/download/$version/sccache-$version-x86_64-pc-windows-msvc.tar.gz",
+        "extract_dir": "sccache-$version-x86_64-pc-windows-msvc"
     }
 }


### PR DESCRIPTION
* The tarball has an internal directory named the same as itself
* Add extract_dir to autoupdate for future versions