### PR TITLE
Improved compare_versions function

### DIFF
--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -18,7 +18,7 @@ function version($ver) {
         if($num) { $num } else { $_ }
     }
 }
-function compare_versions($a, $b) {
+function compare_versions_base($a, $b) {
     $ver_a = @(version $a)
     $ver_b = @(version $b)
 
@@ -34,6 +34,20 @@ function compare_versions($a, $b) {
         if($ver_a[$i] -lt $ver_b[$i]) { return -1; }
     }
     if($ver_b.length -gt $ver_a.length) { return -1 }
+    return 0
+}
+
+function compare_versions($a, $b) {
+    $list_a = @($a -split '-')
+    $list_b = @($b -split '-')
+
+    for($i=0;$i -lt $list_a.length -or $i -lt $list_b.length;$i++) {
+        $result = compare_versions_base $list_a[$i] $list_b[$i]
+
+        if($result -ne 0) {
+            return $result
+        }
+    }
     return 0
 }
 


### PR DESCRIPTION
This is a suggestion to solve some problems with version.

Example: PyCharm-Professional
Current version is `2019.1.2-191.7141.48`, but the command `scoop list` and `scoop update PyCharm-Professional` show old version installed `2019.1-191.6183.50`.

Explain: Current function, when compare, use `[2019,1,191,6,6183,50]` vs `[2019,1,2,191,7141,48]`, the `191` is greater than `2`

My idea: Split first by "-", and compare each group first (Ex.: `2019.1.2` vs `2019.1`)

It work for date and version with text, ex.: `2019-05-16`, `2.2.1-beta1`