### PR TITLE
fix(persist): Using [Array] to persist file 

### DIFF
--- a/bucket/nvm-array.json
+++ b/bucket/nvm-array.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "https://github.com/coreybutler/nvm-windows",
+    "version": "1.1.7",
+    "url": "https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip",
+    "bin": "nvm.exe",
+    "persist": [
+        "nodejs",
+        [
+            "elevate.cmd",
+            "nodejs\\elevate.cmd"
+        ],
+        [
+            "elevate.vbs",
+            "nodejs\\elevate.vbs"
+        ],
+        ["settings.txt", "", "root: $persist_dir\\nodejs`r`narch: $architecture`r`nproxy: none"]
+    ],
+    "env_add_path": "nodejs\\nodejs",
+    "env_set": {
+        "NVM_HOME": "$dir",
+        "NVM_SYMLINK": "$persist_dir\\nodejs\\nodejs"
+    },
+    "hash": "md5:00acf86e40c5f038cca8c383b9d2c207",
+    "notes": "You'll need to restart powershell/cmd to have it reload Environment Variables so nvm will work correctly",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/coreybutler/nvm-windows/releases/download/$version/nvm-noinstall.zip",
+        "hash": {
+            "url": "$url.checksum.txt",
+            "find": "([a-fA-F0-9]{32})"
+        }
+    }
+}

--- a/bucket/nvm-object.json
+++ b/bucket/nvm-object.json
@@ -1,0 +1,43 @@
+{
+    "homepage": "https://github.com/coreybutler/nvm-windows",
+    "version": "1.1.7",
+    "url": "https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip",
+    "bin": "nvm.exe",
+    "persist": [
+        {
+            "name": "nodejs",
+            "type": "directory",
+            "method": "link"
+        },
+        {
+            "name": "elevate.cmd",
+            "type": "file",
+            "target": "nodejs\\elevate.cmd"
+        },
+        {
+            "name": "elevate.vbs",
+            "type": "file",
+            "target": "nodejs\\elevate.vbs"
+        },
+        {
+            "name": "settings.txt",
+            "type": "file",
+            "contents": "root: $persist_dir\\nodejs`r`narch: $architecture`r`nproxy: none"
+        }
+    ],
+    "env_add_path": "nodejs\\nodejs",
+    "env_set": {
+        "NVM_HOME": "$dir",
+        "NVM_SYMLINK": "$persist_dir\\nodejs\\nodejs"
+    },
+    "hash": "md5:00acf86e40c5f038cca8c383b9d2c207",
+    "notes": "You'll need to restart powershell/cmd to have it reload Environment Variables so nvm will work correctly",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/coreybutler/nvm-windows/releases/download/$version/nvm-noinstall.zip",
+        "hash": {
+            "url": "$url.checksum.txt",
+            "find": "([a-fA-F0-9]{32})"
+        }
+    }
+}

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -285,7 +285,25 @@ function isFileLocked([string]$path) {
 }
 
 function is_directory([String] $path) {
-    return (Test-Path $path) -and (Get-Item $path) -is [System.IO.DirectoryInfo]
+    return (Test-Path $path) -and (Get-Item -Path $path) -is [System.IO.DirectoryInfo]
+}
+
+function create_junction([String] $link, [String] $target) {
+    if (!(Test-Path $link) -and (is_directory $target)) {
+        New-Item -ItemType Junction -Path $link -Target $target | Out-Null
+        $dirInfo = New-Object System.IO.DirectoryInfo($link)
+        $dirInfo.Attributes = $dirInfo.Attributes -bor [System.IO.FileAttributes]::ReadOnly
+        return $true
+    }
+    return $false
+}
+
+function create_hardlink([String] $link, [String] $target) {
+    if (!(Test-Path $link) -and (Test-Path $target) -and !(is_directory $target)) {
+        New-Item -ItemType HardLink -Path $link -Target $target | Out-Null
+        return $true
+    }
+    return $false
 }
 
 function movedir($from, $to) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -236,7 +236,7 @@ function url_remote_filename($url) {
     return $basename
 }
 
-function ensure($dir) { if(!(test-path $dir)) { mkdir $dir > $null }; resolve-path $dir }
+function ensure($dir) { if(!(test-path $dir)) { New-Item $dir -ItemType Directory -Force | Out-Null }; resolve-path $dir }
 function fullpath($path) { # should be ~ rooted
     $executionContext.sessionState.path.getUnresolvedProviderPathFromPSPath($path)
 }
