### PR TITLE
Fixed cache copy with aria2 when update

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -336,10 +336,13 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         if(!(test-path $data.$url.source) ) {
             abort $(new_issue_msg $app $bucket "cached file not found")
         }
-        if($use_cache) {
-            Copy-Item $data.$url.source $data.$url.target
-        } else {
-            Move-Item $data.$url.source $data.$url.target -force
+
+        if(!($dir -eq $cachedir)) {
+            if($use_cache) {
+                Copy-Item $data.$url.source $data.$url.target
+            } else {
+                Move-Item $data.$url.source $data.$url.target -force
+            }
         }
     }
 }


### PR DESCRIPTION
When run update with aria2 enabled, a wrong file are stored in cache dir.

If target dir is cachedir, dont copy/move

Current Example: `scoop update busybox -f`

```
// without aria2:
busybox#3025-gc01300361#https_frippery.org_files_busybox_busybox-w64-FRP-3025-gc01300361.exe_busybox.exe

// with aria2:
busybox#3025-gc01300361#https_frippery.org_files_busybox_busybox-w64-FRP-3025-gc01300361.exe_busybox.exe
busybox.exe
```
