### PR TITLE
Command to list all scoop config settings

### DIFF
--- a/default/config.json
+++ b/default/config.json
@@ -1,0 +1,4 @@
+{
+    "SCOOP_BRANCH": "master",
+    "SCOOP_REPO": "https://github.com/lukesampson/scoop"
+}

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -48,8 +48,13 @@ function load_cfg($file) {
 }
 
 function get_config($name, $default) {
-    if($null -eq $scoopConfig.$name -and $null -ne $default) {
-        return $default
+    if($null -eq $scoopConfig.$name) {
+        if($null -ne $default) {
+            Show-DeprecatedWarning $MyInvocation "get_config <name> (specify defaults in default/config.json)"
+            return $default
+        } else {
+            return $CONFIG_DEFAULT.$name
+        }
     }
     return $scoopConfig.$name
 }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -78,6 +78,12 @@ function set_config($name, $value) {
     return $scoopConfig
 }
 
+function list_config() {
+    $scoopConfig | Get-Member -MemberType NoteProperty | ForEach-Object {
+        Write-Output "$($_.Name)=$($scoopConfig.$($_.Name))"
+    }
+}
+
 function setup_proxy() {
     # note: '@' and ':' in password must be escaped, e.g. 'p@ssword' -> p\@ssword'
     $proxy = get_config 'proxy'

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -963,8 +963,12 @@ if ((Test-Path "$env:USERPROFILE\.scoop") -and !(Test-Path $configFile)) {
     write-host "WARN  to '$configFile'" -f darkyellow
 }
 
+# Default config file
+$configFileDefault = "$PSScriptRoot\..\default\config.json"
+
 # Load Scoop config
 $scoopConfig = load_cfg $configFile
+$CONFIG_DEFAULT = load_cfg $configFileDefault
 
 # Setup proxy globally
 setup_proxy

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -38,6 +38,8 @@ if(!$name) { my_usage; exit 1 }
 if($name -like 'rm') {
     set_config $value $null | Out-Null
     Write-Output "'$value' has been removed"
+} elseif($name -like 'list') {
+    list_config
 } elseif($null -ne $value) {
     set_config $name $value | Out-Null
     Write-Output "'$name' has been set to '$value'"

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -14,6 +14,10 @@
 #
 #     scoop config rm <name>
 #
+# To list all configuration settings:
+#
+#     scoop config list
+#
 # Settings
 # --------
 #


### PR DESCRIPTION
It would be nice to have a scoop config 'list' option to easily see all config settings that have been set by the user. Something similar to `git config --list` for git. As of now, you have to cherry-pick individual scoop configs from the command line:

> PS C:\Users\crheidri\projects\scoop> scoop config debug true
'debug' has been set to 'true'
PS C:\Users\crheidri\projects\scoop> scoop config debug
True

Proposed changes:
- Create `list_config()` function in core.ps1 that iterates over `$scoopConfig` and prints 'name=value' pairs.
- Add 'list' elseif statement to scoop-config.ps1 that calls `list_config()`.
- Update help message in scoop-config.ps1 to include 'list' option.

After these changes, the user can see all configuration variables at once:
> PS C:\Users\crheidri\projects\scoop> .\bin\scoop config list
debug=True
lastupdate=2019-05-31T14:35:54.2863076-05:00
SCOOP_BRANCH=master
SCOOP_REPO=https://github.com/lukesampson/scoop

One potential conflict is the word "list" can no longer be used as a config name.