### PR TITLE
fix(config): show correct output when removing a config value

### DIFF
--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -1,6 +1,6 @@
 # Usage: scoop config [rm] name [value]
 # Summary: Get or set configuration values
-# Help: The scoop configuration file is saved at ~/.scoop.
+# Help: The scoop configuration file is saved at ~/.config/scoop/config.json.
 #
 # To get a configuration setting:
 #

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -37,7 +37,7 @@ if(!$name) { my_usage; exit 1 }
 
 if($name -like 'rm') {
     set_config $value $null | Out-Null
-    Write-Output "'$name' has been removed"
+    Write-Output "'$value' has been removed"
 } elseif($null -ne $value) {
     set_config $name $value | Out-Null
     Write-Output "'$name' has been set to '$value'"


### PR DESCRIPTION
Example input:
`scoop config rm proxy`

Example output:
Before: `'rm' has been removed`
Fixed: `'proxy' has been removed`