### PR TITLE
decompress(tests): Improve installation of lessmsi and innounp

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,39 +1,38 @@
 version: "{build}-{branch}"
-
 branches:
   except:
     - gh-pages
-
 build: off
 deploy: off
 clone_depth: 49
-
 image:
-- Visual Studio 2017
-
+  - Visual Studio 2017
 environment:
+  scoop: C:\projects\scoop
+  scoop_home: C:\projects\scoop
+  scoop_helpers: C:\projects\helpers
+  lessmsi: '%scoop_helpers%\lessmsi\lessmsi.exe'
+  innounp: '%scoop_helpers%\innounp\innounp.exe'
   matrix:
     - PowerShell: 5
     - PowerShell: 6
-
 cache:
-  - '%USERPROFILE%\Documents\WindowsPowerShell\Modules -> appveyor.yml'
-
+  - '%USERPROFILE%\Documents\WindowsPowerShell\Modules -> appveyor.yml, test\bin\*.ps1'
+  - C:\projects\helpers  -> appveyor.yml, test\bin\*.ps1
 matrix:
   fast_finish: true
-
 for:
-- matrix:
-    only:
-      - PowerShell: 5
-  install:
-    - ps: .\test\bin\init.ps1
-  test_script:
-    - ps: .\test\bin\test.ps1
-- matrix:
-    only:
-      - PowerShell: 6
-  install:
-    - pwsh: .\test\bin\init.ps1
-  test_script:
-    - pwsh: .\test\bin\test.ps1
+  - matrix:
+      only:
+        - PowerShell: 5
+    install:
+      - ps: . "$env:SCOOP_HOME\test\bin\init.ps1"
+    test_script:
+      - ps: . "$env:SCOOP_HOME\test\bin\test.ps1" -TestPath "$env:APPVEYOR_BUILD_FOLDER"
+  - matrix:
+      only:
+        - PowerShell: 6
+    install:
+      - pwsh: . "$env:SCOOP_HOME\test\bin\init.ps1"
+    test_script:
+      - pwsh: . "$env:SCOOP_HOME\test\bin\test.ps1" -TestPath "$env:APPVEYOR_BUILD_FOLDER"

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -7,19 +7,6 @@
 
 $isUnix = is_unix
 
-function install_app_ci($app, $architecture) {
-    if(installed $app) {
-        return
-    }
-
-    $manifest = manifest $app
-    $version = $manifest.version
-    $dir = ensure (versiondir $app $version)
-    $fname = dl_urls $app $version $manifest $null $architecture $dir
-    $dir = link_current $dir
-    success "'$app' ($version) was installed successfully!"
-}
-
 function test_extract($extract_fn, $from, $removal) {
     $to = (strip_ext $from) -replace '\.tar$', ''
     & $extract_fn ($from -replace '/', '\') ($to -replace '/', '\') -Removal:$removal
@@ -43,8 +30,10 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context "7zip extraction" {
 
         BeforeAll {
-            if (!$isUnix) {
-                install_app_ci 7zip 64bit
+            if($env:CI) {
+                mock file_path { (Get-Command 7z.exe).Path }
+            } elseif(!(installed 7zip)) {
+                scoop install 7zip
             }
             $test1 = "$working_dir\7ZipTest1.7z"
             $test2 = "$working_dir\7ZipTest2.tgz"
@@ -90,8 +79,10 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context "msi extraction" {
 
         BeforeAll {
-            if (!$isUnix) {
-                install_app_ci lessmsi
+            if($env:CI) {
+                mock file_path { $env:lessmsi }
+            } elseif(!(installed lessmsi)) {
+                scoop install lessmsi
             }
             $test1 = "$working_dir\MSITest.msi"
             $test2 = "$working_dir\MSITestNull.msi"
@@ -122,8 +113,10 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
     Context "inno extraction" {
 
         BeforeAll {
-            if (!$isUnix) {
-                install_app_ci innounp
+            if($env:CI) {
+                mock file_path { $env:innounp }
+            } elseif(!(installed innounp)) {
+                scoop install innounp
             }
             $test = "$working_dir\InnoTest.exe"
         }

--- a/test/bin/init.ps1
+++ b/test/bin/init.ps1
@@ -1,8 +1,22 @@
 Write-Host "PowerShell: $($PSVersionTable.PSVersion)"
-
+(7z.exe | Select-String -Pattern '7-Zip').ToString()
 Write-Host "Install dependencies ..."
 Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name Pester -SkipPublisherCheck
 Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name PSScriptAnalyzer,BuildHelpers
+
+if ($env:CI_WINDOWS -eq $true) {
+    if(!(Test-Path $env:SCOOP_HELPERS)) {
+        New-Item -ItemType Directory -Path $env:SCOOP_HELPERS
+    }
+    if(!(Test-Path "$env:SCOOP_HELPERS\lessmsi\lessmsi.exe")) {
+        Start-FileDownload 'https://github.com/activescott/lessmsi/releases/download/v1.6.3/lessmsi-v1.6.3.zip' -FileName "$env:SCOOP_HELPERS\lessmsi.zip"
+        & 7z.exe x "$env:SCOOP_HELPERS\lessmsi.zip" -o"$env:SCOOP_HELPERS\lessmsi" -y
+    }
+    if(!(Test-Path "$env:SCOOP_HELPERS\innounp\innounp.exe")) {
+        Start-FileDownload 'https://raw.githubusercontent.com/scoopinstaller/binary-mirror/master/innounp/innounp048.rar' -FileName "$env:SCOOP_HELPERS\innounp.rar"
+        & 7z.exe x "$env:SCOOP_HELPERS\innounp.rar" -o"$env:SCOOP_HELPERS\innounp" -y
+    }
+}
 
 if($env:CI -eq $true) {
     Write-Host "Load 'BuildHelpers' environment variables ..."

--- a/test/bin/test.ps1
+++ b/test/bin/test.ps1
@@ -38,6 +38,11 @@ if ($env:CI -eq $true) {
         $excludes += 'Decompress'
     }
 
+    if ($env:CI_WINDOWS -ne $true) {
+        Write-Warning "Skipping tests and code linting for decompress.ps1 because they only work on Windows"
+        $excludes += 'Decompress'
+    }
+
     if ($commitMessage -match '!manifests') {
         Write-Warning "Skipping manifest validation per commit flag '!manifests'"
         $excludes += 'Manifests'


### PR DESCRIPTION
- Download `innounp` and `lessmsi` via PowerShell instead of using Scoop
  - `7zip` is already available on AppVeyor images
  - Doesn't require the main bucket to be added
- Install `innounp`/`lessmsi`/`7zip` if `$env:CI` is false and program is not installed
- Mock `file_path` to return correct path to helper programs
- Add Scoop environment variables `SCOOP` and `SCOOP_HOME`
- Remove newlines from `appveyor.yml`