### PR TITLE
[Schema] Add metalink mode to hashmode

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -190,14 +190,10 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
 
     if (!$hashfile_url -and $url -match "^(?:.*fosshub.com\/).*(?:\/|\?dwl=)(?<filename>.*)$") {
         $hashmode = 'fosshub'
-        $hash = find_hash_in_textfile $url $substitutions ($Matches.filename+'.*?"sha256":"([a-fA-F0-9]{64})"')
     }
 
     if (!$hashfile_url -and $url -match "(?:downloads\.)?sourceforge.net\/projects?\/(?<project>[^\/]+)\/(?:files\/)?(?<file>.*)") {
         $hashmode = 'sourceforge'
-        # change the URL because downloads.sourceforge.net doesn't have checksums
-        $hashfile_url = (strip_filename (strip_fragment "https://sourceforge.net/projects/$($matches['project'])/files/$($matches['file'])")).TrimEnd('/')
-        $hash = find_hash_in_textfile $hashfile_url $substitutions '"$basename":.*?"sha1":\s"([a-fA-F0-9]{40})"'
     }
 
     switch ($hashmode) {
@@ -215,6 +211,14 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
             if (!$hash) {
                 $hash = find_hash_in_textfile "$url.meta4" $substitutions
             }
+        }
+        'fosshub' {
+            $hash = find_hash_in_textfile $url $substitutions ($Matches.filename+'.*?"sha256":"([a-fA-F0-9]{64})"')
+        }
+        'sourceforge' {
+            # change the URL because downloads.sourceforge.net doesn't have checksums
+            $hashfile_url = (strip_filename (strip_fragment "https://sourceforge.net/projects/$($matches['project'])/files/$($matches['file'])")).TrimEnd('/')
+            $hash = find_hash_in_textfile $hashfile_url $substitutions '"$basename":.*?"sha1":\s"([a-fA-F0-9]{40})"'
         }
     }
 

--- a/schema.json
+++ b/schema.json
@@ -48,7 +48,8 @@
                         "download",
                         "extract",
                         "json",
-                        "rdf"
+                        "rdf",
+                        "metalink"
                     ]
                 },
                 "type": {

--- a/schema.json
+++ b/schema.json
@@ -49,7 +49,9 @@
                         "extract",
                         "json",
                         "rdf",
-                        "metalink"
+                        "metalink",
+                        "fosshub",
+                        "sourceforge"
                     ]
                 },
                 "type": {


### PR DESCRIPTION
Schema is missing property for metalink

See: https://github.com/lukesampson/scoop/blob/57b0b0e1eb2c946ca74541b2464d3e61e195e979/lib/autoupdate.ps1#L213-L218

![Meld example](https://user-images.githubusercontent.com/13260377/53340452-5bd9cc80-3909-11e9-823c-b6c10b3cce87.png)
