### PR TITLE
Allow uninstall of apps with underscore

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -610,7 +610,7 @@ function applist($apps, $global) {
 }
 
 function parse_app([string] $app) {
-    if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>.*.json$|[a-zA-Z0-9-.]+)(?:@(?<version>.*))?') {
+    if($app -match '(?:(?<bucket>[a-zA-Z0-9-]+)\/)?(?<app>.*.json$|[a-zA-Z0-9-_.]+)(?:@(?<version>.*))?') {
         return $matches['app'], $matches['bucket'], $matches['version']
     }
     return $app, $null, $null


### PR DESCRIPTION
Currently it is not possible to uninstall apps that have a `_` in their name. E.g. `uninstall scoop_ruby` uninstalls `scoop`.

Based on https://github.com/lukesampson/scoop/issues/3128#issuecomment-463662715

closes #3128