### PR TITLE
install.ps1: Run post_install immediately after installer

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -44,6 +44,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     unpack_inno $fname $manifest $dir
     pre_install $manifest $architecture
     run_installer $fname $manifest $architecture $dir $global
+    post_install $manifest $architecture
     ensure_install_dir_not_in_path $dir $global
     $dir = link_current $dir
     create_shims $manifest $dir $global $architecture
@@ -57,7 +58,6 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     persist_data $manifest $original_dir $persist_dir
     persist_permission $manifest $global
 
-    post_install $manifest $architecture
 
     # save info for uninstall
     save_installed_manifest $app $bucket $dir $url


### PR DESCRIPTION
Now `post_installer` is run after creating shims and shortcuts, that is incomprehensible. The intuitive logic should be `pre_install > run_installer > post_install` and then do some end work likes creating shims, persisting data, etc..