### PR TITLE
Allow persist dirs to have trailing slash

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1161,6 +1161,8 @@ function persist_data($manifest, $original_dir, $persist_dir) {
 
             write-host "Persisting $source"
 
+            $source = $source.TrimEnd("/").TrimEnd("\\")
+
             $source = fullpath "$dir\$source"
             $target = fullpath "$persist_dir\$target"
 


### PR DESCRIPTION
This will allow us to differentiate files from directories in persist:
```json
    "persist": [
        "FastCopy2.ini",
        "Log/"
    ],
```
By doing this, we can create the persisted files and directories for the user, if the installer/pre_install fail to create them first.

Here's a (probably incomplete) list of apps in main/extras/versions where we could remove the create file/directory logic from their `pre_install` section:
[main/inadyn-mt](https://github.com/lukesampson/scoop/blob/master/bucket/inadyn-mt.json)
[main/lynx](https://github.com/lukesampson/scoop/blob/master/bucket/lynx.json)
[main/nvm](https://github.com/lukesampson/scoop/blob/master/bucket/nvm.json)
[extras/bandizip](https://github.com/lukesampson/scoop-extras/blob/master/bucket/bandizip.json)
[extras/uninstaller](https://github.com/lukesampson/scoop-extras/blob/master/bucket/bulk-crap-uninstaller.json)
[extras/ccleaner](https://github.com/lukesampson/scoop-extras/blob/master/bucket/ccleaner.json)
[extras/cherrytree](https://github.com/lukesampson/scoop-extras/blob/master/bucket/cherrytree.json)
[extras/conemu](https://github.com/lukesampson/scoop-extras/blob/master/bucket/conemu.json)
[extras/coretemp](https://github.com/lukesampson/scoop-extras/blob/master/bucket/coretemp.json)
[extras/crystaldiskinfo](https://github.com/lukesampson/scoop-extras/blob/master/bucket/crystaldiskinfo.json)
[extras/crystaldiskmark](https://github.com/lukesampson/scoop-extras/blob/master/bucket/crystaldiskmark.json)
[extras/server](https://github.com/lukesampson/scoop-extras/blob/master/bucket/dhcp-server.json)
[extras/ditto](https://github.com/lukesampson/scoop-extras/blob/master/bucket/ditto.json)
[extras/portable](https://github.com/lukesampson/scoop-extras/blob/master/bucket/eagleget-portable.json)
[extras/everything](https://github.com/lukesampson/scoop-extras/blob/master/bucket/everything.json)
[extras/fastcopy](https://github.com/lukesampson/scoop-extras/blob/master/bucket/fastcopy.json)
[extras/freac](https://github.com/lukesampson/scoop-extras/blob/master/bucket/freac.json)
[extras/irfanview](https://github.com/lukesampson/scoop-extras/blob/master/bucket/irfanview.json)
[extras/client](https://github.com/lukesampson/scoop-extras/blob/master/bucket/lantern-client.json)
[extras/listenmoeclient](https://github.com/lukesampson/scoop-extras/blob/master/bucket/listenmoeclient.json)
[extras/emulator](https://github.com/lukesampson/scoop-extras/blob/master/bucket/locale-emulator.json)
[extras/microsip](https://github.com/lukesampson/scoop-extras/blob/master/bucket/microsip.json)
[extras/mobaxterm](https://github.com/lukesampson/scoop-extras/blob/master/bucket/mobaxterm.json)
[extras/mp3tag](https://github.com/lukesampson/scoop-extras/blob/master/bucket/mp3tag.json)
[extras/notepadplusplus](https://github.com/lukesampson/scoop-extras/blob/master/bucket/notepadplusplus.json)
[extras/studio](https://github.com/lukesampson/scoop-extras/blob/master/bucket/obs-studio.json)
[extras/small](https://github.com/lukesampson/scoop-extras/blob/master/bucket/obs-studio-small.json)
[extras/pcem](https://github.com/lukesampson/scoop-extras/blob/master/bucket/pcem.json)
[extras/peerblock](https://github.com/lukesampson/scoop-extras/blob/master/bucket/peerblock.json)
[extras/picotorrent](https://github.com/lukesampson/scoop-extras/blob/master/bucket/picotorrent.json)
[extras/retroarch](https://github.com/lukesampson/scoop-extras/blob/master/bucket/retroarch.json)
[extras/rufus](https://github.com/lukesampson/scoop-extras/blob/master/bucket/rufus.json)
[extras/shadowsocks](https://github.com/lukesampson/scoop-extras/blob/master/bucket/shadowsocks.json)
[extras/csharp](https://github.com/lukesampson/scoop-extras/blob/master/bucket/shadowsocksr-csharp.json)
[extras/shutup10](https://github.com/lukesampson/scoop-extras/blob/master/bucket/shutup10.json)
[extras/simplewall](https://github.com/lukesampson/scoop-extras/blob/master/bucket/simplewall.json)
[extras/snipaste](https://github.com/lukesampson/scoop-extras/blob/master/bucket/snipaste.json)
[extras/speedfan](https://github.com/lukesampson/scoop-extras/blob/master/bucket/speedfan.json)
[extras/subtitleedit](https://github.com/lukesampson/scoop-extras/blob/master/bucket/subtitleedit.json)
[extras/tcpipmanager](https://github.com/lukesampson/scoop-extras/blob/master/bucket/tcpipmanager.json)
[extras/texmaker](https://github.com/lukesampson/scoop-extras/blob/master/bucket/texmaker.json)
[extras/todolist](https://github.com/lukesampson/scoop-extras/blob/master/bucket/todolist.json)
[extras/totalcommander](https://github.com/lukesampson/scoop-extras/blob/master/bucket/totalcommander.json)
[extras/winrar](https://github.com/lukesampson/scoop-extras/blob/master/bucket/winrar.json)
[extras/winscp](https://github.com/lukesampson/scoop-extras/blob/master/bucket/winscp.json)
[extras/wiztree](https://github.com/lukesampson/scoop-extras/blob/master/bucket/wiztree.json)
[extras/x64dbg](https://github.com/lukesampson/scoop-extras/blob/master/bucket/x64dbg.json)
[extras/recode](https://github.com/lukesampson/scoop-extras/blob/master/bucket/xmedia-recode.json)
[versions/lynx283](https://github.com/rasa/versions/blob/master/bucket/lynx283.json)
