### PR TITLE
scoop-list: Identify failed installation

### DIFF
--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -26,14 +26,17 @@ if($apps) {
         $install_info = install_info $app $ver $global
         write-host "  $app " -NoNewline
         write-host -f DarkCyan $ver -NoNewline
-        if($global) {
-            write-host -f DarkRed ' *global*' -NoNewline
-        }
+
+        if($global) { write-host -f DarkGreen ' *global*' -NoNewline }
+
+        if (!$install_info) { Write-Host ' *failed*' -ForegroundColor DarkRed -NoNewline }
+
         if ($install_info.bucket) {
             write-host -f Yellow " [$($install_info.bucket)]" -NoNewline
         } elseif ($install_info.url) {
             write-host -f Yellow " [$($install_info.url)]" -NoNewline
         }
+
         if ($install_info.architecture -and $def_arch -ne $install_info.architecture) {
             write-host -f DarkRed " {$($install_info.architecture)}" -NoNewline
         }


### PR DESCRIPTION
This is minor fix for #3089, lukesampson/scoop-extras#1720 to confort users, until install is refactored.

Global indication color was changed to DarkGreen. I don't know, if there was some reason to make it DarkRed in first place? This make more sense to me, but feel free to suggest better name / color. I followed `status` naming with failed.

![F](https://i.imgur.com/mgH8R6w.png)

![Fa](https://i.imgur.com/Ih8hR3e.png)

- Closes #3089
- Closes lukesampson/scoop-extras#1720