### PR TITLE
`autoupdate.ps1`: Fix `$checksum` to allow BASE64

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -37,7 +37,7 @@ function find_hash_in_textfile([String] $url, [Hashtable] $substitutions, [Strin
         '$sha1' = '([a-fA-F0-9]{40})';
         '$sha256' = '([a-fA-F0-9]{64})';
         '$sha512' = '([a-fA-F0-9]{128})';
-        '$checksum' = '([a-fA-F0-9]{32,128})';
+        '$checksum' = '([a-zA-Z0-9+\/=]{24,128})';
     }
 
     try {

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -37,7 +37,8 @@ function find_hash_in_textfile([String] $url, [Hashtable] $substitutions, [Strin
         '$sha1' = '([a-fA-F0-9]{40})';
         '$sha256' = '([a-fA-F0-9]{64})';
         '$sha512' = '([a-fA-F0-9]{128})';
-        '$checksum' = '([a-zA-Z0-9+\/=]{24,128})';
+        '$checksum' = '([a-fA-F0-9]{32,128})';
+        '$base64' = '([a-zA-Z0-9+\/=]{24,88})';
     }
 
     try {


### PR DESCRIPTION
Enable `$checksum` passthrough BASE64 encoded checksum, e.g. `sha512` of `latest.yml` in many electron released apps (joplin, netron, etc.).

md5:     32 -> 22 + 2
sha1:    40 -> 27 + 1
sha256:  64 -> 43 + 1
sha512: 128 -> 86 + 2