### PR TITLE
premake: Rename premake5 to premake, move premake4 to versions bucket

### DIFF
--- a/bucket/premake.json
+++ b/bucket/premake.json
@@ -6,8 +6,8 @@
     "hash": "712ee206fd2df4adf6320500b755d131ff5fac188a2a653876ae10d3066f4163",
     "bin": "premake5.exe",
     "checkver": {
-        "url": "https://github.com/premake/premake-core/releases/latest",
-        "re": "/releases/tag/v(5[0-9.]+-?(alpha|beta)?([0-9.]+)?)"
+        "url": "https://premake.github.io/download.html",
+        "regex": "v(5[0-9a-z.-]+)"
     },
     "autoupdate": {
         "url": "https://github.com/premake/premake-core/releases/download/v$version/premake-$version-windows.zip"

--- a/bucket/premake4.json
+++ b/bucket/premake4.json
@@ -1,8 +1,0 @@
-{
-    "homepage": "https://premake.github.io/download.html",
-    "version": "4.4-b5",
-    "license": "BSD-3-Clause",
-    "url": "https://downloads.sourceforge.net/project/premake/Premake/4.4/premake-4.4-beta5-windows.zip",
-    "hash": "09614c122156617a2b7973cc9f686daa32e64e3e7335d38db887cfb8f6a8574d",
-    "bin": "premake4.exe"
-}


### PR DESCRIPTION
[premake4](https://github.com/scoopinstaller/versions/blob/master/bucket/premake4.json) and [premake5](https://github.com/scoopinstaller/versions/blob/master/bucket/premake5.json) are in versions bucket already.

And since premake's current version is 5 (although still in alpha), rename premake5 to premake and delete premake4 in main bucket.