### PR TITLE
download progress without newline

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -284,12 +284,12 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
                 # skip blank lines
                 return
             }
+            # clean line
+            Write-Host (' ' * ($Host.UI.RawUI.WindowSize.Width) + "`r") -NoNewline
             Write-Host $prefix -NoNewline
             if($_.StartsWith('(OK):')) {
                 Write-Host $_ -f Green
             } elseif($_.StartsWith('[') -and $_.EndsWith(']')) {
-                # clean line
-                Write-Host (' ' * $Host.UI.RawUI.WindowSize.Width + "`r") -NoNewline
                 # download progress without newline
                 Write-Host "$_`r" -f Cyan -NoNewline
             } else {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -288,7 +288,10 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
             if($_.StartsWith('(OK):')) {
                 Write-Host $_ -f Green
             } elseif($_.StartsWith('[') -and $_.EndsWith(']')) {
-                Write-Host $_ -f Cyan
+                # clean line
+                Write-Host (' ' * $Host.UI.RawUI.WindowSize.Width + "`r") -NoNewline
+                # download progress without newline
+                Write-Host "$_`r" -f Cyan -NoNewline
             } else {
                 Write-Host $_ -f Gray
             }


### PR DESCRIPTION
There are too many download notifications. This is not necessary. We only need one line to download the progress.