### PR TITLE
feat(compress): Allow 'Expand-InnoArchive -ExtractDir' to accept '{xxx}'

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -180,7 +180,12 @@ function Expand-InnoArchive {
         $Removal
     )
     $LogPath = "$(Split-Path $Path)\innounp.log"
-    $ArgList = @('-x', "-d`"$DestinationPath`"", "-c`{app`}\$ExtractDir", "`"$Path`"", '-y')
+    $ArgList = @('-x', "-d`"$DestinationPath`"", "`"$Path`"", '-y')
+    switch -Regex ($ExtractDir) {
+        "^[^{].*" { $ArgList += "-c{app}\$ExtractDir" }
+        "^{.*" { $ArgList += "-c$ExtractDir" }
+        Default { $ArgList += "-c{app}" }
+    }
     if ($Switches) {
         $ArgList += (-split $Switches)
     }


### PR DESCRIPTION
ref: https://github.com/lukesampson/scoop/pull/3466#discussion_r288691859

Now `freedownloadmanager`'s `installer.script` should be simplified to (see https://github.com/lukesampson/scoop-extras/pull/2220)

```json
"installer": {
    "script": [
        "Expand-InnoArchive -Path \"$dir\\$fname\"",
        "Expand-InnoArchive -Path \"$dir\\$fname\" -ExtractDir '{code_CefInstallDir}' -Removal"
    ]
}
```
