### PR TITLE
fix(bin): Checkhashes downloading twice when architecture properties does hot have url property

### DIFF
--- a/bin/checkhashes.ps1
+++ b/bin/checkhashes.ps1
@@ -70,15 +70,15 @@ foreach ($single in Get-ChildItem $Dir "$App.json") {
     $urls = @()
     $hashes = @()
 
-    if ($manifest.architecture) {
+    if ($manifest.url) {
+        $manifest.url | ForEach-Object { $urls += $_ }
+        $manifest.hash | ForEach-Object { $hashes += $_ }
+    } elseif ($manifest.architecture) {
         # First handle 64bit
         url $manifest '64bit' | ForEach-Object { $urls += $_ }
         hash $manifest '64bit' | ForEach-Object { $hashes += $_ }
         url $manifest '32bit' | ForEach-Object { $urls += $_ }
         hash $manifest '32bit' | ForEach-Object { $hashes += $_ }
-    } elseif ($manifest.url) {
-        $manifest.url | ForEach-Object { $urls += $_ }
-        $manifest.hash | ForEach-Object { $hashes += $_ }
     } else {
         err $name 'Manifest does not contain URL property.'
         continue


### PR DESCRIPTION
When there were `url` and `architecture` properties. Architecture properties were considered first, which lead to this:

1. arch_specific 64bit => none, fallback to `url` property on root
1. arch_specific 32bit => none, fallback to `url` property on root
1. Resulted in one URL downloaded twice

Before:

![image](https://user-images.githubusercontent.com/13260377/58379607-08c5f300-7fa6-11e9-86d3-1d9c0ee1cd4b.png)

After:

![image](https://user-images.githubusercontent.com/13260377/58379603-006db800-7fa6-11e9-96da-ad64c4266b8c.png)
