### PR TITLE
[WIP] Persistence rework with backward compatibility (persist)

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -285,7 +285,47 @@ function isFileLocked([string]$path) {
 }
 
 function is_directory([String] $path) {
-    return (Test-Path $path) -and (Get-Item $path) -is [System.IO.DirectoryInfo]
+    return (Test-Path $path) -and (Get-Item -Path $path) -is [System.IO.DirectoryInfo]
+}
+
+function is_junction([String] $path) {
+    return (Test-Path $path) -and (Get-Item -Path $path).LinkType -eq 'Junction'
+}
+
+function create_junction([String] $link, [String] $target) {
+    if (!(Test-Path $link) -and (is_directory $target)) {
+        New-Item -ItemType Junction -Path (Split-Path -Path $link) -Name (Split-Path -Leaf $link) -Target $target | Out-Null
+        $dirInfo = New-Object System.IO.DirectoryInfo($link)
+        $dirInfo.Attributes = $dirInfo.Attributes -bor [System.IO.FileAttributes]::ReadOnly
+        return $true
+    }
+    return $false
+}
+
+function remove_junction([String] $link) {
+    if(is_junction $link) {
+        $dirInfo = New-Object System.IO.DirectoryInfo($link)
+        $dirInfo.Attributes = $dirInfo.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
+        $dirInfo.Delete()
+        return $true
+    }
+    return $false
+}
+
+function create_hardlink([String] $link, [String] $target) {
+    if (!(Test-Path $link) -and (Test-Path $target) -and !(is_directory $target)) {
+        New-Item -ItemType HardLink -Path (Split-Path -Path $link) -Name (Split-Path -Leaf $link) -Target $target | Out-Null
+        return $true
+    }
+    return $false
+}
+
+function remove_hardlink([String] $link) {
+    if ((Test-Path $link) -and !(is_directory $link)) {
+        Remove-Item -Path $link | Out-Null
+        return $true
+    }
+    return $false
 }
 
 function movedir($from, $to) {

--- a/schema.json
+++ b/schema.json
@@ -202,6 +202,80 @@
             },
             "type": "object"
         },
