### PR TITLE
nunit-console: Fix manifest and add extensions

### DIFF
--- a/bucket/nunit-console.json
+++ b/bucket/nunit-console.json
@@ -3,17 +3,30 @@
     "description": "NUnit Console runner for NUnit, the most popular and widely used unit testing framework for .NET",
     "version": "3.10.0",
     "license": "MIT",
-    "url": "https://github.com/nunit/nunit-console/releases/download/v3.10/NUnit.Console-3.10.0.zip",
-    "hash": "64f4420a90a3ee12c60a13d7162ac52e32b84b704bfd54b9e9d6d4500313d0ac",
+    "url": "https://packages.chocolatey.org/nunit-console-runner.3.10.0.nupkg",
+    "hash": "ffe44c9c1c118c570bc1758293a3a88ac02df1d78b7fbda78aabf200659cda15",
+    "extract_dir": "tools",
+    "post_install": "New-Item -Path \"$dir\\nunit.scoop.addins\" -ItemType File -Value '../../nunit-extension-*/current/     # find extensions installed under scoop' | Out-Null",
     "bin": "nunit3-console.exe",
     "suggest": {
-        "NuGet": "nuget"
+        "NuGet": "nuget",
+        "NUnit Extension": [
+            "nunit-extension-nunit-project-loader",
+            "nunit-extension-nunit-v2-driver",
+            "nunit-extension-nunit-v2-result-writer",
+            "nunit-extension-teamcity-event-listener",
+            "nunit-extension-vs-project-loader"
+        ]
     },
     "checkver": {
-        "github": "https://github.com/nunit/nunit-console/",
-        "regex": "NUnit\\.Console-([\\d\\.]+)\\.zip"
+        "url": "https://chocolatey.org/packages/nunit-console-runner",
+        "regex": "Chocolatey.*?([\\d.]+)\\r"
     },
     "autoupdate": {
-        "url": "https://github.com/nunit/nunit-console/releases/download/v$majorVersion.$minorVersion/NUnit.Console-$version.zip"
+        "url": "https://packages.chocolatey.org/nunit-console-runner.$version.nupkg",
+        "hash": {
+            "url": "https://chocolatey.org/packages/nunit-console-runner",
+            "regex": "$sha256.*?$basename"
+        }
     }
 }

--- a/bucket/nunit-extension-nunit-project-loader.json
+++ b/bucket/nunit-extension-nunit-project-loader.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://nunit.org/",
+    "description": "NUnit Project Loader Extension",
+    "version": "3.6.0",
+    "license": "MIT",
+    "url": "https://packages.chocolatey.org/nunit-extension-nunit-project-loader.3.6.0.nupkg",
+    "hash": "521c80333844358fcb8cd9896464f87a31dd20dfa4998d1bb6f881e855753dc5",
+    "extract_dir": "tools",
+    "depends": "nunit-console",
+    "checkver": {
+        "url": "https://chocolatey.org/packages/nunit-extension-nunit-project-loader",
+        "regex": "Chocolatey.*?([\\d.]+)\\r"
+    },
+    "autoupdate": {
+        "url": "https://packages.chocolatey.org/nunit-extension-nunit-project-loader.$version.nupkg",
+        "hash": {
+            "url": "https://chocolatey.org/packages/nunit-extension-nunit-project-loader",
+            "regex": "$sha256.*?$basename"
+        }
+    }
+}

--- a/bucket/nunit-extension-nunit-v2-driver.json
+++ b/bucket/nunit-extension-nunit-v2-driver.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://nunit.org/",
+    "description": "NUnit V2 Framework Driver Extension",
+    "version": "3.7.0",
+    "license": "MIT",
+    "url": "https://packages.chocolatey.org/nunit-extension-nunit-v2-driver.3.7.0.nupkg",
+    "hash": "3cd3d4a16f5a304eaf8090221bcc8edc867f6f1ff3ee7bb2d2376afeb2e9512e",
+    "extract_dir": "tools",
+    "depends": "nunit-console",
+    "checkver": {
+        "url": "https://chocolatey.org/packages/nunit-extension-nunit-v2-driver",
+        "regex": "Chocolatey.*?([\\d.]+)\\r"
+    },
+    "autoupdate": {
+        "url": "https://packages.chocolatey.org/nunit-extension-nunit-v2-driver.$version.nupkg",
+        "hash": {
+            "url": "https://chocolatey.org/packages/nunit-extension-nunit-v2-driver",
+            "regex": "$sha256.*?$basename"
+        }
+    }
+}

