### PR TITLE
Add Xidel

### DIFF
--- a/bucket/xidel.json
+++ b/bucket/xidel.json
@@ -2,7 +2,7 @@
     "homepage": "http://www.videlibri.de/xidel.html",
     "description": "command line tool to download and extract data from HTML/XML pages as well as JSON APIs.",
     "version": "0.9.8",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-or-later",
     "url": "https://github.com/benibela/xidel/releases/download/Xidel_0.9.8/xidel-0.9.8.win32.zip",
     "hash": "96854c2be1e3755f56fabb8f00d1fe567108461b9fab139039219a1b7c17e382",
     "bin": "xidel.exe",

--- a/bucket/xidel.json
+++ b/bucket/xidel.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "http://www.videlibri.de/xidel.html",
+    "description": "command line tool to download and extract data from HTML/XML pages as well as JSON APIs.",
+    "version": "0.9.8",
+    "license": "GPL-3.0",
+    "url": "https://github.com/benibela/xidel/releases/download/Xidel_0.9.8/xidel-0.9.8.win32.zip",
+    "hash": "96854c2be1e3755f56fabb8f00d1fe567108461b9fab139039219a1b7c17e382",
+    "bin": "xidel.exe",
+    "checkver": {
+        "github": "https://github.com/benibela/xidel"
+    },
+    "autoupdate": {
+        "url": "https://github.com/benibela/xidel/releases/download/Xidel_$version/xidel-$version.win32.zip"
+    }
+}


### PR DESCRIPTION
> Xidel is a command line tool to download and extract data from HTML/XML pages using CSS selectors, XPath/XQuery 3.0, as well as querying JSON files or APIs (e.g. REST) using JSONiq.
> https://github.com/benibela/xidel