### PR TITLE
fix: force to add new main bucket

### DIFF
--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -11,6 +11,14 @@ set-strictmode -off
 
 reset_aliases
 
+# TODO: remove this in a few weeks
+if ((Get-LocalBucket) -notcontains 'main') {
+    warn "The main bucket of Scoop has been separated to 'https://github.com/scoopinstaller/scoop-main'"
+    warn "You don't have the main bucket added, adding main bucket for you..."
+    add_bucket 'main'
+    exit
+}
+
 $commands = commands
 if ('--version' -contains $cmd -or (!$cmd -and '-v' -contains $args)) {
     Push-Location $(versiondir 'scoop' 'current')

--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -1,5 +1,5 @@
 function git_proxy_cmd {
-    $proxy = $(scoop config proxy)
+    $proxy = get_config 'proxy'
     $cmd = "git $($args | ForEach-Object { "$_ " })"
     if($proxy -and $proxy -ne 'none') {
         $cmd = "SET HTTPS_PROXY=$proxy&&SET HTTP_PROXY=$proxy&&$cmd"


### PR DESCRIPTION
Close #3400 . It's a hotfix and should be merged into master. And then sync it to develop branch.

```
$ scoop status
WARN  The main bucket of Scoop has been separated to 'https://github.com/scoopinstaller/scoop-main'
WARN  You don't have the main bucket added, adding main bucket for you...
Checking repo... ok
The main bucket was added successfully.
$
``` 