### PR TITLE
chore: add notification for new main bucket

### DIFF
--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -105,6 +105,7 @@ function update_scoop() {
     }
 
     if ((Get-LocalBucket) -notcontains 'main') {
+        Write-Host "The main bucket of Scoop has been separated to 'https://github.com/scoopinstaller/scoop-main', adding main bucket..." -f DarkYellow
         add_bucket 'main'
     }
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -105,7 +105,8 @@ function update_scoop() {
     }
 
     if ((Get-LocalBucket) -notcontains 'main') {
-        Write-Host "The main bucket of Scoop has been separated to 'https://github.com/scoopinstaller/scoop-main', adding main bucket..." -f DarkYellow
+        info "The main bucket of Scoop has been separated to 'https://github.com/scoopinstaller/scoop-main'"
+        info "Adding main bucket..."
         add_bucket 'main'
     }
 


### PR DESCRIPTION
Add notification.

```
$ scoop update
Updating Scoop...
Checking repo... ok
The main bucket was added successfully.
Updating 'dorado' bucket...
Updating 'extras' bucket...
Updating 'java' bucket...
Updating 'main' bucket...
Updating 'versions' bucket...
```

```
$ scoop update
Updating Scoop...
The main bucket of Scoop has been separated to 'https://github.com/scoopinstaller/scoop-main'
Adding main bucket...
Checking repo... ok
The main bucket was added successfully.
Updating 'dorado' bucket...
Updating 'extras' bucket...
Updating 'java' bucket...
Updating 'main' bucket...
Updating 'versions' bucket...
```