### PR TITLE
Update install.ps1

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -12,7 +12,7 @@ if(($PSVersionTable.PSVersion.Major) -lt 3) {
 }
 
 # show notification to change execution policy:
-if((Get-ExecutionPolicy) -eq 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
+if((Get-ExecutionPolicy) -ge 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
     Write-Output "PowerShell requires an execution policy of 'RemoteSigned' to run Scoop."
     Write-Output "To make this change please run:"
     Write-Output "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -12,7 +12,7 @@ if(($PSVersionTable.PSVersion.Major) -lt 3) {
 }
 
 # show notification to change execution policy:
-if((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
+if((Get-ExecutionPolicy) -eq 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
     Write-Output "PowerShell requires an execution policy of 'RemoteSigned' to run Scoop."
     Write-Output "To make this change please run:"
     Write-Output "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"


### PR DESCRIPTION
```pwsh
(Get-ExecutionPolicy) -gt 'RemoteSigned'
```

Will always evaluate to false no matter what the policy is set to. It should be set to:

```pwsh
(Get-ExecutionPolicy) -eq 'RemoteSigned'
```