### PR TITLE
Use 7zip when available for zip file (more fast)

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -540,6 +540,10 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
             $extract_fn = 'Expand-InnoArchive'
         } elseif($fname -match '\.zip$') {
             $extract_fn = 'Expand-ZipArchive'
+            # Use 7zip when available (more fast)
+            if (((get_config 7ZIPEXTRACT_USE_EXTERNAL) -and (Test-CommandAvailable 7z)) -or (Test-HelperInstalled -Helper 7zip)) {
+                $extract_fn = 'Expand-7zipArchive'
+            }
         } elseif($fname -match '\.msi$') {
             # check manifest doesn't use deprecated install method
             if(msi $manifest $architecture) {

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -539,10 +539,11 @@ function dl_urls($app, $version, $manifest, $bucket, $architecture, $dir, $use_c
         if ($manifest.innosetup) {
             $extract_fn = 'Expand-InnoArchive'
         } elseif($fname -match '\.zip$') {
-            $extract_fn = 'Expand-ZipArchive'
             # Use 7zip when available (more fast)
             if (((get_config 7ZIPEXTRACT_USE_EXTERNAL) -and (Test-CommandAvailable 7z)) -or (Test-HelperInstalled -Helper 7zip)) {
                 $extract_fn = 'Expand-7zipArchive'
+            } else {
+                $extract_fn = 'Expand-ZipArchive'
             }
         } elseif($fname -match '\.msi$') {
             # check manifest doesn't use deprecated install method


### PR DESCRIPTION
Example with vim, reduce the time of 67 seconds to 23 seconds

Command for test: 
```ps1
Measure-Command { .\bin\scoop.ps1 update vim -f }

#output
vim: 8.1.1330 -> 8.1.1330
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
Updating one outdated app:
Updating 'vim' (8.1.1330 -> 8.1.1330)
Downloading new version
Loading gvim_8.1.1330_x64.zip from cache.
Checking hash of gvim_8.1.1330_x64.zip ... ok.
Uninstalling 'vim' (8.1.1330)
Unlinking ~\scoop\apps\vim\current
Loading gvim_8.1.1330_x64.zip from cache.
Extracting gvim_8.1.1330_x64.zip ... done.
Linking ~\scoop\apps\vim\current => ~\scoop\apps\vim\8.1.1330
Creating shortcut for gVim (gvim.exe)
'vim' (8.1.1330) was installed successfully!
```

Measure with 7zip:
```
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 23
Milliseconds      : 112
Ticks             : 231125631
TotalDays         : 0,000267506517361111
TotalHours        : 0,00642015641666667
TotalMinutes      : 0,385209385
TotalSeconds      : 23,1125631
TotalMilliseconds : 23112,5631
```

Measure with powershell 5:
```
Days              : 0
Hours             : 0
Minutes           : 1
Seconds           : 7
Milliseconds      : 113
Ticks             : 671134835
TotalDays         : 0,000776776429398148
TotalHours        : 0,0186426343055556
TotalMinutes      : 1,11855805833333
TotalSeconds      : 67,1134835
TotalMilliseconds : 67113,4835
```