### PR TITLE
Cmake 3.14.0: fix hash

### DIFF
--- a/bucket/cmake.json
+++ b/bucket/cmake.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cmake.org/files/v3.14/cmake-3.14.0-win64-x64.zip",
-            "hash": "42c47c0b378834d1250c8076c39175d21ccf9801f67d7e8662b5edc0b2f4f7a6",
+            "hash": "40e8140d68120378262322bbc8c261db8d184d7838423b2e5bf688a6209d3807",
             "extract_dir": "cmake-3.14.0-win64-x64"
         },
         "32bit": {


### PR DESCRIPTION
#3253 

https://cmake.org/files/v3.14/cmake-3.14.0-SHA-256.txt
```
97f34f3ce6657a65c5232bfc1ecea41c8e7bf084d35ce5a43c58f02b97143771  cmake-3.14.0-Darwin-x86_64.dmg
a02ad0d5b955dfad54c095bd7e937eafbbbfe8a99860107025cc442290a3e903  cmake-3.14.0-Darwin-x86_64.tar.gz
7f3e227cfd9804ee9931490a83cb7029991bc73573ceb1c8ba11714775e8c334  cmake-3.14.0-Linux-x86_64.sh
91dc9af7345e458eb10c853aa875e591efb7079a045641685ddec8d973c2b2bc  cmake-3.14.0-Linux-x86_64.tar.gz
913b231e189824b679b60d9c9d45549bb047866431cd023afbb0b9d10e579279  cmake-3.14.0-win32-x86.msi
9eb42917f9c5dc30ff86d8197497e4f8e2f4455b4c07841aa3dfb3283902d1ee  cmake-3.14.0-win32-x86.zip
2e61b8d41514b36e7d8de455e5201b5a44d36fb33667a5dba5b5fcb656788d44  cmake-3.14.0-win64-x64.msi
40e8140d68120378262322bbc8c261db8d184d7838423b2e5bf688a6209d3807  cmake-3.14.0-win64-x64.zip
685523c50288165ce23c6b580ba9c9ba344e194e3b7cce2ce319700fab28906b  cmake-3.14.0.tar.Z
aa76ba67b3c2af1946701f847073f4652af5cbd9f141f221c97af99127e75502  cmake-3.14.0.tar.gz
dc7d51d172baedcdd5349f514a5c3de504dea67ec3c3b5651f712089a1747bb9  cmake-3.14.0.zip
```