### PR TITLE
Refactor function names and fix installing 7zip locally if already globally available

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -169,13 +169,13 @@ function Get-AppFilePath {
 
     # normal path to file
     $Path = "$(versiondir $App 'current' $false)\$File"
-    if(Test-Path($Path)) {
+    if(Test-Path $Path) {
         return $Path
     }
 
     # global path to file
     $Path = "$(versiondir $App 'current' $true)\$File"
-    if(Test-Path($Path)) {
+    if(Test-Path $Path) {
         return $Path
     }
 
@@ -220,7 +220,7 @@ function Test-HelperInstalled {
     return ![String]::IsNullOrWhiteSpace((Get-HelperPath -Helper $Helper))
 }
 
-function Test-Aria2Enabled() {
+function Test-Aria2Enabled {
     return (Test-HelperInstalled -Helper Aria2) -and (get_config 'aria2-enabled' $true)
 }
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -183,6 +183,22 @@ function Test-7zipInstalled() {
     return ![String]::IsNullOrWhiteSpace("$(Get-7zipPath)")
 }
 
+function Get-LessmsiPath() {
+    return (file_path 'lessmsi' 'lessmsi.exe')
+}
+
+function Test-LessmsiInstalled() {
+    return ![String]::IsNullOrWhiteSpace("$(Get-LessmsiPath)")
+}
+
+function Get-InnounpPath() {
+    return (file_path 'innounp' 'innounp.exe')
+}
+
+function Test-InnounpInstalled() {
+    return ![String]::IsNullOrWhiteSpace("$(Get-InnounpPath)")
+}
+
 function Get-Aria2Path() {
     return (file_path 'aria2' 'aria2c.exe')
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -175,12 +175,12 @@ Function Test-CommandAvailable {
     Return [Boolean](Get-Command $Name -ErrorAction Ignore)
 }
 
-function 7zip_path() {
+function Get-7zipPath() {
     return (file_path '7zip' '7z.exe')
 }
 
-function 7zip_installed() {
-    return ![String]::IsNullOrWhiteSpace("$(7zip_path)")
+function Test-7zipInstalled() {
+    return ![String]::IsNullOrWhiteSpace("$(Get-7zipPath)")
 }
 
 function aria2_path() {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -183,16 +183,16 @@ function Test-7zipInstalled() {
     return ![String]::IsNullOrWhiteSpace("$(Get-7zipPath)")
 }
 
-function aria2_path() {
+function Get-Aria2Path() {
     return (file_path 'aria2' 'aria2c.exe')
 }
 
-function aria2_installed() {
-    return ![String]::IsNullOrWhiteSpace("$(aria2_path)")
+function Test-Aria2Installed() {
+    return ![String]::IsNullOrWhiteSpace("$(Get-Aria2Path)")
 }
 
-function aria2_enabled() {
-    return (aria2_installed) -and (get_config 'aria2-enabled' $true)
+function Test-Aria2Enabled() {
+    return (Test-Aria2Installed) -and (get_config 'aria2-enabled' $true)
 }
 
 function app_status($app, $global) {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -152,16 +152,31 @@ function installed_apps($global) {
 }
 
 function file_path($app, $file) {
+    Show-DeprecatedWarning $MyInvocation 'Get-AppFilePath'
+    Get-AppFilePath -App $app -File $file
+}
+
+function Get-AppFilePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [String]
+        $App,
+        [Parameter(Mandatory = $true, Position = 1)]
+        [String]
+        $File
+    )
+
     # normal path to file
-    $path = "$(versiondir $app 'current' $false)\$file"
-    if(Test-Path($path)) {
-        return $path
+    $Path = "$(versiondir $App 'current' $false)\$File"
+    if(Test-Path($Path)) {
+        return $Path
     }
 
     # global path to file
-    $path = "$(versiondir $app 'current' $true)\$file"
-    if(Test-Path($path)) {
-        return $path
+    $Path = "$(versiondir $App 'current' $true)\$File"
+    if(Test-Path($Path)) {
+        return $Path
     }
 
     # not found

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -190,40 +190,38 @@ Function Test-CommandAvailable {
     Return [Boolean](Get-Command $Name -ErrorAction Ignore)
 }
 
-function Get-7zipPath() {
-    return (file_path '7zip' '7z.exe')
+function Get-HelperPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [ValidateSet('7zip', 'Lessmsi', 'Innounp', 'Dark', 'Aria2')]
+        [String]
+        $Helper
+    )
+
+    switch ($Helper) {
+        '7zip' { Get-AppFilePath '7zip' '7z.exe' }
+        'Lessmsi' { Get-AppFilePath 'lessmsi' 'lessmsi.exe' }
+        'Innounp' { Get-AppFilePath 'innounp' 'innounp.exe' }
+        'Dark' { Get-AppFilePath 'dark' 'dark.exe' }
+        'Aria2' { Get-AppFilePath 'aria2' 'aria2c.exe' }
+    }
 }
 
-function Test-7zipInstalled() {
-    return ![String]::IsNullOrWhiteSpace("$(Get-7zipPath)")
-}
+function Test-HelperInstalled {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [ValidateSet('7zip', 'Lessmsi', 'Innounp', 'Dark', 'Aria2')]
+        [String]
+        $Helper
+    )
 
-function Get-LessmsiPath() {
-    return (file_path 'lessmsi' 'lessmsi.exe')
-}
-
-function Test-LessmsiInstalled() {
-    return ![String]::IsNullOrWhiteSpace("$(Get-LessmsiPath)")
-}
-
-function Get-InnounpPath() {
-    return (file_path 'innounp' 'innounp.exe')
-}
-
-function Test-InnounpInstalled() {
-    return ![String]::IsNullOrWhiteSpace("$(Get-InnounpPath)")
-}
-
-function Get-Aria2Path() {
-    return (file_path 'aria2' 'aria2c.exe')
-}
-
-function Test-Aria2Installed() {
-    return ![String]::IsNullOrWhiteSpace("$(Get-Aria2Path)")
+    return ![String]::IsNullOrWhiteSpace((Get-HelperPath -Helper $Helper))
 }
 
 function Test-Aria2Enabled() {
-    return (Test-Aria2Installed) -and (get_config 'aria2-enabled' $true)
+    return (Test-HelperInstalled -Helper Aria2) -and (get_config 'aria2-enabled' $true)
 }
 
 function app_status($app, $global) {

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -202,8 +202,8 @@ function Expand-ZipArchive {
 }
 
 function extract_7zip($path, $to, $removal) {
-    Expand-7zipArchive -Path $path -DestinationPath $to -Removal:$removal @args
     Show-DeprecatedWarning $MyInvocation 'Expand-7zipArchive'
+    Expand-7zipArchive -Path $path -DestinationPath $to -Removal:$removal @args
 }
 
 function extract_msi($path, $to, $removal) {

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -66,7 +66,7 @@ function Expand-7zipArchive {
             abort "Cannot find external 7-Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7-Zip manually and try again."
         }
     } else {
-        &(file_path 7zip 7z.exe) x "$Path" -o"$DestinationPath" (-split $Switches) -y | Out-File $LogLocation
+        & (Get-7zipPath) x "$Path" -o"$DestinationPath" (-split $Switches) -y | Out-File $LogLocation
     }
     if ($LASTEXITCODE -ne 0) {
         abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
@@ -76,7 +76,7 @@ function Expand-7zipArchive {
     }
     if ((strip_ext $Path) -match '\.tar$' -or $Path -match '\.tgz$') {
         # Check for tar
-        $ArchivedFile = &(file_path 7zip 7z.exe) l "$Path"
+        $ArchivedFile = & (Get-7zipPath) l "$Path"
         if ($LASTEXITCODE -eq 0) {
             $TarFile = $ArchivedFile[-3] -replace '.{53}(.*)', '$1' # get inner tar file name
             Expand-7zipArchive "$DestinationPath\$TarFile" $DestinationPath -Removal
@@ -104,7 +104,7 @@ function Expand-MsiArchive {
     )
     $LogLocation = "$(Split-Path $Path)\msi.log"
     if ((get_config MSIEXTRACT_USE_LESSMSI)) {
-        &(file_path lessmsi lessmsi.exe) x "$Path" "$DestinationPath\" | Out-File $LogLocation
+        & (Get-LessmsiPath) x "$Path" "$DestinationPath\" | Out-File $LogLocation
         if ($LASTEXITCODE -ne 0) {
             abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
         }
@@ -143,7 +143,7 @@ function Expand-InnoArchive {
         $Removal
     )
     $LogLocation = "$(Split-Path $Path)\innounp.log"
-    &(file_path innounp innounp.exe) -x -d"$DestinationPath" -c'{app}' "$Path" (-split $Switches) -y | Out-File $LogLocation
+    & (Get-InnounpPath) -x -d"$DestinationPath" -c'{app}' "$Path" (-split $Switches) -y | Out-File $LogLocation
     if ($LASTEXITCODE -ne 0) {
         abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
     }

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -1,4 +1,4 @@
-function Test-7ZipRequirement {
+function Test-7zipRequirement {
     [CmdletBinding(DefaultParameterSetName = "URL")]
     [OutputType([Boolean])]
     param(
@@ -13,14 +13,14 @@ function Test-7ZipRequirement {
         if ((get_config 7ZIPEXTRACT_USE_EXTERNAL)) {
             return $false
         } else {
-            return ($URL | Where-Object { Test-7ZipRequirement -File $_ }).Count -gt 0
+            return ($URL | Where-Object { Test-7zipRequirement -File $_ }).Count -gt 0
         }
     } else {
         return $File -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(bz2)|(7z)|(rar)|(iso)|(xz)|(lzh)|(nupkg))$'
     }
 }
 
-function Test-LessMSIRequirement {
+function Test-LessmsiRequirement {
     [CmdletBinding()]
     [OutputType([Boolean])]
     param(
@@ -35,7 +35,7 @@ function Test-LessMSIRequirement {
     }
 }
 
-function Expand-7ZipArchive {
+function Expand-7zipArchive {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
@@ -63,7 +63,7 @@ function Expand-7ZipArchive {
         try {
             7z x "$Path" -o"$DestinationPath" (-split $Switches) -y | Out-File $LogLocation
         } catch [System.Management.Automation.CommandNotFoundException] {
-            abort "Cannot find external 7Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7Zip manually and try again."
+            abort "Cannot find external 7-Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7-Zip manually and try again."
         }
     } else {
         &(file_path 7zip 7z.exe) x "$Path" -o"$DestinationPath" (-split $Switches) -y | Out-File $LogLocation
@@ -79,9 +79,9 @@ function Expand-7ZipArchive {
         $ArchivedFile = &(file_path 7zip 7z.exe) l "$Path"
         if ($LASTEXITCODE -eq 0) {
             $TarFile = $ArchivedFile[-3] -replace '.{53}(.*)', '$1' # get inner tar file name
-            Expand-7ZipArchive "$DestinationPath\$TarFile" $DestinationPath -Removal
+            Expand-7zipArchive "$DestinationPath\$TarFile" $DestinationPath -Removal
         } else {
-            abort "Failed to list files in $Path.`nNot a 7Zip supported archive file."
+            abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."
         }
     }
     if ($Removal) {
@@ -90,7 +90,7 @@ function Expand-7ZipArchive {
     }
 }
 
-function Expand-MSIArchive {
+function Expand-MsiArchive {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
@@ -175,15 +175,15 @@ function Expand-ZipArchive {
             [System.IO.Compression.ZipFile]::ExtractToDirectory($Path, $DestinationPath)
         } catch [System.IO.PathTooLongException] {
             # try to fall back to 7zip if path is too long
-            if (7zip_installed) {
-                Expand-7ZipArchive $Path $DestinationPath -Removal
+            if (Test-7zipInstalled) {
+                Expand-7zipArchive $Path $DestinationPath -Removal
                 return
             } else {
                 abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
             }
         } catch [System.IO.IOException] {
-            if (7zip_installed) {
-                Expand-7ZipArchive $Path $DestinationPath -Removal
+            if (Test-7zipInstalled) {
+                Expand-7zipArchive $Path $DestinationPath -Removal
                 return
             } else {
                 abort "Unzip failed: Windows can't handle the file names in this zip file.`nRun 'scoop install 7zip' and try again."
@@ -202,13 +202,13 @@ function Expand-ZipArchive {
 }
 
 function extract_7zip($path, $to, $removal) {
-    Show-DeprecatedWarning $MyInvocation 'Expand-7ZipArchive'
-    Expand-7ZipArchive -Path $path -DestinationPath $to -Removal:$removal @args
+    Expand-7zipArchive -Path $path -DestinationPath $to -Removal:$removal @args
+    Show-DeprecatedWarning $MyInvocation 'Expand-7zipArchive'
 }
 
 function extract_msi($path, $to, $removal) {
-    Show-DeprecatedWarning $MyInvocation 'Expand-MSIArchive'
-    Expand-MSIArchive -Path $path -DestinationPath $to -Removal:$removal
+    Show-DeprecatedWarning $MyInvocation 'Expand-MsiArchive'
+    Expand-MsiArchive -Path $path -DestinationPath $to -Removal:$removal
 }
 
 function unpack_inno($path, $to, $removal) {

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -52,13 +52,13 @@ function runtime_deps($manifest) {
 function install_deps($manifest, $arch) {
     $deps = @()
 
-    if (!(Test-7zipInstalled) -and (Test-7zipRequirement -URL (url $manifest $arch))) {
+    if (!(Test-HelperInstalled -Helper 7zip) -and (Test-7zipRequirement -URL (url $manifest $arch))) {
         $deps += '7zip'
     }
-    if (!(Test-LessmsiInstalled) -and (Test-LessmsiRequirement -URL (url $manifest $arch))) {
+    if (!(Test-HelperInstalled -Helper Lessmsi) -and (Test-LessmsiRequirement -URL (url $manifest $arch))) {
         $deps += 'lessmsi'
     }
-    if (!(Test-InnounpInstalled) -and $manifest.innosetup) {
+    if (!(Test-HelperInstalled -Helper Innounp) -and $manifest.innosetup) {
         $deps += 'innounp'
     }
 

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -52,9 +52,15 @@ function runtime_deps($manifest) {
 function install_deps($manifest, $arch) {
     $deps = @()
 
-    if (Test-7zipRequirement -URL (url $manifest $arch)) { $deps += '7zip'}
-    if (Test-LessmsiRequirement -URL (url $manifest $arch)) { $deps += 'lessmsi' }
-    if ($manifest.innosetup) { $deps += 'innounp' }
+    if (!(Test-7zipInstalled) -and (Test-7zipRequirement -URL (url $manifest $arch))) {
+        $deps += '7zip'
+    }
+    if (!(Test-LessmsiInstalled) -and (Test-LessmsiRequirement -URL (url $manifest $arch))) {
+        $deps += 'lessmsi'
+    }
+    if (!(Test-InnounpInstalled) -and $manifest.innosetup) {
+        $deps += 'innounp'
+    }
 
     return $deps
 }

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -52,8 +52,8 @@ function runtime_deps($manifest) {
 function install_deps($manifest, $arch) {
     $deps = @()
 
-    if (Test-7ZipRequirement -URL (url $manifest $arch)) { $deps += '7zip' }
-    if (Test-LessMSIRequirement -URL (url $manifest $arch)) { $deps += 'lessmsi' }
+    if (Test-7zipRequirement -URL (url $manifest $arch)) { $deps += '7zip'}
+    if (Test-LessmsiRequirement -URL (url $manifest $arch)) { $deps += 'lessmsi' }
     if ($manifest.innosetup) { $deps += 'innounp' }
 
     return $deps

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -278,7 +278,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         Set-Content -Path $urlstxt $urlstxt_content
 
         # build aria2 command
-        $aria2 = "& '$(aria2_path)' $($options -join ' ')"
+        $aria2 = "& '$(Get-Aria2Path)' $($options -join ' ')"
 
         # handle aria2 console output
         Write-Host "Starting download with aria2 ..."
@@ -496,7 +496,7 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
     $extracted = 0;
 
     # download first
-    if(aria2_enabled) {
+    if(Test-Aria2Enabled) {
         dl_with_cache_aria2 $app $version $manifest $architecture $dir $cookies $use_cache $check_hash
     } else {
         foreach($url in $urls) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -545,10 +545,10 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
             if(msi $manifest $architecture) {
                 warn "MSI install is deprecated. If you maintain this manifest, please refer to the manifest reference docs."
             } else {
-                $extract_fn = 'Expand-MSIArchive'
+                $extract_fn = 'Expand-MsiArchive'
             }
-        } elseif(Test-7ZipRequirement -File $fname) { # 7zip
-            $extract_fn = 'Expand-7ZipArchive'
+        } elseif(Test-7zipRequirement -File $fname) { # 7zip
+            $extract_fn = 'Expand-7zipArchive'
         }
 
         if($extract_fn) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -278,7 +278,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         Set-Content -Path $urlstxt $urlstxt_content
 
         # build aria2 command
-        $aria2 = "& '$(Get-Aria2Path)' $($options -join ' ')"
+        $aria2 = "& '$(Get-HelperPath -Helper Aria2)' $($options -join ' ')"
 
         # handle aria2 console output
         Write-Host "Starting download with aria2 ..."

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -120,7 +120,7 @@ $skip | Where-Object { $explicit_apps -contains $_ } | ForEach-Object {
 }
 
 $suggested = @{ };
-if (aria2_enabled) {
+if (Test-Aria2Enabled) {
     warn "Scoop uses 'aria2c' for multi-connection downloads."
     warn "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
 }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -194,7 +194,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     # Workaround for https://github.com/lukesampson/scoop/issues/2220 until install is refactored
     # Remove and replace whole region after proper fix
     Write-Host "Downloading new version"
-    if (aria2_enabled) {
+    if (Test-Aria2Enabled) {
         dl_with_cache_aria2 $app $version $manifest $architecture $cachedir $manifest.cookie $true $check_hash
     } else {
         $urls = url $manifest $architecture
@@ -307,7 +307,7 @@ if (!$apps) {
 
     $suggested = @{};
     # # $outdated is a list of ($app, $global) tuples
-    if (aria2_enabled) {
+    if (Test-Aria2Enabled) {
         warn "Scoop uses 'aria2c' for multi-connection downloads."
         warn "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
     }

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if($env:CI) {
-                mock file_path { (Get-Command 7z.exe).Path }
+                mock Get-AppFilePath { (Get-Command 7z.exe).Path }
             } elseif(!(installed 7zip)) {
                 scoop install 7zip
             }
@@ -80,7 +80,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if($env:CI) {
-                mock file_path { $env:lessmsi }
+                mock Get-AppFilePath { $env:lessmsi }
             } elseif(!(installed lessmsi)) {
                 scoop install lessmsi
             }
@@ -114,7 +114,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         BeforeAll {
             if($env:CI) {
-                mock file_path { $env:innounp }
+                mock Get-AppFilePath { $env:innounp }
             } elseif(!(installed innounp)) {
                 scoop install innounp
             }

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -19,11 +19,11 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         It "Decompression test cases should exist" {
             $testcases = "$working_dir\TestCases.zip"
+            $testcases | Should -Exist
+            compute_hash $testcases 'sha256' | Should -Be '695bb18cafda52644a19afd184b2545e9c48f1a191f7ff1efc26cb034587079c'
             if (!$isUnix) {
                 Expand-Archive $testcases $working_dir
             }
-            $testcases | Should -Exist
-            compute_hash $testcases 'sha256' | Should -Be '695bb18cafda52644a19afd184b2545e9c48f1a191f7ff1efc26cb034587079c'
         }
     }
 

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -42,7 +42,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
         }
 
         It "extract normal compressed file" -Skip:$isUnix {
-            $to = test_extract "Expand-7ZipArchive" $test1
+            $to = test_extract "Expand-7zipArchive" $test1
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
@@ -50,20 +50,20 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         It "extract nested compressed file" -Skip:$isUnix {
             # file ext: tgz
-            $to = test_extract "Expand-7ZipArchive" $test2
+            $to = test_extract "Expand-7zipArchive" $test2
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
 
             # file ext: tar.bz2
-            $to = test_extract "Expand-7ZipArchive" $test3
+            $to = test_extract "Expand-7zipArchive" $test3
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
         It "extract nested compressed file with different inner name" -Skip:$isUnix {
-            $to = test_extract "Expand-7ZipArchive" $test4
+            $to = test_extract "Expand-7zipArchive" $test4
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1
@@ -71,7 +71,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
             $test1 | Should -Exist
-            test_extract "Expand-7ZipArchive" $test1 $true
+            test_extract "Expand-7zipArchive" $test1 $true
             $test1 | Should -Not -Exist
         }
     }
@@ -90,7 +90,7 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         It "extract normal MSI file" -Skip:$isUnix {
             mock get_config { $false }
-            $to = test_extract "Expand-MSIArchive" $test1
+            $to = test_extract "Expand-MsiArchive" $test1
             $to | Should -Exist
             "$to\MSITest\empty" | Should -Exist
             (Get-ChildItem "$to\MSITest").Count | Should -Be 1
@@ -98,14 +98,14 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         It "extract empty MSI file using lessmsi" -Skip:$isUnix {
             mock get_config { $true }
-            $to = test_extract "Expand-MSIArchive" $test2
+            $to = test_extract "Expand-MsiArchive" $test2
             $to | Should -Exist
         }
 
         It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
             mock get_config { $false }
             $test1 | Should -Exist
-            test_extract "Expand-MSIArchive" $test1 $true
+            test_extract "Expand-MsiArchive" $test1 $true
             $test1 | Should -Not -Exist
         }
     }


### PR DESCRIPTION
Fixes:
- Prevents installing 7zip/lessmsi/innounp locally if they are already available globally

Additions:
- `Get-HelperPath`
- `Test-HelperInstalled`
- ~`Get-LessmsiPath`~ `Get-HelperPath -Helper Lessmsi`
- ~`Test-LessmsiInstalled`~ `Test-HelperInstalled -Helper Lessmsi`
- ~`Get-InnounpPath`~ `Get-HelperPath -Helper Innounp`
- ~`Test-InnounpInstalled`~ `Test-HelperInstalled -Helper Innounp`
- `Get-HelperPath -Helper Dark`
- `Test-HelperInstalled -Helper Dark`

Added tests for:
- `Get-AppFilePath`
- `Get-HelperPath`
- `Test-HelperInstalled`
- `Test-Aria2Enabled`
- `Test-CommandAvailable`

Refactors:
- `aria2_path` > `Get-HelperPath -Helper Aria2`
- `aria2_installed` > `Test-HelperInstalled -Helper Aria2`
- `aria2_enabled` > `Test-Aria2Enabled`
- `7zip_path` > `Get-HelperPath -Helper 7zip`
- `7zip_installed` > `Test-HelperInstalled -Helper 7zip`
- `Expand-7ZipArchive` > `Expand-7zipArchive`
- `Test-7ZipRequirement` > `Test-7zipRequirement`
- `Expand-MSIArchive` > `Expand-MsiArchive`
- `Test-LessMSIRequirement` > `Test-LessmsiRequirement`
- `file_path` > `Get-AppFilePath`