### PR TITLE
refactor(core):  Add more generic 'Invoke-ExternalCommand' instead of 'run'

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -233,7 +233,7 @@ function Get-AppFilePath {
 }
 
 Function Test-CommandAvailable {
-    Param (
+    param (
         [String]$Name
     )
     Return [Boolean](Get-Command $Name -ErrorAction Ignore)
@@ -366,6 +366,89 @@ function is_local($path) {
 }
 
 # operations
+
+function run($exe, $arg, $msg, $continue_exit_codes) {
+    Show-DeprecatedWarning $MyInvocation 'Invoke-ExternalCommand'
+    Invoke-ExternalCommand -FilePath $exe -ArgumentList $arg -Activity $msg -ContinueExitCodes $continue_exit_codes
+}
+
+function Invoke-ExternalCommand {
+    [CmdletBinding()]
+    [OutputType([Boolean])]
+    param (
+        [Parameter(Mandatory = $true,
+                   Position = 0)]
+        [Alias("Path")]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $FilePath,
+        [Parameter(Position = 1)]
+        [Alias("Args")]
+        [String[]]
+        $ArgumentList,
+        [Switch]
+        $RunAs,
+        [Alias("Msg")]
+        [String]
+        $Activity,
+        [Alias("cec")]
+        [Hashtable]
+        $ContinueExitCodes,
+        [Alias("Log")]
+        [String]
+        $LogPath
+    )
+    if ($Activity) {
+        Write-Host "$Activity " -NoNewline
+    }
+    $Process = New-Object System.Diagnostics.Process
+    $Process.StartInfo.FileName = $FilePath
+    $Process.StartInfo.Arguments = ($ArgumentList | Select-Object -Unique) -join ' '
+    $Process.StartInfo.UseShellExecute = $false
+    if ($LogPath) {
+        if ($FilePath -match '(^|\W)msiexec($|\W)') {
+            $Process.StartInfo.Arguments += " /lwe `"$LogPath`""
+        } else {
+            $Process.StartInfo.RedirectStandardOutput = $true
+        }
+    }
+    if ($RunAs) {
+        $Process.StartInfo.Verb = 'RunAs'
+    }
+    try {
+        $Process.Start() | Out-Null
+    } catch {
+        if ($Activity) {
+            Write-Host "error." -ForegroundColor DarkRed
+        }
+        error $_.Exception.Message
+        return $false
+    }
+    if ($LogPath -and ($FilePath -notmatch '(^|\W)msiexec($|\W)')) {
+        Out-File -FilePath $LogPath -Encoding ASCII -Append -InputObject $Process.StandardOutput.ReadToEnd()
+    }
+    $Process.WaitForExit()
+    if ($Process.ExitCode -ne 0) {
+        if ($ContinueExitCodes -and ($ContinueExitCodes.ContainsKey($Process.ExitCode))) {
+            if ($Activity) {
+                Write-Host "done." -ForegroundColor DarkYellow
+            }
+            warn $ContinueExitCodes[$Process.ExitCode]
+            return $true
+        } else {
+            if ($Activity) {
+                Write-Host "error." -ForegroundColor DarkRed
+            }
+            error "Exit code was $($Process.ExitCode)!"
+            return $false
+        }
+    }
+    if ($Activity) {
+        Write-Host "done." -ForegroundColor Green
+    }
+    return $true
+}
+
 function dl($url,$to) {
     $wc = New-Object Net.Webclient
     $wc.headers.add('Referer', (strip_filename $url))

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -1,7 +1,7 @@
 function Test-7zipRequirement {
     [CmdletBinding(DefaultParameterSetName = "URL")]
     [OutputType([Boolean])]
-    param(
+    param (
         [Parameter(Mandatory = $true, ParameterSetName = "URL")]
         [String[]]
         $URL,
@@ -23,7 +23,7 @@ function Test-7zipRequirement {
 function Test-LessmsiRequirement {
     [CmdletBinding()]
     [OutputType([Boolean])]
-    param(
+    param (
         [Parameter(Mandatory = $true)]
         [String[]]
         $URL
@@ -37,48 +37,53 @@ function Test-LessmsiRequirement {
 
 function Expand-7zipArchive {
     [CmdletBinding()]
-    param(
+    param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
         [String]
         $Path,
         [Parameter(Position = 1)]
         [String]
         $DestinationPath = (Split-Path $Path),
-        [ValidateSet("All", "Skip", "Rename")]
-        [String]
-        $Overwrite,
         [Parameter(ValueFromRemainingArguments = $true)]
         [String]
         $Switches,
+        [ValidateSet("All", "Skip", "Rename")]
+        [String]
+        $Overwrite,
         [Switch]
         $Removal
     )
-    $LogLocation = "$(Split-Path $Path)\7zip.log"
-    switch ($Overwrite) {
-        "All" { $Switches += " -aoa" }
-        "Skip" { $Switches += " -aos" }
-        "Rename" { $Switches += " -aou" }
-    }
     if ((get_config 7ZIPEXTRACT_USE_EXTERNAL)) {
         try {
-            7z x "$Path" -o"$DestinationPath" (-split $Switches) -y | Out-File $LogLocation
+            $7zPath = (Get-Command '7z' -CommandType Application | Select-Object -First 1).Source
         } catch [System.Management.Automation.CommandNotFoundException] {
             abort "Cannot find external 7-Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7-Zip manually and try again."
         }
     } else {
-        & (Get-HelperPath -Helper 7zip) x "$Path" -o"$DestinationPath" (-split $Switches) -y | Out-File $LogLocation
+        $7zPath = Get-HelperPath -Helper 7zip
     }
-    if ($LASTEXITCODE -ne 0) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
+    $LogPath = "$(Split-Path $Path)\7zip.log"
+    $ArgList = @('x', "`"$Path`"", "-o`"$DestinationPath`"", '-y')
+    if ($Switches) {
+        $ArgList += (-split $Switches)
     }
-    if (Test-Path $LogLocation) {
-        Remove-Item $LogLocation -Force
+    switch ($Overwrite) {
+        "All" { $ArgList += "-aoa" }
+        "Skip" { $ArgList += "-aos" }
+        "Rename" { $ArgList += "-aou" }
     }
-    if ((strip_ext $Path) -match '\.tar$' -or $Path -match '\.tgz$') {
+    $Status = Invoke-ExternalCommand $7zPath $ArgList -LogPath $LogPath
+    if (!$Status) {
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)"
+    }
+    if (Test-Path $LogPath) {
+        Remove-Item $LogPath -Force
+    }
+    if ((strip_ext $Path) -match '\.tar$' -or $Path -match '\.t[abgpx]z2?$') {
         # Check for tar
-        $ArchivedFile = & (Get-HelperPath -Helper 7zip) l "$Path"
-        if ($LASTEXITCODE -eq 0) {
-            $TarFile = $ArchivedFile[-3] -replace '.{53}(.*)', '$1' # get inner tar file name
+        $Status = Invoke-ExternalCommand $7zPath @('l', "`"$Path`"") -LogPath $LogPath
+        if ($Status) {
+            $TarFile = (Get-Content -Path $LogPath)[-4] -replace '.{53}(.*)', '$1' # get inner tar file name
             Expand-7zipArchive "$DestinationPath\$TarFile" $DestinationPath -Removal
         } else {
             abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."
@@ -92,44 +97,7 @@ function Expand-7zipArchive {
 
 function Expand-MsiArchive {
     [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        [String]
-        $Path,
-        [Parameter(Position = 1)]
-        [String]
-        $DestinationPath = (Split-Path $Path),
-        [Switch]
-        $Removal
-    )
-    $LogLocation = "$(Split-Path $Path)\msi.log"
-    if ((get_config MSIEXTRACT_USE_LESSMSI)) {
-        & (Get-HelperPath -Helper Lessmsi) x "$Path" "$DestinationPath\" | Out-File $LogLocation
-        if ($LASTEXITCODE -ne 0) {
-            abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
-        }
-        if (Test-Path "$DestinationPath\SourceDir") {
-            movedir "$DestinationPath\SourceDir" "$DestinationPath" | Out-Null
-        }
-    } else {
-        $ok = run 'msiexec' @('/a', "`"$Path`"", '/qn', "TARGETDIR=`"$DestinationPath`"", "/lwe `"$LogLocation`"")
-        if (!$ok) {
-            abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
-        }
-        Remove-Item "$DestinationPath\$(fname $Path)" -Force
-    }
-    if (Test-Path $LogLocation) {
-        Remove-Item $LogLocation -Force
-    }
-    if ($Removal) {
-        # Remove original archive file
-        Remove-Item $Path -Force
-    }
-}
-
-function Expand-InnoArchive {
-    [CmdletBinding()]
-    param(
+    param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
         [String]
         $Path,
@@ -142,13 +110,62 @@ function Expand-InnoArchive {
         [Switch]
         $Removal
     )
-    $LogLocation = "$(Split-Path $Path)\innounp.log"
-    & (Get-HelperPath -Helper Innounp) -x -d"$DestinationPath" -c'{app}' "$Path" (-split $Switches) -y | Out-File $LogLocation
-    if ($LASTEXITCODE -ne 0) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
+    if ((get_config MSIEXTRACT_USE_LESSMSI)) {
+        $MsiPath = Get-HelperPath -Helper Lessmsi
+        $ArgList = @('x', "`"$Path`"", "`"$DestinationPath\\`"")
+    } else {
+        $MsiPath = 'msiexec.exe'
+        $ArgList = @('/a', "`"$Path`"", '/qn', "TARGETDIR=`"$DestinationPath`"")
     }
-    if (Test-Path $LogLocation) {
-        Remove-Item $LogLocation -Force
+    $LogPath = "$(Split-Path $Path)\msi.log"
+    if ($Switches) {
+        $ArgList += (-split $Switches)
+    }
+    $Status = Invoke-ExternalCommand $MsiPath $ArgList -LogPath $LogPath
+    if (!$Status) {
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)"
+    }
+    if (Test-Path "$DestinationPath\SourceDir") {
+        movedir "$DestinationPath\SourceDir" "$DestinationPath" | Out-Null
+    }
+    if (($DestinationPath -ne (Split-Path $Path)) -and (Test-Path "$DestinationPath\$(fname $Path)")) {
+        Remove-Item "$DestinationPath\$(fname $Path)" -Force
+    }
+    if (Test-Path $LogPath) {
+        Remove-Item $LogPath -Force
+    }
+    if ($Removal) {
+        # Remove original archive file
+        Remove-Item $Path -Force
+    }
+}
+
+function Expand-InnoArchive {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [String]
+        $Path,
+        [Parameter(Position = 1)]
+        [String]
+        $DestinationPath = (Split-Path $Path),
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [String]
+        $Switches,
+        [Switch]
+        $Removal
+    )
+    $LogPath = "$(Split-Path $Path)\innounp.log"
+    $ArgList = @('-x', "-d`"$DestinationPath`"", "-c`{app`}", "`"$Path`"", '-y')
+    if ($Switches) {
+        $ArgList += (-split $Switches)
+    }
+    $Status = Invoke-ExternalCommand (Get-HelperPath -Helper Innounp) $ArgList -LogPath $LogPath
+    if (!$Status) {
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)"
+    }
+    if (Test-Path $LogPath) {
+        Remove-Item $LogPath -Force
     }
     if ($Removal) {
         # Remove original archive file
@@ -158,7 +175,7 @@ function Expand-InnoArchive {
 
 function Expand-ZipArchive {
     [CmdletBinding()]
-    param(
+    param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
         [String]
         $Path,
@@ -211,16 +228,23 @@ function Expand-DarkArchive {
         [Parameter(Position = 1)]
         [String]
         $DestinationPath = (Split-Path $Path),
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [String]
+        $Switches,
         [Switch]
         $Removal
     )
-    $LogLocation = "$(Split-Path $Path)\dark.log"
-    & (Get-HelperPath -Helper Dark) -nologo -x "$Path" "$DestinationPath" | Out-File $LogLocation
-    if ($LASTEXITCODE -ne 0) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
+    $LogPath = "$(Split-Path $Path)\dark.log"
+    $ArgList = @('-nologo', "-x `"$DestinationPath`"", "`"$Path`"")
+    if ($Switches) {
+        $ArgList += (-split $Switches)
     }
-    if (Test-Path $LogLocation) {
-        Remove-Item $LogLocation -Force
+    $Status = Invoke-ExternalCommand (Get-HelperPath -Helper Dark) $ArgList -LogPath $LogPath
+    if (!$Status) {
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)"
+    }
+    if (Test-Path $LogPath) {
+        Remove-Item $LogPath -Force
     }
     if ($Removal) {
         # Remove original archive file


### PR DESCRIPTION
Refactor `run` in `install.ps1`

- Rename to `Invoke-ExternalCommand` and move to `core.ps1`
- Use `Invoke-ExternalCommand` to refactor `Expand-7zipArchive`, `Expand-MsiArchive`, `Expand-InnoArchive`

TODO in next PR: Refactor `Expand-XXXArchive` to use an universal interface, just as `Get-HelperPath`, for further extending.