+        "persist": {
+            "anyOf": [
+                {
+                    "description": "Deprecated, use object representation instead.",
+                    "type": "string"
+                },
+                {
+                    "description": "Deprecated, use object representation instead.",
+                    "items": {
+                        "$ref": "#/definitions/stringOrArrayOfStrings"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                {
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "name",
+                            "type"
+                        ],
+                        "if": {
+                            "properties": {
+                                "type": {
+                                    "const": "file"
+                                }
+                            }
+                        },
+                        "then": {
+                            "required": [
+                                "encoding",
+                                "content"
+                            ]
+                        },
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "target": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "enum": [
+                                    "file",
+                                    "directory",
+                                    "folder"
+                                ]
+                            },
+                            "encoding": {
+                                "enum": [
+                                    "utf-8",
+                                    "ascii",
+                                    "byte"
+                                ]
+                            },
+                            "content": {
+                                "$ref": "#/definitions/stringOrArrayOfStrings"
+                            },
+                            "method": {
+                                "enum": [
+                                    "copy",
+                                    "merge",
+                                    "link",
+                                    "update"
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "checkver": {
             "anyOf": [
                 {
@@ -407,7 +481,7 @@
             "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
         },
         "persist": {
-            "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
+            "$ref": "#/definitions/persist"
         },
         "checkver": {
             "$ref": "#/definitions/checkver"

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -6,20 +6,103 @@
 $repo_dir = (Get-Item $MyInvocation.MyCommand.Path).directory.parent.FullName
 $isUnix = is_unix
 
-describe "is_directory" -Tag 'Scoop' {
+describe "directory/junction/hardlink handling" -Tag 'Scoop' {
     beforeall {
         $working_dir = setup_working "is_directory"
     }
 
-    it "is_directory recognize directories" {
+    it "is_directory recognizes directories" {
         is_directory "$working_dir\i_am_a_directory" | should -be $true
     }
-    it "is_directory recognize files" {
+
+    it "is_directory recognizes files" {
         is_directory "$working_dir\i_am_a_file.txt" | should -be $false
     }
 
     it "is_directory is falsey on unknown path" {
         is_directory "$working_dir\i_do_not_exist" | should -be $false
+    }
+
+    it "create_junction recognizes directories and creates junction" {
+        create_junction "$working_dir\i_am_a_junction" "$working_dir\i_am_a_directory" | should -be $true
+        Test-Path "$working_dir\i_am_a_junction" | should -be $true
+    }
+
+    it "create_junction recognizes existing target" {
+        create_junction "$working_dir\i_am_a_junction" "$working_dir\i_am_a_directory" | should -be $false
+    }
+
+    it "create_junction recognizes files" {
+        create_junction "$working_dir\i_am_a_junction_file.txt" "$working_dir\i_am_a_file.txt" | should -be $false
+        Test-Path "$working_dir\i_am_a_junction_file.txt" | should -be $false
+    }
+
+    it "create_junction is falsey on unknown path" {
+        create_junction "$working_dir\i_am_a_junction" "$working_dir\i_do_not_exist" | should -be $false
+    }
+
+    it "is_junction recognizes junctions" {
+        is_junction "$working_dir\i_am_a_junction" | should -be $true
+    }
+
+    it "is_junction recognizes directories" {
+        is_junction "$working_dir\i_am_a_directory" | should -be $false
+    }
+
+    it "is_junction recognizes files" {
+        is_junction "$working_dir\i_am_a_file.txt" | should -be $false
+    }
+
+    it "is_junction is falsey on unknown path" {
+        is_junction "$working_dir\i_do_not_exist" | should -be $false
+    }
+
+    it "remove_junction recognizes junctions" {
+        remove_junction "$working_dir\i_am_a_junction" | should -be $true
+        Test-Path "$working_dir\i_am_a_junction" | should -be $false
+    }
+
+    it "remove_junction recognizes directories" {
+        remove_junction "$working_dir\i_am_a_directory" | should -be $false
+    }
+
+    it "remove_junction recognizes files" {
+        remove_junction "$working_dir\i_am_a_file.txt" | should -be $false
+    }
+
+    it "remove_junction is falsey on unknown path" {
+        remove_junction "$working_dir\i_do_not_exist" | should -be $false
+    }
+
+    it "create_hardlink recognizes files and creates hardlink" {
+        create_hardlink "$working_dir\i_am_a_hardlinked_file.txt" "$working_dir\i_am_a_file.txt" | should -be $true
+        Test-Path "$working_dir\i_am_a_hardlinked_file.txt" | should -be $true
+    }
+
+    it "create_hardlink recognizes existing target" {
+        create_hardlink "$working_dir\i_am_a_hardlinked_file.txt" "$working_dir\i_am_a_file.txt" | should -be $false
+    }
+
+    it "create_hardlink recognizes directories" {
+        create_hardlink "$working_dir\i_am_a_hardlinked_directory" "$working_dir\i_am_a_directory" | should -be $false
+        Test-Path "$working_dir\i_am_a_hardlinked_directory" | should -be $false
+    }
+
+    it "create_hardlink is falsey on unknown path" {
+        create_hardlink "$working_dir\i_do_not_exist.txt" "$working_dir\i_do_not_exist.txt" | should -be $false
+    }
+
+    it "remove_hardlink recognizes hardlinks/files" {
+        remove_hardlink "$working_dir\i_am_a_hardlinked_file.txt" | should -be $true
+        Test-Path "$working_dir\i_am_a_hardlinked_file.txt" | should -be $false
+    }
+
+    it "remove_hardlink recognizes directories" {
+        remove_hardlink "$working_dir\i_am_a_directory" | should -be $false
+    }
+
+    it "remove_hardlink is falsey on unknown path" {
+        remove_hardlink "$working_dir\i_do_not_exist" | should -be $false
     }
 }
 


### PR DESCRIPTION
Complete rework of the `persist` property including backward compatibility.

- [ ] Introduces new `persist`-objects to JSON Schema <sup>subject to change</sup>
  ```json
    "persist": [
        {
            "type": "file",
            "name": "config.dat",
            "content": "[Config]`nlanguage=eng",
            "encoding": "UTF-8",
            "method": "copy"
        },
        {
            "type": "directory",
            "name": "data",
            "method": "link"
        },
        {
            "type": "directory",
            "name": "plugins",
            "method": "merge"
        }
    ]
  ```
- [x] Introduces new functions for Junction and Hardlink handling including Tests
  - Drops `$env:COMSPEC` and `attrib` calls
- [x] Extract old `persist_data` behaviour to `persist_data_old` <sup>subject to change</sup>




- [ ] More tests (more mocking)
- [ ] Implement actual feature :grin: