### PR TITLE
fix(readme): adjust url of `runat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The apps that install best with Scoop are commonly called "portable" apps: i.e. 
 
 Since installers are common, Scoop supports them too (and their uninstallers).
 
-Scoop is also great at handling single-file programs and Powershell scripts. These don't even need to be compressed. See the [runat](https://github.com/lukesampson/scoop/blob/master/bucket/runat.json) package for an example: it's really just a GitHub gist.
+Scoop is also great at handling single-file programs and Powershell scripts. These don't even need to be compressed. See the [runat](https://github.com/ScoopInstaller/Main/blob/master/bucket/runat.json) package for an example: it's really just a GitHub gist.
 
 ### Support this project
 


### PR DESCRIPTION
Since main bucket has been moved to [ScoopInstaller/Main](https://github.com/ScoopInstaller/Main).

The url of `runat` on `README.md` should change to https://github.com/ScoopInstaller/Main/blob/master/bucket/runat.json 😃 