### PR TITLE
Fix fosshub.com url handler and add fosshub hash mode

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -188,6 +188,11 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         $regex = $config.regex
     }
 
+    if (!$hashfile_url -and $url -match "^(?:.*fosshub.com\/).*(?:\/|\?dwl=)(?<filename>.*)$") {
+        $hashmode = 'fosshub'
+        $hash = find_hash_in_textfile $url $substitutions ($Matches.filename+'.*?"sha256":"([a-fA-F0-9]{64})"')
+    }
+
     if (!$hashfile_url -and $url -match "(?:downloads\.)?sourceforge.net\/projects?\/(?<project>[^\/]+)\/(?:files\/)?(?<file>.*)") {
         $hashmode = 'sourceforge'
         # change the URL because downloads.sourceforge.net doesn't have checksums


### PR DESCRIPTION
- Fix broken fosshub.com url handle function. It can handle urls like `https://www.fosshub.com/Calibre.html/calibre-64bit-3.39.1.msi` or `https://www.fosshub.com/Audacity.html?dwl=audacity-win-2.3.0.zip` and get the right download link.
- Add `fosshub` hash extraction mode.