### PR TITLE
Corrected imagemagick version -- updated to version 7.0.8-42

### DIFF
--- a/bucket/imagemagick.json
+++ b/bucket/imagemagick.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.imagemagick.org/script/index.php",
     "license": "ImageMagick",
-    "version": "7.0.8-41",
+    "version": "7.0.8-42",
     "architecture": {
         "64bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-41-portable-Q16-x64.zip",
-            "hash": "0bcf6544373757cb6d8079c8ac27876a711ed090706424b4a60e5783f8e46407"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-42-portable-Q16-x64.zip",
+            "hash": "584e069f56456ce7dde40220948ff9568ac810688c892c5dfb7f6db902aa05aa"
         },
         "32bit": {
-            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-41-portable-Q16-x86.zip",
-            "hash": "e2b279ef46b4a6f28ef8e31e645f138adad6f299b7bf3f9c26a621b30e59d3bf"
+            "url": "https://www.imagemagick.org/download/binaries/ImageMagick-7.0.8-42-portable-Q16-x86.zip",
+            "hash": "22dacd95afb32ab817713585b327d218baef517c95447a48506cec6dc02b0b00"
         }
     },
     "depends": "ffmpeg",

--- a/bucket/wget.json
+++ b/bucket/wget.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "https://eternallybored.org/misc/wget/releases/wget-1.20.3-win64.zip",
-            "hash": "9dea6d658ab14a77958233a116a86bc2f5adb1feb425848d58f918d354bdd1ea"
+            "hash": "7EF40A647A153ACCBFB8CD79B3D9E3BF8AC1BAB95B704176E3172589285A13DE"
         },
         "32bit": {
             "url": "https://eternallybored.org/misc/wget/releases/wget-1.20.3-win32.zip",
-            "hash": "4ac00c798d9ef6a394a0442607e0961de75bc6abf8fa36dbdea381eb0e93a0ab"
+            "hash": "021F547BACA74FCA939D50951CE967502D160A7502F02FAB706F9293E1475FB8"
         }
     },
     "bin": "wget.exe",


### PR DESCRIPTION
My imagemagick update failed. The manifest points to a non-existent release version. Ran the auto-update script and fixed it. 