### PR TITLE
feat(core): support loading basedirs from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ These settings can be changed through environment variables.
 ### Install Scoop to a Custom Directory
 
 ```powershell
-[environment]::setEnvironmentVariable('SCOOP','D:\Applications\Scoop','User')
 $env:SCOOP='D:\Applications\Scoop'
+[Environment]::SetEnvironmentVariable('SCOOP', $env:SCOOP, 'User')
 iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
 ```
 
 ### Configure Scoop to install global programs to a Custom Directory
 
 ```powershell
-[environment]::setEnvironmentVariable('SCOOP_GLOBAL','F:\GlobalScoopApps','Machine')
 $env:SCOOP_GLOBAL='F:\GlobalScoopApps'
+[Environment]::SetEnvironmentVariable('SCOOP_GLOBAL', $env:SCOOP_GLOBAL, 'Machine')
 ```
 
 ## [Documentation](https://github.com/lukesampson/scoop/wiki)

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -838,18 +838,7 @@ function get_magic_bytes_pretty($file, $glue = ' ') {
 #       for all communication with api.github.com
 Optimize-SecurityProtocol
 
-# Note: The default directory changed from ~/AppData/Local/scoop to ~/scoop
-#       on 1 Nov, 2016 to work around long paths used by NodeJS.
-#       Old installations should continue to work using the old path.
-#       There is currently no automatic migration path to deal
-#       with updating old installations to the new path.
 $scoopdir = $env:SCOOP, (get_config 'rootPath'), "$env:USERPROFILE\scoop" | Select-Object -first 1
-
-$oldscoopdir = "$env:LOCALAPPDATA\scoop"
-if((test-path $oldscoopdir) -and !$env:SCOOP) {
-    $scoopdir = $oldscoopdir
-}
-
 $globaldir = $env:SCOOP_GLOBAL, (get_config 'globalPath'), "$env:ProgramData\scoop" | Select-Object -first 1
 
 # Note: Setting the SCOOP_CACHE environment variable to use a shared directory

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -3,20 +3,20 @@
 #       Old installations should continue to work using the old path.
 #       There is currently no automatic migration path to deal
 #       with updating old installations to the new path.
-$scoopdir = $env:SCOOP, "$env:USERPROFILE\scoop" | Select-Object -first 1
+$scoopdir = $env:SCOOP, (get_config 'rootPath'), "$env:USERPROFILE\scoop" | Select-Object -first 1
 
 $oldscoopdir = "$env:LOCALAPPDATA\scoop"
 if((test-path $oldscoopdir) -and !$env:SCOOP) {
     $scoopdir = $oldscoopdir
 }
 
-$globaldir = $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | Select-Object -first 1
+$globaldir = $env:SCOOP_GLOBAL, (get_config 'globalPath'), "$env:ProgramData\scoop" | Select-Object -first 1
 
 # Note: Setting the SCOOP_CACHE environment variable to use a shared directory
 #       is experimental and untested. There may be concurrency issues when
 #       multiple users write and access cached files at the same time.
 #       Use at your own risk.
-$cachedir = $env:SCOOP_CACHE, "$scoopdir\cache" | Select-Object -first 1
+$cachedir = $env:SCOOP_CACHE, (get_config 'cachePath'), "$scoopdir\cache" | Select-Object -first 1
 
 $configHome = $env:XDG_CONFIG_HOME, "$env:USERPROFILE\.config" | Select-Object -First 1
 $configFile = "$configHome\scoop\config.json"

--- a/lib/unix.ps1
+++ b/lib/unix.ps1
@@ -10,9 +10,9 @@ if(!(is_unix)) {
 }
 
 # core.ps1
-$scoopdir = $env:SCOOP, (Join-Path $env:HOME "scoop") | Select-Object -first 1
-$globaldir = $env:SCOOP_GLOBAL, "/usr/local/scoop" | Select-Object -first 1
-$cachedir = $env:SCOOP_CACHE, (Join-Path $scoopdir "cache") | Select-Object -first 1
+$scoopdir = $env:SCOOP, (get_config 'rootPath'), (Join-Path $env:HOME "scoop") | Select-Object -first 1
+$globaldir = $env:SCOOP_GLOBAL, (get_config 'globalPath'), "/usr/local/scoop" | Select-Object -first 1
+$cachedir = $env:SCOOP_CACHE, (get_config 'cachePath'), (Join-Path $scoopdir "cache") | Select-Object -first 1
 
 # core.ps1
 function ensure($dir) {

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -15,13 +15,13 @@ $issues += !(check_long_paths)
 
 $globaldir = New-Object System.IO.DriveInfo($globaldir)
 if($globaldir.DriveFormat -ne 'NTFS') {
-    error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP_GLOBAL variable to another Drive."
+    error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP_GLOBAL or 'globalPath' variable in '~/.config/scoop/config.json' to another Drive."
     $issues++
 }
 
 $scoopdir = New-Object System.IO.DriveInfo($scoopdir)
 if($scoopdir.DriveFormat -ne 'NTFS') {
-    error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP variable to another Drive."
+    error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP or 'rootPath' variable in '~/.config/scoop/config.json' to another Drive."
     $issues++
 }
 


### PR DESCRIPTION
- [x] BLOCKED BY #3242 (MERGED)

Reopen #3116 . ~~This is a breaking change.~~

- ~~revert #3115 , import `config.ps1` in `core.ps1` instead~~
- add support loading env from `~/.config/scoop/config.json` config file, preparing for the new scoop installer (see [scoopinstaller/install#2](https://github.com/scoopinstaller/install/issues/2) and [scoopinstaller/install#4](https://github.com/ScoopInstaller/Install/pull/4))
- drop `$oldscoopdir = "$env:LOCALAPPDATA\scoop"` support, I think nobody use old scoop dir now, it has been 3 years.
