### PR TITLE
feat(install): Add arch support to `env_add_path` and `env_set`

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -594,13 +594,25 @@ function strip_path($orig_path, $dir) {
     return ($stripped -ne $orig_path), $stripped
 }
 
-function remove_from_path($dir,$global) {
+function add_first_in_path($dir, $global) {
+    $dir = fullpath $dir
+
+    # future sessions
+    $null, $currpath = strip_path (env 'path' $global) $dir
+    env 'path' $global "$dir;$currpath"
+
+    # this session
+    $null, $env:PATH = strip_path $env:PATH $dir
+    $env:PATH = "$dir;$env:PATH"
+}
+
+function remove_from_path($dir, $global) {
     $dir = fullpath $dir
 
     # future sessions
     $was_in_path, $newpath = strip_path (env 'path' $global) $dir
     if($was_in_path) {
-        write-output "Removing $(friendly_path $dir) from your path."
+        Write-Output "Removing $(friendly_path $dir) from your path."
         env 'path' $global $newpath
     }
 

--- a/schema.json
+++ b/schema.json
@@ -95,6 +95,12 @@
                 "checkver": {
                     "$ref": "#/definitions/checkver"
                 },
+                "env_add_path": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
+                "env_set": {
+                    "type": "object"
+                },
                 "extract_dir": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },


### PR DESCRIPTION
- Fix https://github.com/lukesampson/scoop/issues/3609

Just like `url`, `bin`, `shorcuts`, etc.

For MiKTeX that 64bit and 32bit offer different linked bin folder (which needed to be added to `PATH`)