### PR TITLE
[Workaround] Download and verify before update

### DIFF
--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -156,17 +156,16 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     # region Workaround
     # Workaround for https://github.com/lukesampson/scoop/issues/2220 until install is refactored
     # Remove and replace whole region after proper fix
-    if ($check_hash) {
-        Write-Host "Downloading new version to verify integrity of files"
-        if (aria2_enabled) {
-            dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookies $true $check_hash
-        } else {
-            # dl_with_cache $app $version $
-            $urls = url $manifest $architecture
+    Write-Host "Downloading new version"
+    if (aria2_enabled) {
+        dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookies $true $check_hash
+    } else {
+        $urls = url $manifest $architecture
 
-            foreach ($url in $urls) {
-                dl_with_cache $app $version $url $null $manifest.cookies $true
+        foreach ($url in $urls) {
+            dl_with_cache $app $version $url $null $manifest.cookies $true
 
+            if ($check_hash) {
                 $manifest_hash = hash_for_url $manifest $url $architecture
                 $source = fullpath (cache_path $app $version $url)
                 $ok, $err = check_hash $source $manifest_hash $(show_app $app $bucket)
@@ -184,10 +183,10 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
                 }
             }
         }
-        # There is no need to check hash again
-        $check_hash = $false
-        Write-Host "Verifing OK. Updating continue" -ForegroundColor Green
     }
+    # There is no need to check hash again while installing
+    $check_hash = $false
+    Write-Host "Verifing OK. Updating continue" -ForegroundColor Green
     # endregion Workaround
 
     $dir = versiondir $app $old_version $global

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -186,7 +186,6 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     }
     # There is no need to check hash again while installing
     $check_hash = $false
-    Write-Host "Verifing OK. Updating continue" -ForegroundColor Green
     # endregion Workaround
 
     $dir = versiondir $app $old_version $global

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -155,37 +155,39 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
 
     # region Workaround
     # Workaround for https://github.com/lukesampson/scoop/issues/2220 until install is refactored
-    # Remove whole region after proper fix
-    Write-Host "Downloading new version to verify integrity of files"
-    if (aria2_enabled) {
-        dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookies $true $check_hash
-    } else {
-        # dl_with_cache $app $version $
-        $urls = url $manifest $architecture
+    # Remove and replace whole region after proper fix
+    if ($check_hash) {
+        Write-Host "Downloading new version to verify integrity of files"
+        if (aria2_enabled) {
+            dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookies $true $check_hash
+        } else {
+            # dl_with_cache $app $version $
+            $urls = url $manifest $architecture
 
-        foreach ($url in $urls) {
-            dl_with_cache $app $version $url $null $manifest.cookies $true
+            foreach ($url in $urls) {
+                dl_with_cache $app $version $url $null $manifest.cookies $true
 
-            $manifest_hash = hash_for_url $manifest $url $architecture
-            $source = fullpath (cache_path $app $version $url)
-            $ok, $err = check_hash $source $manifest_hash $(show_app $app $bucket)
+                $manifest_hash = hash_for_url $manifest $url $architecture
+                $source = fullpath (cache_path $app $version $url)
+                $ok, $err = check_hash $source $manifest_hash $(show_app $app $bucket)
 
-            if(!$ok) {
-                error $err
-                if(test-path $source) {
-                    # rm cached file
-                    Remove-Item -force $source
+                if (!$ok) {
+                    error $err
+                    if (test-path $source) {
+                        # rm cached file
+                        Remove-Item -force $source
+                    }
+                    if ($url.Contains('sourceforge.net')) {
+                        Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
+                    }
+                    abort $(new_issue_msg $app $bucket "hash check failed")
                 }
-                if($url.Contains('sourceforge.net')) {
-                    Write-Host -f yellow 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
-                }
-                abort $(new_issue_msg $app $bucket "hash check failed")
             }
         }
+        # There is no need to check hash again
+        $check_hash = $false
+        Write-Host "Verifing OK. Updating continue" -ForegroundColor Green
     }
-    # There is no need to check hash again
-    $check_hash = $false
-    Write-Host "Verifing OK. Updating continue" -ForegroundColor Green
     # endregion Workaround
 
     $dir = versiondir $app $old_version $global


### PR DESCRIPTION
This is temporary solution for #2220 until whole install.ps1 refactor is done to make this tweak easily, in the best way one-liner. ~~Today i will follow with issue how this refactor should looks like, because there is some inconsistency and could be much more easier to maintain.~~ #3149 

- Closes #2220
- Closes #2343
- Closes #1605 

## Aria2

![ARia OK](https://i.imgur.com/sOmFE5p.png)

![Aria Fail](https://i.imgur.com/wJXlAXh.png)

## Normal

![OK](https://i.imgur.com/rbrUbUv.png)

![Fail](https://i.imgur.com/wClzbXB.png)

Co-authored-by: Chawye Hsu <h404bi@outlook.com>