### PR TITLE
Fix error matching bat and cmd file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{bat,cmd,[Bb][Aa][Tt],[Cc][Mm][Dd]]
+[*.{bat,cmd,[Bb][Aa][Tt],[Cc][Mm][Dd]}]
 # DOS/Win *requires* BAT/CMD files to have CRLF newlines
 end_of_line = crlf
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{bat,cmd,[Bb][Aa][Tt],[Cc][Mm][Dd]}]
+[*.{[Bb][Aa][Tt],[Cc][Mm][Dd]}]
 # DOS/Win *requires* BAT/CMD files to have CRLF newlines
 end_of_line = crlf
 


### PR DESCRIPTION
https://github.com/lukesampson/scoop/blob/1836edba8857373f56a4332dab81a7030a47fe76/.editorconfig#L15

Miss symbol `}`.