--- a/bucket/nunit-extension-nunit-v2-result-writer.json
+++ b/bucket/nunit-extension-nunit-v2-result-writer.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://nunit.org/",
+    "description": "NUnit V2 Result Writer Extension",
+    "version": "3.6.0",
+    "license": "MIT",
+    "url": "https://packages.chocolatey.org/nunit-extension-nunit-v2-result-writer.3.6.0.nupkg",
+    "hash": "9e3526f9b272ab22802c300b8640f34cec29cb9466db785477b414e3f688b16d",
+    "extract_dir": "tools",
+    "depends": "nunit-console",
+    "checkver": {
+        "url": "https://chocolatey.org/packages/nunit-extension-nunit-v2-result-writer",
+        "regex": "Chocolatey.*?([\\d.]+)\\r"
+    },
+    "autoupdate": {
+        "url": "https://packages.chocolatey.org/nunit-extension-nunit-v2-result-writer.$version.nupkg",
+        "hash": {
+            "url": "https://chocolatey.org/packages/nunit-extension-nunit-v2-result-writer",
+            "regex": "$sha256.*?$basename"
+        }
+    }
+}

--- a/bucket/nunit-extension-teamcity-event-listener.json
+++ b/bucket/nunit-extension-teamcity-event-listener.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://nunit.org/",
+    "description": "NUnit Team City Event Listener Extension",
+    "version": "1.0.6",
+    "license": "MIT",
+    "url": "https://packages.chocolatey.org/nunit-extension-teamcity-event-listener.1.0.6.nupkg",
+    "hash": "8ddea8d7d7c86806b8b0dafbfaaab322a6152ff02bd25280488e0a81233c859e",
+    "extract_dir": "tools",
+    "depends": "nunit-console",
+    "checkver": {
+        "url": "https://chocolatey.org/packages/nunit-extension-teamcity-event-listener",
+        "regex": "Chocolatey.*?([\\d.]+)\\r"
+    },
+    "autoupdate": {
+        "url": "https://packages.chocolatey.org/nunit-extension-teamcity-event-listener.$version.nupkg",
+        "hash": {
+            "url": "https://chocolatey.org/packages/nunit-extension-teamcity-event-listener",
+            "regex": "$sha256.*?$basename"
+        }
+    }
+}

--- a/bucket/nunit-extension-vs-project-loader.json
+++ b/bucket/nunit-extension-vs-project-loader.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://nunit.org/",
+    "description": "NUnit Visual Studio Project Loader Extension",
+    "version": "3.8.0",
+    "license": "MIT",
+    "url": "https://packages.chocolatey.org/nunit-extension-vs-project-loader.3.8.0.nupkg",
+    "hash": "ed024f0c6695951babb015ce7eee601cfca68f40512ec95ac4fe07dc08e27f0a",
+    "extract_dir": "tools",
+    "depends": "nunit-console",
+    "checkver": {
+        "url": "https://chocolatey.org/packages/nunit-extension-vs-project-loader",
+        "regex": "Chocolatey.*?([\\d.]+)\\r"
+    },
+    "autoupdate": {
+        "url": "https://packages.chocolatey.org/nunit-extension-vs-project-loader.$version.nupkg",
+        "hash": {
+            "url": "https://chocolatey.org/packages/nunit-extension-vs-project-loader",
+            "regex": "$sha256.*?$basename"
+        }
+    }
+}


### PR DESCRIPTION
Close #3304 

Add seperated extensions, and after installation, NUnit Console Runner could find them automatically.