### PR TITLE
innounp: Add autoupdate and bump to 0.48

### DIFF
--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,10 +1,10 @@
 {
-    "version": "0.47",
+    "version": "0.48",
     "description": "Inno Setup Unpacker.",
     "homepage": "http://innounp.sourceforge.net",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/scoopinstaller/binary-mirror/raw/master/innounp/innounp047.rar",
-    "hash": "sha1:ba0cebf7e3003847d5ed5811620c54d7576146e7",
+    "url": "https://raw.githubusercontent.com/scoopinstaller/binary-mirror/master/innounp/innounp048.rar",
+    "hash": "59e80a6f46b2de48d5cd929479adf0784a2a2580cd6ea67ea2a9560eb8082ba4",
     "bin": "innounp.exe",
     "checkver": "Version\\s+([\\d\\.]+)\\s*<br>",
     "autoupdate": {

--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -1,8 +1,16 @@
 {
-    "homepage": "http://innounp.sourceforge.net",
     "version": "0.47",
+    "description": "Inno Setup Unpacker.",
+    "homepage": "http://innounp.sourceforge.net",
+    "license": "GPL-3.0-only",
     "url": "https://github.com/scoopinstaller/binary-mirror/raw/master/innounp/innounp047.rar",
     "hash": "sha1:ba0cebf7e3003847d5ed5811620c54d7576146e7",
     "bin": "innounp.exe",
-    "checkver": "Version\\s+([\\d.]+)\\s*<br>"
+    "checkver": "Version\\s+([\\d\\.]+)\\s*<br>",
+    "autoupdate": {
+        "url": "https://github.com/scoopinstaller/binary-mirror/raw/master/innounp/innounp$cleanVersion.rar",
+        "hash": {
+            "url": "$baseurl/innounp$cleanVersion.sha1"
+        }
+    }
 }

--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -8,7 +8,7 @@
     "bin": "innounp.exe",
     "checkver": "Version\\s+([\\d\\.]+)\\s*<br>",
     "autoupdate": {
-        "url": "https://github.com/scoopinstaller/binary-mirror/raw/master/innounp/innounp$cleanVersion.rar",
+        "url": "https://raw.githubusercontent.com/scoopinstaller/binary-mirror/master/innounp/innounp$cleanVersion.rar",
         "hash": {
             "url": "$baseurl/innounp$cleanVersion.sha1"
         }

--- a/bucket/innounp.json
+++ b/bucket/innounp.json
@@ -4,7 +4,7 @@
     "homepage": "http://innounp.sourceforge.net",
     "license": "GPL-3.0-only",
     "url": "https://raw.githubusercontent.com/scoopinstaller/binary-mirror/master/innounp/innounp048.rar",
-    "hash": "59e80a6f46b2de48d5cd929479adf0784a2a2580cd6ea67ea2a9560eb8082ba4",
+    "hash": "sha1:638a8ff3b87c40d12b43ca964e6777baca2176c8",
     "bin": "innounp.exe",
     "checkver": "Version\\s+([\\d\\.]+)\\s*<br>",
     "autoupdate": {


### PR DESCRIPTION
Commit with update will come after scoopinstaller/binary-mirror#2 is merged

- Closes #3047 
- Closes #3069