### PR TITLE
Fix dual license error in "scoop info"

### DIFF
--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -69,6 +69,9 @@ if ($manifest.license) {
         $license = "$($manifest.license.identifier) ($($manifest.license.url))"
     } elseif ($manifest.license -match '^((ht)|f)tps?://') {
         $license = "$($manifest.license)"
+    } elseif ($manifest.license -match '[|,]') {
+        $licurl = $manifest.license.Split("|,") | ForEach-Object {"https://spdx.org/licenses/$_.html"}
+        $license = "$($manifest.license) ($($licurl -join ', '))"
     } else {
         $license = "$($manifest.license) (https://spdx.org/licenses/$($manifest.license).html)"
     }


### PR DESCRIPTION
For dual licenses in manifest, e.g. "MIT|GPL", `scoop info` will return wrong URL (`https://spdx.org/licenses/MIT|GPL.html`).

This PR fixes it (return `https://spdx.org/licenses/MIT.html, https://spdx.org/licenses/GPL.html`)