### PR TITLE
Migrating core environment variable to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,12 @@ These settings can be changed through environment variables.
 
 #### Install Scoop to a Custom Directory
 ```powershell
-[environment]::setEnvironmentVariable('SCOOP','D:\Applications\Scoop','User')
 $env:SCOOP='D:\Applications\Scoop'
 iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
 ```
 
 #### Configure Scoop to install global programs to a Custom Directory
 ```powershell
-[environment]::setEnvironmentVariable('SCOOP_GLOBAL','F:\GlobalScoopApps','Machine')
 $env:SCOOP_GLOBAL='F:\GlobalScoopApps'
 ```
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -30,6 +30,7 @@ $globaldir = (get_config 'globalPath' $null), "$env:ProgramData\scoop" | Select-
 #       is experimental and untested. There may be concurrency issues when
 #       multiple users write and access cached files at the same time.
 #       Use at your own risk.
+
 # Note: migrating $env:SCOOP_CACHE to `.scoop` config
 if (!(get_config 'cachePath' $null) -and $env:SCOOP_CACHE) {
     scoop config 'cachePath' $env:SCOOP_CACHE

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -3,20 +3,39 @@
 #       Old installations should continue to work using the old path.
 #       There is currently no automatic migration path to deal
 #       with updating old installations to the new path.
-$scoopdir = $env:SCOOP, "$env:USERPROFILE\scoop" | Select-Object -first 1
+
+# Note: migrating $env:SCOOP to `.scoop` config
+if (!(get_config 'rootPath' $null) -and $env:SCOOP) {
+    scoop config 'rootPath' $env:SCOOP
+    [Environment]::SetEnvironmentVariable("SCOOP", $null, "User")
+    Write-Output "Notice: `$env:SCOOP has been migrated to 'rootPath' variable in '~/.scoop'."
+}
+
+$scoopdir = (get_config 'rootPath' $null), "$env:USERPROFILE\scoop" | Select-Object -first 1
 
 $oldscoopdir = "$env:LOCALAPPDATA\scoop"
 if((test-path $oldscoopdir) -and !$env:SCOOP) {
     $scoopdir = $oldscoopdir
 }
 
-$globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | Select-Object -first 1
+# Note: migrating $env:SCOOP_GLOBAL to `.scoop` config
+if (!(get_config 'globalPath' $null) -and $env:SCOOP_GLOBAL) {
+    scoop config 'globalPath' $env:SCOOP_GLOBAL
+    Write-Output "Notice: `$env:SCOOP_GLOBAL has been migrated to 'globalPath' variable in '~/.scoop', you can now unset `$env:SCOOP_GLOBAL."
+}
+
+$globaldir = (get_config 'globalPath' $null), "$env:ProgramData\scoop" | Select-Object -first 1
 
 # Note: Setting the SCOOP_CACHE environment variable to use a shared directory
 #       is experimental and untested. There may be concurrency issues when
 #       multiple users write and access cached files at the same time.
 #       Use at your own risk.
-$cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | Select-Object -first 1
+# Note: migrating $env:SCOOP_CACHE to `.scoop` config
+if (!(get_config 'cachePath' $null) -and $env:SCOOP_CACHE) {
+    scoop config 'cachePath' $env:SCOOP_CACHE
+    Write-Output "Notice: `$env:SCOOP_CACHE has been migrated to 'cachePath' variable in '~/.scoop', you can now unset `$env:SCOOP_CACHE."
+}
+$cachedir = (get_config 'cachePath' $null), "$scoopdir\cache" | Select-Object -first 1
 
 # Note: Github disabled TLS 1.0 support on 2018-02-23. Need to enable TLS 1.2
 # for all communication with api.github.com

--- a/lib/unix.ps1
+++ b/lib/unix.ps1
@@ -10,9 +10,9 @@ if(!(is_unix)) {
 }
 
 # core.ps1
-$scoopdir = $env:SCOOP, (Join-Path $env:HOME "scoop") | Select-Object -first 1
-$globaldir = $env:SCOOP_GLOBAL, "/usr/local/scoop" | Select-Object -first 1
-$cachedir = $env:SCOOP_CACHE, (Join-Path $scoopdir "cache") | Select-Object -first 1
+$scoopdir = (get_config 'rootPath' $null), (Join-Path $env:HOME "scoop") | Select-Object -first 1
+$globaldir = (get_config 'globalPath' $null), "/usr/local/scoop" | Select-Object -first 1
+$cachedir = (get_config 'cachePath' $null), (Join-Path $scoopdir "cache") | Select-Object -first 1
 
 # core.ps1
 function ensure($dir) {

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -13,13 +13,13 @@ $issues += !(check_windows_defender $true)
 
 $globaldir = New-Object System.IO.DriveInfo($globaldir)
 if($globaldir.DriveFormat -ne 'NTFS') {
-    error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP_GLOBAL variable to another Drive."
+    error "Scoop requires an NTFS volume to work! Please point 'globalPath' variable in '~/.scoop' to another Drive."
     $issues++
 }
 
 $scoopdir = New-Object System.IO.DriveInfo($scoopdir)
 if($scoopdir.DriveFormat -ne 'NTFS') {
-    error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP variable to another Drive."
+    error "Scoop requires an NTFS volume to work! Please point 'rootPath' variable in '~/.scoop' to another Drive."
     $issues++
 }
 


### PR DESCRIPTION
this requires #3115 to be merged first.

This will avoid polluting environment variables, and prepare for the new scoop installer (see https://github.com/scoopinstaller/install/issues/2)