### PR TITLE
imagemagick: Update to version 7.0.8-42

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.imagemagick.org/script/index.php",
     "license": "ImageMagick",
-    "version": "7.0.8-41",
+    "version": "7.0.8-42",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-41-portable-Q16-x64.zip",
-            "hash": "0bcf6544373757cb6d8079c8ac27876a711ed090706424b4a60e5783f8e46407"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-42-portable-Q16-x64.zip",
+            "hash": "584e069f56456ce7dde40220948ff9568ac810688c892c5dfb7f6db902aa05aa"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-41-portable-Q16-x86.zip",
-            "hash": "e2b279ef46b4a6f28ef8e31e645f138adad6f299b7bf3f9c26a621b30e59d3bf"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-42-portable-Q16-x86.zip",
+            "hash": "22dacd95afb32ab817713585b327d218baef517c95447a48506cec6dc02b0b00"
         }
     },
     "depends": "ffmpeg",


### PR DESCRIPTION
Updates to latest version.
Fixes error:
```
The remote server returned an error: (404) Not Found.
URL https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-41-portable-Q16-x64.zip is not valid
```
when trying to install