### PR TITLE
Add Expand-DarkArchive and some other dependency features

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -248,13 +248,26 @@ function Get-HelperPath {
         $Helper
     )
 
+    $HelperPath = $null
     switch ($Helper) {
-        '7zip' { Get-AppFilePath '7zip' '7z.exe' }
-        'Lessmsi' { Get-AppFilePath 'lessmsi' 'lessmsi.exe' }
-        'Innounp' { Get-AppFilePath 'innounp' 'innounp.exe' }
-        'Dark' { Get-AppFilePath 'dark' 'dark.exe' }
-        'Aria2' { Get-AppFilePath 'aria2' 'aria2c.exe' }
+        '7zip' {
+            $HelperPath = Get-AppFilePath '7zip' '7z.exe'
+            if([String]::IsNullOrEmpty($HelperPath)) {
+                $HelperPath = Get-AppFilePath '7zip-zstd' '7z.exe'
+            }
+        }
+        'Lessmsi' { $HelperPath = Get-AppFilePath 'lessmsi' 'lessmsi.exe' }
+        'Innounp' { $HelperPath = Get-AppFilePath 'innounp' 'innounp.exe' }
+        'Dark' {
+            $HelperPath = Get-AppFilePath 'dark' 'dark.exe'
+            if([String]::IsNullOrEmpty($HelperPath)) {
+                $HelperPath = Get-AppFilePath 'wixtoolset' 'dark.exe'
+            }
+        }
+        'Aria2' { $HelperPath = Get-AppFilePath 'aria2' 'aria2c.exe' }
     }
+
+    return $HelperPath
 }
 
 function Test-HelperInstalled {

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -202,6 +202,32 @@ function Expand-ZipArchive {
     }
 }
 
