### PR TITLE
pshazz, concfg, psutils: Fix checkver error

### DIFF
--- a/bucket/concfg.json
+++ b/bucket/concfg.json
@@ -7,8 +7,8 @@
     "extract_dir": "concfg-d9628d71460f3a3ae83dfbaf20a60f17fa40c45a",
     "bin": "bin\\concfg.ps1",
     "checkver": {
-        "url": "https://github.com/lukesampson/concfg",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "url": "https://github.com/lukesampson/concfg/commits/master.atom",
+        "re": "(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/gitignore.json
+++ b/bucket/gitignore.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "Fetches .gitignore file templates from gitignore.io and writes them to standard output.",
-    "version": "0.2018.08.04",
+    "version": "0.2018.07.25",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/gitignore.ps1",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3290c04d7653ea8183a5e11d3d5a4e46716035d1/gitignore.ps1",
     "hash": "733e4e2bece6e84ad1d25589cc6d1f852587f2d4a6ffe74b8268435ae229487a",
     "bin": "gitignore.ps1",
     "checkver": {
         "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "re": "gitignore\\.ps1[\\S\\s]*?/(?<sha>[0-9a-f]{40})[\\S\\s]*?(\\d+)-(\\d+)-(\\d+)",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/ln.json
+++ b/bucket/ln.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "An approximation of the Unix ln command.",
-    "version": "0.2018.08.04",
+    "version": "0.2018.07.25",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/ln.ps1",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3290c04d7653ea8183a5e11d3d5a4e46716035d1/ln.ps1",
     "hash": "2e97f2f1bacba1c403c538a80493e8c6c56203ba689f2a29a9fde6ba3576d3f7",
     "bin": "ln.ps1",
     "checkver": {
         "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "re": "ln\\.ps1[\\S\\s]*?/(?<sha>[0-9a-f]{40})[\\S\\s]*?(\\d+)-(\\d+)-(\\d+)",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/pshazz.json
+++ b/bucket/pshazz.json
@@ -9,8 +9,8 @@
         "file": "bin\\install.ps1"
     },
     "checkver": {
-        "url": "https://github.com/lukesampson/pshazz",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "url": "https://github.com/lukesampson/pshazz/commits/master.atom",
+        "re": "(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/psutils.json
+++ b/bucket/psutils.json
@@ -22,8 +22,8 @@
     ],
     "notes": "Please use 'timecmd' instead of 'time' in cmd.exe.",
     "checkver": {
-        "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "url": "https://github.com/lukesampson/psutils/commits/master.atom",
+        "re": "(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/runat.json
+++ b/bucket/runat.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "A replacement for the at command which Microsoft has deprecated and removed in Windows 2012.",
-    "version": "0.2018.08.04",
+    "version": "0.2018.07.25",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/runat.ps1",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3290c04d7653ea8183a5e11d3d5a4e46716035d1/runat.ps1",
     "hash": "3a7f3cf34a9695ae607627f4d3c041543909c217f54997ebbeb3871ce6f96889",
     "bin": "runat.ps1",
     "checkver": {
         "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "re": "runat\\.ps1[\\S\\s]*?/(?<sha>[0-9a-f]{40})[\\S\\s]*?(\\d+)-(\\d+)-(\\d+)",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/sudo.json
+++ b/bucket/sudo.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "An approximation of the Unix sudo command. Shows a UAC popup window unfortunately.",
-    "version": "0.2018.08.04",
+    "version": "0.2018.07.25",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/sudo.ps1",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3290c04d7653ea8183a5e11d3d5a4e46716035d1/sudo.ps1",
     "hash": "7c124e37f3f15e200a651cec5c5f58d05b5e347d8697f2204d0a40c4181b3642",
     "bin": "sudo.ps1",
     "checkver": {
         "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "re": "sudo\\.ps1[\\S\\s]*?/(?<sha>[0-9a-f]{40})[\\S\\s]*?(\\d+)-(\\d+)-(\\d+)",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/time.json
+++ b/bucket/time.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "An approximation of the Unix time command.",
-    "version": "0.2018.08.04",
+    "version": "0.2018.07.25",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/time.ps1",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3290c04d7653ea8183a5e11d3d5a4e46716035d1/time.ps1",
     "hash": "250413758eb4845973cfd0778b58e40ec52b881f17cbe13b22afac440fb26d93",
     "bin": [
         "time.ps1",
@@ -15,7 +15,7 @@
     "notes": "Please use 'timecmd' instead of 'time' in cmd.exe.",
     "checkver": {
         "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "re": "time\\.ps1[\\S\\s]*?/(?<sha>[0-9a-f]{40})[\\S\\s]*?(\\d+)-(\\d+)-(\\d+)",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/touch.json
+++ b/bucket/touch.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "A port of the Unix touch command.",
-    "version": "0.2018.08.04",
+    "version": "0.2018.07.25",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/touch.ps1",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3290c04d7653ea8183a5e11d3d5a4e46716035d1/touch.ps1",
     "hash": "11eeb18ca3143929b5ace9a838a88d9b1c5bc657bcc8dd46708ba7e50ba331d9",
     "bin": "touch.ps1",
     "checkver": {
         "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "re": "touch\\.ps1[\\S\\s]*?/(?<sha>[0-9a-f]{40})[\\S\\s]*?(\\d+)-(\\d+)-(\\d+)",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {

--- a/bucket/vimtutor.json
+++ b/bucket/vimtutor.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://github.com/lukesampson/psutils",
     "description": "The vimtutor that comes with Vim for Windows doesn't work with Scoop. This one does.",
-    "version": "0.2018.08.04",
+    "version": "0.2018.07.25",
     "license": "MIT",
-    "url": "https://raw.githubusercontent.com/lukesampson/psutils/de1a069215c54a1cb105f3dc79f14e25570c75f2/vimtutor.ps1",
+    "url": "https://raw.githubusercontent.com/lukesampson/psutils/3290c04d7653ea8183a5e11d3d5a4e46716035d1/vimtutor.ps1",
     "hash": "1df57e3bf4139ca096acd71896cc1797ae539ed3ab77185c0ed93846b3c60790",
     "bin": "vimtutor.ps1",
     "suggest": {
@@ -11,7 +11,7 @@
     },
     "checkver": {
         "url": "https://github.com/lukesampson/psutils",
-        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "re": "vimtutor\\.ps1[\\S\\s]*?/(?<sha>[0-9a-f]{40})[\\S\\s]*?(\\d+)-(\\d+)-(\\d+)",
         "replace": "0.${1}.${2}.${3}"
     },
     "autoupdate": {


### PR DESCRIPTION
- Using `/commits/master.atom` file in `checkver` to avoid github page load error (get wrong commit date 2016.03.23)
- Modify `checkver` of tools in `psutils` that return last modify date of single `ps1` file.