### PR TITLE
rustup: Update to version 1.18.0

### DIFF
--- a/bucket/rustup.json
+++ b/bucket/rustup.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.17.0",
+    "version": "1.18.0",
     "license": "MIT",
-    "hash": "e6a7dd25ab1620827d0848840ee7347248f3f88fc91b2d1e9359700853d5c3fe",
+    "hash": "45f9adcf71cf40983afab6bcb79f6bbdcee02ade696af5574fbaf3aa55e2382e",
     "homepage": "https://github.com/rust-lang-nursery/rustup.rs",
     "checkver": {
         "url": "https://raw.githubusercontent.com/rust-lang-nursery/rustup.rs/master/Cargo.toml",
@@ -30,5 +30,5 @@
             "& \"$dir\\rustup-init.exe\" -y --no-modify-path --default-toolchain stable-gnu"
         ]
     },
-    "notes": "To use the MSVC ABI without Visual Studio 2015 (or higher) installed, you will need the Visual Studio 2017 Build Tools: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017"
+    "notes": "To use the MSVC ABI without Visual Studio 2015 (or higher) installed, you will need the Visual Studio 2019 Build Tools: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019"
 }


### PR DESCRIPTION
Changed the Visual Studio Build Tools version number to 2019 according to rustup install instructions