+function Expand-DarkArchive {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [String]
+        $Path,
+        [Parameter(Position = 1)]
+        [String]
+        $DestinationPath = (Split-Path $Path),
+        [Switch]
+        $Removal
+    )
+    $LogLocation = "$(Split-Path $Path)\dark.log"
+    & (Get-HelperPath -Helper Dark) -nologo -x "$DestinationPath" "$Path" | Out-File $LogLocation
+    if ($LASTEXITCODE -ne 0) {
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogLocation)"
+    }
+    if (Test-Path $LogLocation) {
+        Remove-Item $LogLocation -Force
+    }
+    if ($Removal) {
+        # Remove original archive file
+        Remove-Item $Path -Force
+    }
+}
+
 function extract_7zip($path, $to, $removal) {
     Show-DeprecatedWarning $MyInvocation 'Expand-7zipArchive'
     Expand-7zipArchive -Path $path -DestinationPath $to -Removal:$removal @args

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -49,6 +49,31 @@ function runtime_deps($manifest) {
     if ($manifest.depends) { return $manifest.depends }
 }
 
+function script_deps($script) {
+    $deps = @()
+    if($script -is [Array]) {
+        $script = $script -join "`n"
+    }
+    if([String]::IsNullOrEmpty($script)) {
+        return $deps
+    }
+
+    if($script -like '*Expand-7zipArchive *' -or $script -like '*extract_7zip *') {
+        $deps += '7zip'
+    }
+    if($script -like '*Expand-MsiArchive *' -or $script -like '*extract_msi *') {
+        $deps += 'lessmsi'
+    }
+    if($script -like '*Expand-InnoArchive *' -or $script -like '*unpack_inno *') {
+        $deps += 'innounp'
+    }
+    if($script -like '*Expand-DarkArchive *') {
+        $deps += 'dark'
+    }
+
+    return $deps
+}
+
 function install_deps($manifest, $arch) {
     $deps = @()
 
@@ -61,6 +86,16 @@ function install_deps($manifest, $arch) {
     if (!(Test-HelperInstalled -Helper Innounp) -and $manifest.innosetup) {
         $deps += 'innounp'
     }
+    if (!(Test-HelperInstalled -Helper Dark)) {
+        $deps += 'dark'
+    }
 
-    return $deps
+    $pre_install = arch_specific 'pre_install' $manifest $arch
+    $installer = arch_specific 'installer' $manifest $arch
+    $post_install = arch_specific 'post_install' $manifest $arch
+    $deps += script_deps $pre_install
+    $deps += script_deps $installer.script
+    $deps += script_deps $post_install
+
+    return $deps | Select-Object -Unique
 }

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -13,6 +13,30 @@ $issues += !(check_windows_defender $true)
 $issues += !(check_main_bucket)
 $issues += !(check_long_paths)
 
+if (!(Test-HelperInstalled -Helper 7zip)) {
+    error "'7-Zip' is not installed! It's required for unpacking most programs. Please Run 'scoop install 7zip' or 'scoop install 7zip-zstd'."
+    $issues++
+}
+
+if (!(Test-HelperInstalled -Helper Lessmsi)) {
+    error "'lessmsi' is not installed! It's required for unpacking programs with MSI packages. Please run 'scoop install lessmsi'."
+    $issues++
+}
+
+if (!(Test-HelperInstalled -Helper Innounp)) {
+    error "'Inno Setup Unpacker' is not installed! It's required for unpacking InnoSetup files. Please run 'scoop install innounp'."
+    $issues++
+}
+
+if (!(Test-HelperInstalled -Helper Dark)) {
+    error "'dark' is not installed! It's require for unpacking installers created with the WiX Toolset. Please run 'scoop install dark' or 'scoop install wixtoolset'."
+    $issues++
+}
+
+if (!(Test-HelperInstalled -Helper Aria2)) {
+    warn "'aria2' is not installed! This can improve download speeds. You may run 'scoop install aria2'."
+}
+
 $globaldir = New-Object System.IO.DriveInfo($globaldir)
 if($globaldir.DriveFormat -ne 'NTFS') {
     error "Scoop requires an NTFS volume to work! Please point `$env:SCOOP_GLOBAL or 'globalPath' variable in '~/.config/scoop/config.json' to another Drive."

--- a/libexec/scoop-checkup.ps1
+++ b/libexec/scoop-checkup.ps1
@@ -18,11 +18,6 @@ if (!(Test-HelperInstalled -Helper 7zip)) {
     $issues++
 }
 
-if (!(Test-HelperInstalled -Helper Lessmsi)) {
-    error "'lessmsi' is not installed! It's required for unpacking programs with MSI packages. Please run 'scoop install lessmsi'."
-    $issues++
-}
-
 if (!(Test-HelperInstalled -Helper Innounp)) {
     error "'Inno Setup Unpacker' is not installed! It's required for unpacking InnoSetup files. Please run 'scoop install innounp'."
     $issues++
@@ -31,10 +26,6 @@ if (!(Test-HelperInstalled -Helper Innounp)) {
 if (!(Test-HelperInstalled -Helper Dark)) {
     error "'dark' is not installed! It's require for unpacking installers created with the WiX Toolset. Please run 'scoop install dark' or 'scoop install wixtoolset'."
     $issues++
-}
-
-if (!(Test-HelperInstalled -Helper Aria2)) {
-    warn "'aria2' is not installed! This can improve download speeds. You may run 'scoop install aria2'."
 }
 
 $globaldir = New-Object System.IO.DriveInfo($globaldir)


### PR DESCRIPTION
- Add `Expand-DarkArchive` helper function
- Allow `dark.exe` from wixtoolset and `7zip-zstd` as valid helpers
- Add warnings to 'scoop checkup' for missing unpackers
- Auto detect dependencies from `pre_install`/`post_install` and `installer.script` by simply searching for the function names.

Should be merge into `develop` before merging `develop` into `master`.
This will allow us to remove the `dark` dependency from some manifests.
`Expand-7zipArchive` is widely used without the manifest actually depending on it. 
The installation will fail with the following message when `Get-HelperPath` returns nothing.
```
The expression after '&' in a pipeline element produced an object that was not valid. It must result in a command name, a script block, or a CommandInfo object.
```

https://github.com/lukesampson/scoop/issues/3417