### PR TITLE
Update name of the buffalo binary for 0.14.0

### DIFF
--- a/bucket/buffalo.json
+++ b/bucket/buffalo.json
@@ -7,7 +7,7 @@
     "hash": "19606a46becc689105bff7939099c32a044fa93eceecc4f11bfc300751e591bc",
     "bin": [
         [
-            "buffalo-no-sqlite.exe",
+            "buffalo.exe",
             "buffalo"
         ]
     ],


### PR DESCRIPTION
They changed the name back to `buffalo.exe`. I'm not super familiar with scoop (just started using it yesterday). But making this change on my `C:\Users\$User\scoop\apps\scoop\current\bucket\buffalo.json` seems to have gotten in installed, so I hope this is the right way to do it.

- Update Commit Here:  https://github.com/lukesampson/scoop/commit/b342ddd305455844d91de0d985817bb4b7d8f2de
- Rename Here: https://github.com/gobuffalo/buffalo/commit/7335d7019683031067128937a8493e130e59f89c