### PR TITLE
[buckets] Fix regression from bucket folder structure

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -94,7 +94,7 @@ function add_bucket($name, $repo) {
 
 function rm_bucket($name) {
     if (!$name) { "<name> missing"; $usage_rm; exit 1 }
-    $dir = bucketdir $name
+    $dir = "$bucketsdir\$name"
     if (!(test-path $dir)) {
         abort "'$name' bucket not found."
     }


### PR DESCRIPTION
- Closes lukesampson/scoop-extras#1794

Regression from pretty old PR with bucket folder adoption. 

Now only bucket folder is deleted, when removing bucket (due to bucketdir function).