@@ -306,13 +306,13 @@ function create_hardlink([String] $link, [String] $target) {
     return $false
 }
 
-function movedir($from, $to) {
+function movedir($from, $to, $par = "") {
     $from = $from.trimend('\')
     $to = $to.trimend('\')
 
     $proc = New-Object System.Diagnostics.Process
     $proc.StartInfo.FileName = 'robocopy.exe'
-    $proc.StartInfo.Arguments = "`"$from`" `"$to`" /e /move"
+    $proc.StartInfo.Arguments = "`"$from`" `"$to`" /e /move " + $par
     $proc.StartInfo.RedirectStandardOutput = $true
     $proc.StartInfo.RedirectStandardError = $true
     $proc.StartInfo.UseShellExecute = $false
@@ -329,6 +329,7 @@ function movedir($from, $to) {
     # wait for robocopy to terminate its threads
     1..10 | ForEach-Object {
         if (Test-Path $from) {
+            Remove-Item -Path $from.FullName -Recurse -Force
             Start-Sleep -Milliseconds 100
         }
     }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1209,7 +1209,7 @@ function unlink_persist_data($dir) {
         if ($null -ne $file.LinkType) {
             $filepath = $file.FullName
             # directory (junction)
-            if (is_directory $file) {
+            if (is_directory $filepath) {
                 # remove read-only attribute on the link
                 attrib -R /L $filepath
                 # remove the junction

--- a/schema.json
+++ b/schema.json
@@ -202,63 +202,72 @@
             },
             "type": "object"
         },
-        "persist": {
+        "persistItem": {
             "anyOf": [
                 {
                     "description": "Deprecated, use object representation instead.",
-                    "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
+                {
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "target": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "enum": [
+                                "file",
+                                "directory"
+                            ]
+                        },
+                        "encoding": {
+                            "enum": [
+                                "ASCII",
+                                "BigEndianUnicode",
+                                "BigEndianUTF32",
+                                "Default",
+                                "OEM",
+                                "Unicode",
+                                "UTF7",
+                                "UTF8",
+                                "UTF32"
+                            ]
+                        },
+                        "content": {
+                            "$ref": "#/definitions/stringOrArrayOfStrings"
+                        },
+                        "glue": {
+                            "description": "Characters to join content array",
+                            "type": "string"
+                        },
+                        "method": {
+                            "enum": [
+                                "link",
+                                "copy",
+                                "merge",
+                                "update"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        },
+        "persist": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/persistItem"
                 },
                 {
                     "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "required": [
-                            "name",
-                            "type"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "target": {
-                                "type": "string"
-                            },
-                            "type": {
-                                "enum": [
-                                    "file",
-                                    "directory"
-                                ]
-                            },
-                            "encoding": {
-                                "enum": [
-                                    "ASCII",
-                                    "BigEndianUnicode",
-                                    "BigEndianUTF32",
-                                    "Byte",
-                                    "Default",
-                                    "OEM",
-                                    "Unicode",
-                                    "UTF7",
-                                    "UTF8",
-                                    "UTF32"
-                                ]
-                            },
-                            "content": {
-                                "$ref": "#/definitions/stringOrArrayOfStrings"
-                            },
-                            "glue": {
-                                "description": "Characters to join content array",
-                                "type": "string"
-                            },
-                            "method": {
-                                "enum": [
-                                    "link",
-                                    "copy",
-                                    "merge",
-                                    "update"
-                                ]
-                            }
-                        }
+                        "$ref": "#/definitions/persistItem"
                     },
                     "minItems": 1,
                     "type": "array"

--- a/schema.json
+++ b/schema.json
@@ -224,7 +224,9 @@
                         "type": {
                             "enum": [
                                 "file",
-                                "directory"
+                                "directory",
+                                "dir",
+                                "folder"
                             ]
                         },
                         "encoding": {

--- a/schema.json
+++ b/schema.json
@@ -202,6 +202,69 @@
             },
             "type": "object"
         },
+        "persist": {
+            "anyOf": [
+                {
+                    "description": "Deprecated, use object representation instead.",
+                    "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
+                },
+                {
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "name",
+                            "type"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "target": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "enum": [
+                                    "file",
+                                    "directory"
+                                ]
+                            },
+                            "encoding": {
+                                "enum": [
+                                    "ASCII",
+                                    "BigEndianUnicode",
+                                    "BigEndianUTF32",
+                                    "Byte",
+                                    "Default",
+                                    "OEM",
+                                    "Unicode",
+                                    "UTF7",
+                                    "UTF8",
+                                    "UTF32"
+                                ]
+                            },
+                            "content": {
+                                "$ref": "#/definitions/stringOrArrayOfStrings"
+                            },
+                            "glue": {
+                                "description": "Characters to join content array",
+                                "type": "string"
+                            },
+                            "method": {
+                                "enum": [
+                                    "link",
+                                    "copy",
+                                    "merge",
+                                    "update"
+                                ]
+                            }
+                        }
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            ]
+        },
         "checkver": {
             "anyOf": [
                 {
@@ -407,7 +470,7 @@
             "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
         },
         "persist": {
-            "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
+            "$ref": "#/definitions/persist"
         },
         "checkver": {
             "$ref": "#/definitions/checkver"

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -6,20 +6,57 @@
 $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
 $isUnix = is_unix
 
-describe "is_directory" -Tag 'Scoop' {
+describe "directory/junction/hardlink handling" -Tag 'Scoop' {
     beforeall {
         $working_dir = setup_working "is_directory"
     }
 
-    it "is_directory recognize directories" {
+    it "is_directory recognizes directories" {
         is_directory "$working_dir\i_am_a_directory" | should -be $true
     }
-    it "is_directory recognize files" {
+
+    it "is_directory recognizes files" {
         is_directory "$working_dir\i_am_a_file.txt" | should -be $false
     }
 
     it "is_directory is falsey on unknown path" {
         is_directory "$working_dir\i_do_not_exist" | should -be $false
+    }
+
+    it "create_junction recognizes directories and creates junction" {
+        create_junction "$working_dir\i_am_a_junction" "$working_dir\i_am_a_directory" | should -be $true
+        Test-Path "$working_dir\i_am_a_junction" | should -be $true
+    }
+
+    it "create_junction recognizes existing target" {
+        create_junction "$working_dir\i_am_a_junction" "$working_dir\i_am_a_directory" | should -be $false
+    }
+
+    it "create_junction recognizes files" {
+        create_junction "$working_dir\i_am_a_junction_file.txt" "$working_dir\i_am_a_file.txt" | should -be $false
+        Test-Path "$working_dir\i_am_a_junction_file.txt" | should -be $false
+    }
+
+    it "create_junction is falsey on unknown path" {
+        create_junction "$working_dir\i_am_a_junction" "$working_dir\i_do_not_exist" | should -be $false
+    }
+
+    it "create_hardlink recognizes files and creates hardlink" {
+        create_hardlink "$working_dir\i_am_a_hardlinked_file.txt" "$working_dir\i_am_a_file.txt" | should -be $true
+        Test-Path "$working_dir\i_am_a_hardlinked_file.txt" | should -be $true
+    }
+
+    it "create_hardlink recognizes existing target" {
+        create_hardlink "$working_dir\i_am_a_hardlinked_file.txt" "$working_dir\i_am_a_file.txt" | should -be $false
+    }
+
+    it "create_hardlink recognizes directories" {
+        create_hardlink "$working_dir\i_am_a_hardlinked_directory" "$working_dir\i_am_a_directory" | should -be $false
+        Test-Path "$working_dir\i_am_a_hardlinked_directory" | should -be $false
+    }
+
+    it "create_hardlink is falsey on unknown path" {
+        create_hardlink "$working_dir\i_do_not_exist.txt" "$working_dir\i_do_not_exist.txt" | should -be $false
     }
 }
 

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -124,32 +124,58 @@ describe "shim_def" -Tag 'Scoop' {
 
 describe 'persist_def' -Tag 'Scoop' {
     it 'parses string correctly' {
-        $source, $target = persist_def "test"
+        $source, $target, $contents = persist_def "test"
         $source | should -be "test"
         $target | should -be "test"
+        $contents | should -be $null
     }
 
     it 'should handle sub-folder' {
-        $source, $target = persist_def "foo/bar"
+        $source, $target, $contents = persist_def "foo/bar"
         $source | should -be "foo/bar"
         $target | should -be "foo/bar"
+        $contents | should -be $null
     }
 
-    it 'should handle arrays' {
+    it 'should handle directory' {
         # both specified
-        $source, $target = persist_def @("foo", "bar")
+        $source, $target, $contents = persist_def @("foo", "bar")
         $source | should -be "foo"
         $target | should -be "bar"
-
-        # only first specified
-        $source, $target = persist_def @("foo")
-        $source | should -be "foo"
-        $target | should -be "foo"
+        $contents | should -be $null
 
         # null value specified
-        $source, $target = persist_def @("foo", $null)
+        $source, $target, $contents = persist_def @("foo", $null)
         $source | should -be "foo"
         $target | should -be "foo"
+        $contents | should -be $null
+    }
+
+    it 'should handle file' {
+
+        # no file contents specified
+        $source, $target, $contents = persist_def @("foo")
+        $source | should -be "foo"
+        $target | should -be "foo"
+        $contents | should -be ""
+
+        # file contents specified
+        $source, $target, $contents = persist_def @("foo", "", "file contents")
+        $source | should -be "foo"
+        $target | should -be "foo"
+        $contents | should -be "file contents"
+
+        # null and file contents specified
+        $source, $target, $contents = persist_def @("foo", $null, "file contents")
+        $source | should -be "foo"
+        $target | should -be "foo"
+        $contents | should -be "file contents"
+
+        # several lines of file contents specified
+        $source, $target, $contents = persist_def @("foo", "", "file", "contents")
+        $source | should -be "foo"
+        $target | should -be "foo"
+        $contents | should -be "file`r`ncontents"
     }
 }
 

--- a/test/Scoop-Install.Tests.ps1
+++ b/test/Scoop-Install.Tests.ps1
@@ -101,7 +101,7 @@ describe "env add and remove path" -Tag 'Scoop' {
     }
 }
 
-describe "shim_def" -Tag 'Scoop' {
+describe "shim parsing" -Tag 'Scoop' {
     it "should use strings correctly" {
         $target, $name, $shimArgs = shim_def "command.exe"
         $target | should -be "command.exe"
@@ -122,60 +122,60 @@ describe "shim_def" -Tag 'Scoop' {
     }
 }
 
-describe 'persist_def' -Tag 'Scoop' {
+describe 'persist parsing for array' -Tag 'Scoop' {
     it 'parses string correctly' {
-        $source, $target, $contents = persist_def "test"
-        $source | should -be "test"
-        $target | should -be "test"
-        $contents | should -be $null
+        $persist_def = persist_def_arr "test"
+        $persist_def.source | should -be "test"
+        $persist_def.target | should -be "test"
+        $persist_def.contents | should -be $null
     }
 
     it 'should handle sub-folder' {
-        $source, $target, $contents = persist_def "foo/bar"
-        $source | should -be "foo/bar"
-        $target | should -be "foo/bar"
-        $contents | should -be $null
+        $persist_def = persist_def_arr "foo/bar"
+        $persist_def.source | should -be "foo/bar"
+        $persist_def.target | should -be "foo/bar"
+        $persist_def.contents | should -be $null
     }
 
     it 'should handle directory' {
         # both specified
-        $source, $target, $contents = persist_def @("foo", "bar")
-        $source | should -be "foo"
-        $target | should -be "bar"
-        $contents | should -be $null
+        $persist_def = persist_def_arr @("foo", "bar")
+        $persist_def.source | should -be "foo"
+        $persist_def.target | should -be "bar"
+        $persist_def.contents | should -be $null
 
         # null value specified
-        $source, $target, $contents = persist_def @("foo", $null)
-        $source | should -be "foo"
-        $target | should -be "foo"
-        $contents | should -be $null
+        $persist_def = persist_def_arr @("foo", $null)
+        $persist_def.source | should -be "foo"
+        $persist_def.target | should -be "foo"
+        $persist_def.contents | should -be $null
     }
 
     it 'should handle file' {
 
         # no file contents specified
-        $source, $target, $contents = persist_def @("foo")
-        $source | should -be "foo"
-        $target | should -be "foo"
-        $contents | should -be ""
+        $persist_def = persist_def_arr @("foo")
+        $persist_def.source | should -be "foo"
+        $persist_def.target | should -be "foo"
+        $persist_def.contents | should -be ""
 
         # file contents specified
-        $source, $target, $contents = persist_def @("foo", "", "file contents")
-        $source | should -be "foo"
-        $target | should -be "foo"
-        $contents | should -be "file contents"
+        $persist_def = persist_def_arr @("foo", "", "file contents")
+        $persist_def.source | should -be "foo"
+        $persist_def.target | should -be "foo"
+        $persist_def.contents | should -be "file contents"
 
         # null and file contents specified
-        $source, $target, $contents = persist_def @("foo", $null, "file contents")
-        $source | should -be "foo"
-        $target | should -be "foo"
-        $contents | should -be "file contents"
+        $persist_def = persist_def_arr @("foo", $null, "file contents")
+        $persist_def.source | should -be "foo"
+        $persist_def.target | should -be "foo"
+        $persist_def.contents | should -be "file contents"
 
         # several lines of file contents specified
-        $source, $target, $contents = persist_def @("foo", "", "file", "contents")
-        $source | should -be "foo"
-        $target | should -be "foo"
-        $contents | should -be "file`r`ncontents"
+        $persist_def = persist_def_arr @("foo", "", "file", "contents")
+        $persist_def.source | should -be "foo"
+        $persist_def.target | should -be "foo"
+        $persist_def.contents | should -be "file`r`ncontents"
     }
 }
 

--- a/test/fixtures/persist/persist-array.json
+++ b/test/fixtures/persist/persist-array.json
@@ -1,0 +1,35 @@
+{
+    "persist_dir": [
+        "foo",
+        "foo\\bar",
+        [
+            "foo",
+            "bar"
+        ],
+        [
+            "foo",
+            null
+        ]
+    ],
+    "persist_file": [
+        [
+            "foo"
+        ],
+        [
+            "foo",
+            "",
+            "file contents"
+        ],
+        [
+            "foo",
+            null,
+            "file contents"
+        ],
+        [
+            "foo",
+            "",
+            "file",
+            "contents"
+        ]
+    ]
+}

--- a/test/fixtures/persist/persist-object.json
+++ b/test/fixtures/persist/persist-object.json
@@ -1,0 +1,54 @@
+{
+    "persist_dir": [
+        {
+            "name": "foo",
+            "type": "directory"
+        }, {
+            "name": "foo\\"
+        }, {
+            "name": "foo\\bar\\"
+        }, {
+            "name": "foo\\",
+            "target": "bar"
+        }, {
+            "name": "foo\\",
+            "encoding": "UTF8",
+            "contents": "file contents"
+        }, {
+            "name": "foo\\",
+            "method": "merge"
+        }
+    ],
+    "persist_file": [
+        {
+            "name": "foo",
+            "type": "file"
+        }, {
+            "name": "foo"
+        }, {
+            "name": "foo",
+            "contents": "file contents"
+        }, {
+            "name": "foo",
+            "contents": [
+                "file",
+                "contents"
+            ]
+        }, {
+            "name": "foo",
+            "contents": [
+                "file",
+                "contents"
+            ],
+            "glue": " "
+        }, {
+            "name": "foo",
+            "contents": [
+                "file",
+                "contents"
+            ],
+            "encoding": "UTF8",
+            "method": "update"
+        }
+    ]
+}


### PR DESCRIPTION
A new way to handle persist data, esp. with files

With this patch, one can distinguish file and dir in `persist` property by the following code:

```json
"persist": [
    "dir",
    ["another_dir", "different_persist_name"],
    ["file"],
    ["another_file", "different_persist_name", ""],
    ["third_file", "", "third_file_contents"],
    ["forth_file", "different_persist_name", "forth_file_contents"],
    ["fifth_file", "", "fifth_file", "contents"]
]
```

`persist` accepts `[Array]` as persist object, and array length is checked to determine if it is file or dir, with the following logic:

1. length = 1. Object is file, and file contents is empty string (`""`, not `$null`)
1. length = 2. Object is dir, and the second element is the changed persist name
1. length >= 3, Object is file, and the remaining elements is file contents which will be joined with `\r\n`

if persist object is `[String]`, it is dir without change.

In persisted file contents, every variables that can be used in `installer.script` can be used, e.g., `$persist_dir`, `$architecture`, etc.

~~It is ready to test and be merged, and I made a modified manifest of [`nvm.json`](https://github.com/lukesampson/scoop/blob/6a79e8c271d999e7835f996a10966f3b2b494d3f/bucket/nvm.json) for testing.~~