### PR TITLE
nssm: Update to prebuild 2.24-103

### DIFF
--- a/bucket/nssm.json
+++ b/bucket/nssm.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.24",
+    "version": "2.24-103",
     "description": "The Non-Sucking Service Manager.",
     "homepage": "https://nssm.cc/",
     "license": "Public Domain",
-    "url": "https://nssm.cc/release/nssm-2.24.zip",
-    "hash": "sha1:be7b3577c6e3a280e5106a9e9db5b3775931cefc",
+    "url": "https://nssm.cc/ci/nssm-2.24-103-gdee49fc.zip",
+    "hash": "sha1:0722c8a775deb4a1460d1750088916f4f5951773",
     "architecture": {
         "64bit": {
-            "extract_dir": "nssm-2.24\\win64"
+            "extract_dir": "nssm-2.24-103-gdee49fc\\win64"
         },
         "32bit": {
-            "extract_dir": "nssm-2.24\\win32"
+            "extract_dir": "nssm-2.24-103-gdee49fc\\win32"
         }
     },
     "bin": [
@@ -21,21 +21,21 @@
         ]
     ],
     "checkver": {
-        "url": "https://nssm.cc/changelog/",
-        "regex": "Changes since ([\\d\\.]+)"
+        "url": "https://nssm.cc/builds",
+        "regex": "nssm-([\\d.]+-\\d+)-(?<build>.*?).zip"
     },
     "autoupdate": {
-        "url": "https://nssm.cc/release/nssm-$version.zip",
+        "url": "https://nssm.cc/ci/nssm-$version-$matchBuild.zip",
         "hash": {
-            "url": "https://nssm.cc/download/",
-            "regex": "\\[$sha1\\]"
+            "url": "https://nssm.cc/builds",
+            "regex": "$basename.*?$sha1"
         },
         "architecture": {
             "64bit": {
-                "extract_dir": "nssm-$version\\win64"
+                "extract_dir": "nssm-$version-$matchBuild\\win64"
             },
             "32bit": {
-                "extract_dir": "nssm-$version\\win32"
+                "extract_dir": "nssm-$version-$matchBuild\\win32"
             }
         }
     }


### PR DESCRIPTION
From https://nssm.cc/download:

> Windows 10 Creators Update
> 
> 2017-04-26: Users of Windows 10 Creators Update should use prelease build 2.2.4-101 to avoid an issue with services failing to start. If for some reason you cannot use that build you can also set AppNoConsole=1 in the registry, noting that applications which expect a console window may behave unexpectedly.

Since stable release has not been updated for 5 years, and prerelease has not been updated for 2 years, using latest prerelease as stable and changing `nssm.json`'s download url is resonable, I think.