### PR TITLE
yarn: Make `global` persist and fix global bin issue

### DIFF
--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -1,36 +1,42 @@
 {
     "homepage": "https://yarnpkg.com/",
-    "description": "Dependency manager",
+    "description": "Node.js dependency manager",
+    "version": "1.15.0",
     "license": "BSD-2-Clause",
-    "version": "1.13.0",
-    "suggest": {
-        "Node.js": [
-            "nodejs",
-            "nodejs-lts"
-        ],
-        "NVM": "nvm"
-    },
-    "url": "https://yarnpkg.com/downloads/1.13.0/yarn-1.13.0.msi",
-    "hash": "e3da89d8ea6b200908e1a47ed95a474e0acd5437b719590f497f52c1a9d32730",
+    "url": "https://github.com/yarnpkg/yarn/releases/download/v1.15.0/yarn-1.15.0.msi",
+    "hash": "823abe4ca1c71d07338260cb540b7eaf853d923a2ca92c0daf765c0c091f6f47",
     "persist": [
         "cache",
-        "bin",
-        "mirror"
+        "mirror",
+        "global"
     ],
     "post_install": [
         "yarn config set cache-folder \"$dir\\cache\"",
         "yarn config set yarn-offline-mirror \"$dir\\mirror\"",
-        "yarn config set prefix \"$dir\""
+        "yarn config set global-folder \"$dir\\global\""
     ],
+    "uninstaller": {
+        "script": [
+            "Remove-Item $env:LOCALAPPDATA\\Yarn -Recurse -Force",
+            "Remove-Item $env:USERPROFILE\\.yarnrc -Force"
+        ]
+    },
     "env_add_path": [
-        "bin",
+        "global\\node_modules\\.bin",
         "Yarn\\bin"
     ],
     "checkver": {
-        "url": "https://yarnpkg.com/latest-version",
-        "re": "([\\d.]+)"
+        "github": "https://github.com/yarnpkg/yarn/"
     },
     "autoupdate": {
-        "url": "https://yarnpkg.com/downloads/$version/yarn-$version.msi"
+        "url": "https://github.com/yarnpkg/yarn/releases/download/v$version/yarn-$version.msi"
+    },
+    "suggest": {
+        "Node.js": [
+            "nodejs",
+            "nodejs-lts",
+            "nvm",
+            "nvs"
+        ]
     }
 }

--- a/bucket/yarn.json
+++ b/bucket/yarn.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://yarnpkg.com/",
     "description": "Node.js dependency manager",
-    "version": "1.15.0",
+    "version": "1.15.2",
     "license": "BSD-2-Clause",
-    "url": "https://github.com/yarnpkg/yarn/releases/download/v1.15.0/yarn-1.15.0.msi",
-    "hash": "823abe4ca1c71d07338260cb540b7eaf853d923a2ca92c0daf765c0c091f6f47",
+    "url": "https://yarnpkg.com/downloads/1.15.2/yarn-1.15.2.msi",
+    "hash": "e3b07031012c83367809da702db77a70a151f457b4e83e6cb4d70e9426625f67",
     "persist": [
         "cache",
         "mirror",
@@ -26,10 +26,11 @@
         "Yarn\\bin"
     ],
     "checkver": {
-        "github": "https://github.com/yarnpkg/yarn/"
+        "url": "https://yarnpkg.com/latest-version",
+        "re": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/yarnpkg/yarn/releases/download/v$version/yarn-$version.msi"
+        "url": "https://yarnpkg.com/downloads/$version/yarn-$version.msi"
     },
     "suggest": {
         "Node.js": [


### PR DESCRIPTION
- Yarn's global folder can be set via `yarn config set global-folder` (https://github.com/yarnpkg/yarn/pull/7056) and thus can be persisted. 
- ~~Since yarn's global bin creating procedure is still problematic (https://github.com/yarnpkg/yarn/issues/6902, **fixed by https://github.com/yarnpkg/yarn/pull/6954**),~~ The `.bin` folder in `global\node_modules` is a better path to add to env, and this can avoid the annoying problem when you install scoop in some place except `C:` (that the shims in global bin have wrong relative path pointer).
- If you install yarn via `scoop install yarn`, the `Yarn` folder in `$env:LOCALAPPDATA` is useless, and when you uninstall `yarn`, the `.yarnrc` is unused, so the manifest add `uninstaller.script` to remove them when you uninstall.
- For reconfiguration, please use `scoop update yarn -f` instead of `scoop reset yarn`.

Should close #2969. 