### PR TITLE
🚸 Display help on incorrect cache command

### DIFF
--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -47,8 +47,11 @@ switch($cmd) {
     'show' {
         show $app
     }
-    default {
+    '' {
         show
+    }
+    default {
+        my_usage
     }
 }
 


### PR DESCRIPTION
Countless times I've tried to run `scoop cache clear` wondering why it didn't work. 😶 