### PR TITLE
[Regression] Fix search after buckets optimize

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -47,7 +47,7 @@ function Get-LocalBucket {
         List all local buckets.
     #>
 
-    return (Get-ChildItem $bucketsdir).Name
+    return (Get-ChildItem $bucketsdir -ErrorAction SilentlyContinue).Name
 }
 
 function buckets {

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -97,7 +97,10 @@ function search_remotes($query) {
     }
 }
 
-@($null) + @(Get-LocalBucket) | ForEach-Object { # $null is main bucket
+$buckets = Get-LocalBucket
+if ($buckets) { $buckets += $null } # $null is main bucket
+
+$buckets | ForEach-Object {
     $res = search_bucket $_ $query
     $local_results = $local_results -or $res
     if($res) {


### PR DESCRIPTION
- Closes #3349 

![image](https://user-images.githubusercontent.com/13260377/56473815-ed306f80-6470-11e9-913e-7312d20b4390.png)

`Get-LocalBucket` will return $null if folder does not exists, or is empty. So if this function return something, add $null for main. With actual implementaion there was two runs of main bucket when empty `@($null) + @($null)`