### PR TITLE
scoop-status: Add bucket and global info to status output

### DIFF
--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -44,6 +44,7 @@ $true, $false | ForEach-Object { # local and global apps
     Get-ChildItem $dir | Where-Object name -ne 'scoop' | ForEach-Object {
         $app = $_.name
         $status = app_status $app $global
+        $install_info = install_info $app $status.version $global
         if($status.failed) {
             $failed += @{ $app = $status.version }
         }
@@ -51,7 +52,7 @@ $true, $false | ForEach-Object { # local and global apps
             $removed += @{ $app = $status.version }
         }
         if($status.outdated) {
-            $outdated += @{ $app = @($status.version, $status.latest_version) }
+            $outdated += @{ $app = @($status.version, $status.latest_version, $install_info.bucket, $global) }
         }
         if($status.missing_deps) {
             $missing_deps += ,(@($app) + @($status.missing_deps))
@@ -63,7 +64,10 @@ if($outdated) {
     write-host -f DarkCyan 'Updates are available for:'
     $outdated.keys | ForEach-Object {
         $versions = $outdated.$_
-        "    $_`: $($versions[0]) -> $($versions[1])"
+        write-host "    $_`: $($versions[0]) -> $($versions[1])" -NoNewline
+        if($versions[2]) { write-host -f Yellow " [$($versions[2])]" -NoNewline }
+        if($versions[3]) { write-host -f DarkGreen ' *global*' -NoNewline }
+        write-host ''
     }
 }
 


### PR DESCRIPTION
This will add bucket and global info to status output, like `scoop list`.

- Before:

```
PS C:\Users\USERNAME> scoop status
Scoop is up to date.
Updates are available for:
    explzh.ja: 7.67 -> 7.78
    go: 1.12.3 -> 1.12.4
    pleiades4.8-java-win-full: 4.8.0.v20180627 -> 4.8.0.v20180923
    jetbrains-toolbox: 1.14.5037 -> 1.14.5179
    keepassxc: 2.4.0 -> 2.4.1
```

- After:

```
PS C:\Users\USERNAME> scoop status
Scoop is up to date.
Updates are available for:
    explzh.ja: 7.67 -> 7.78 [jfut] *global*
    go: 1.12.3 -> 1.12.4 *global*
    pleiades4.8-java-win-full: 4.8.0.v20180627 -> 4.8.0.v20180923 [pleiades] *global*
    jetbrains-toolbox: 1.14.5037 -> 1.14.5179
    keepassxc: 2.4.0 -> 2.4.1 [extras]
```
