### PR TITLE
opt(decompress): Add [Array] and pipeline support to `Expand-XXX`'s params

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -39,12 +39,13 @@ function Expand-7zipArchive {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        [String]
+        [String[]]
         $Path,
-        [Parameter(Position = 1)]
-        [String]
-        $DestinationPath = (Split-Path $Path),
-        [String]
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
+        $DestinationPath,
+        [Parameter(Position = 2, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
         $ExtractDir,
         [Parameter(ValueFromRemainingArguments = $true)]
         [String]
@@ -55,52 +56,70 @@ function Expand-7zipArchive {
         [Switch]
         $Removal
     )
-    if ((get_config 7ZIPEXTRACT_USE_EXTERNAL)) {
-        try {
-            $7zPath = (Get-Command '7z' -CommandType Application | Select-Object -First 1).Source
-        } catch [System.Management.Automation.CommandNotFoundException] {
-            abort "Cannot find external 7-Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7-Zip manually and try again."
-        }
-    } else {
-        $7zPath = Get-HelperPath -Helper 7zip
-    }
-    $LogPath = "$(Split-Path $Path)\7zip.log"
-    $ArgList = @('x', "`"$Path`"", "-o`"$DestinationPath`"", '-y')
-    $IsTar = ((strip_ext $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
-    if (!$IsTar -and $ExtractDir) {
-        $ArgList += "-ir!$ExtractDir\*"
-    }
-    if ($Switches) {
-        $ArgList += (-split $Switches)
-    }
-    switch ($Overwrite) {
-        "All" { $ArgList += "-aoa" }
-        "Skip" { $ArgList += "-aos" }
-        "Rename" { $ArgList += "-aou" }
-    }
-    $Status = Invoke-ExternalCommand $7zPath $ArgList -LogPath $LogPath
-    if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
-    }
-    if (!$IsTar -and $ExtractDir) {
-        movedir "$DestinationPath\$ExtractDir" $DestinationPath | Out-Null
-    }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
-    }
-    if ($IsTar) {
-        # Check for tar
-        $Status = Invoke-ExternalCommand $7zPath @('l', "`"$Path`"") -LogPath $LogPath
-        if ($Status) {
-            $TarFile = (Get-Content -Path $LogPath)[-4] -replace '.{53}(.*)', '$1' # get inner tar file name
-            Expand-7zipArchive -Path "$DestinationPath\$TarFile" -DestinationPath $DestinationPath -ExtractDir $ExtractDir -Removal
+    begin {
+        if ((get_config 7ZIPEXTRACT_USE_EXTERNAL)) {
+            try {
+                $7zPath = (Get-Command '7z' -CommandType Application | Select-Object -First 1).Source
+            } catch [System.Management.Automation.CommandNotFoundException] {
+                abort "Cannot find external 7-Zip (7z.exe) while '7ZIPEXTRACT_USE_EXTERNAL' is 'true'!`nRun 'scoop config 7ZIPEXTRACT_USE_EXTERNAL false' or install 7-Zip manually and try again."
+            }
         } else {
-            abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."
+            $7zPath = Get-HelperPath -Helper 7zip
         }
     }
-    if ($Removal) {
-        # Remove original archive file
-        Remove-Item $Path -Force
+    process {
+        if (!$DestinationPath) {
+            $DestinationPath = Split-Path -Path $Path
+        }
+        for ($i = 0; $i -lt $Path.Length; $i++) {
+            $aPath = $Path[$i]
+            if ($aDestinationPath = $DestinationPath[$i]) {
+                $aDestinationPath = $DestinationPath[-1]
+            }
+            if ($ExtractDir) {
+                if ($aExtractDir = $ExtractDir[$i]) {
+                    $aExtractDir = $ExtractDir[-1]
+                }
+            }
+            $LogPath = "$(Split-Path $aPath)\7zip.log"
+            $ArgList = @('x', "`"$aPath`"", "-o`"$aDestinationPath`"", '-y')
+            $IsTar = ((strip_ext $aPath) -match '\.tar$') -or ($aPath -match '\.t[abgpx]z2?$')
+            if (!$IsTar -and $aExtractDir) {
+                $ArgList += "-ir!$aExtractDir\*"
+            }
+            if ($Switches) {
+                $ArgList += (-split $Switches)
+            }
+            switch ($Overwrite) {
+                "All" { $ArgList += "-aoa" }
+                "Skip" { $ArgList += "-aos" }
+                "Rename" { $ArgList += "-aou" }
+            }
+            $Status = Invoke-ExternalCommand $7zPath $ArgList -LogPath $LogPath
+            if (!$Status) {
+                abort "Failed to extract files from $aPath.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+            }
+            if (!$IsTar -and $aExtractDir) {
+                movedir "$aDestinationPath\$aExtractDir" $aDestinationPath | Out-Null
+            }
+            if (Test-Path $LogPath) {
+                Remove-Item $LogPath -Force
+            }
+            if ($IsTar) {
+                # Check for tar
+                $Status = Invoke-ExternalCommand $7zPath @('l', "`"$aPath`"") -LogPath $LogPath
+                if ($Status) {
+                    $TarFile = (Get-Content -Path $LogPath)[-4] -replace '.{53}(.*)', '$1' # get inner tar file name
+                    Expand-7zipArchive -Path "$aDestinationPath\$TarFile" -DestinationPath $aDestinationPath -ExtractDir $aExtractDir -Removal
+                } else {
+                    abort "Failed to list files in $aPath.`nNot a 7-Zip supported archive file."
+                }
+            }
+            if ($Removal) {
+                # Remove original archive file
+                Remove-Item $aPath -Force
+            }
+        }
     }
 }
 
@@ -108,12 +127,13 @@ function Expand-MsiArchive {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        [String]
+        [String[]]
         $Path,
-        [Parameter(Position = 1)]
-        [String]
-        $DestinationPath = (Split-Path $Path),
-        [String]
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
+        $DestinationPath,
+        [Parameter(Position = 2, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
         $ExtractDir,
         [Parameter(ValueFromRemainingArguments = $true)]
         [String]
@@ -121,44 +141,60 @@ function Expand-MsiArchive {
         [Switch]
         $Removal
     )
-    $DestinationPath = $DestinationPath.TrimEnd("\")
-    if ($ExtractDir) {
-        $OriDestinationPath = $DestinationPath
-        $DestinationPath = "$DestinationPath\_tmp"
-    }
-    if ((get_config MSIEXTRACT_USE_LESSMSI)) {
-        $MsiPath = Get-HelperPath -Helper Lessmsi
-        $ArgList = @('x', "`"$Path`"", "`"$DestinationPath\\`"")
-    } else {
-        $MsiPath = 'msiexec.exe'
-        $ArgList = @('/a', "`"$Path`"", '/qn', "TARGETDIR=`"$DestinationPath\\SourceDir`"")
-    }
-    $LogPath = "$(Split-Path $Path)\msi.log"
-    if ($Switches) {
-        $ArgList += (-split $Switches)
-    }
-    $Status = Invoke-ExternalCommand $MsiPath $ArgList -LogPath $LogPath
-    if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
-    }
-    if ($ExtractDir -and (Test-Path "$DestinationPath\SourceDir")) {
-        movedir "$DestinationPath\SourceDir\$ExtractDir" $OriDestinationPath | Out-Null
-        Remove-Item $DestinationPath -Recurse -Force
-    } elseif ($ExtractDir) {
-        movedir "$DestinationPath\$ExtractDir" $OriDestinationPath | Out-Null
-        Remove-Item $DestinationPath -Recurse -Force
-    } elseif (Test-Path "$DestinationPath\SourceDir") {
-        movedir "$DestinationPath\SourceDir" $DestinationPath | Out-Null
-    }
-    if (($DestinationPath -ne (Split-Path $Path)) -and (Test-Path "$DestinationPath\$(fname $Path)")) {
-        Remove-Item "$DestinationPath\$(fname $Path)" -Force
-    }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
-    }
-    if ($Removal) {
-        # Remove original archive file
-        Remove-Item $Path -Force
+    process {
+        if (!$DestinationPath) {
+            $DestinationPath = Split-Path -Path $Path
+        }
+        for ($i = 0; $i -lt $Path.Length; $i++) {
+            $aPath = $Path[$i]
+            if ($aDestinationPath = $DestinationPath[$i]) {
+                $aDestinationPath = $DestinationPath[-1]
+            }
+            if ($ExtractDir) {
+                if ($aExtractDir = $ExtractDir[$i]) {
+                    $aExtractDir = $ExtractDir[-1]
+                }
+            }
+            $aDestinationPath = $aDestinationPath.TrimEnd("\")
+            if ($aExtractDir) {
+                $OriDestinationPath = $aDestinationPath
+                $aDestinationPath = "$aDestinationPath\_tmp"
+            }
+            if ((get_config MSIEXTRACT_USE_LESSMSI)) {
+                $MsiPath = Get-HelperPath -Helper Lessmsi
+                $ArgList = @('x', "`"$aPath`"", "`"$aDestinationPath\\`"")
+            } else {
+                $MsiPath = 'msiexec.exe'
+                $ArgList = @('/a', "`"$aPath`"", '/qn', "TARGETDIR=`"$aDestinationPath\\SourceDir`"")
+            }
+            $LogPath = "$(Split-Path $aPath)\msi.log"
+            if ($Switches) {
+                $ArgList += (-split $Switches)
+            }
+            $Status = Invoke-ExternalCommand $MsiPath $ArgList -LogPath $LogPath
+            if (!$Status) {
+                abort "Failed to extract files from $aPath.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+            }
+            if ($aExtractDir -and (Test-Path "$aDestinationPath\SourceDir")) {
+                movedir "$aDestinationPath\SourceDir\$aExtractDir" $OriDestinationPath | Out-Null
+                Remove-Item $aDestinationPath -Recurse -Force
+            } elseif ($aExtractDir) {
+                movedir "$aDestinationPath\$aExtractDir" $OriDestinationPath | Out-Null
+                Remove-Item $aDestinationPath -Recurse -Force
+            } elseif (Test-Path "$aDestinationPath\SourceDir") {
+                movedir "$aDestinationPath\SourceDir" $aDestinationPath | Out-Null
+            }
+            if (($aDestinationPath -ne (Split-Path $aPath)) -and (Test-Path "$aDestinationPath\$(fname $aPath)")) {
+                Remove-Item "$aDestinationPath\$(fname $aPath)" -Force
+            }
+            if (Test-Path $LogPath) {
+                Remove-Item $LogPath -Force
+            }
+            if ($Removal) {
+                # Remove original archive file
+                Remove-Item $aPath -Force
+            }
+        }
     }
 }
 
@@ -166,12 +202,13 @@ function Expand-InnoArchive {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        [String]
+        [String[]]
         $Path,
-        [Parameter(Position = 1)]
-        [String]
-        $DestinationPath = (Split-Path $Path),
-        [String]
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
+        $DestinationPath,
+        [Parameter(Position = 2, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
         $ExtractDir,
         [Parameter(ValueFromRemainingArguments = $true)]
         [String]
@@ -179,26 +216,42 @@ function Expand-InnoArchive {
         [Switch]
         $Removal
     )
-    $LogPath = "$(Split-Path $Path)\innounp.log"
-    $ArgList = @('-x', "-d`"$DestinationPath`"", "`"$Path`"", '-y')
-    switch -Regex ($ExtractDir) {
-        "^[^{].*" { $ArgList += "-c{app}\$ExtractDir" }
-        "^{.*" { $ArgList += "-c$ExtractDir" }
-        Default { $ArgList += "-c{app}" }
-    }
-    if ($Switches) {
-        $ArgList += (-split $Switches)
-    }
-    $Status = Invoke-ExternalCommand (Get-HelperPath -Helper Innounp) $ArgList -LogPath $LogPath
-    if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
-    }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
-    }
-    if ($Removal) {
-        # Remove original archive file
-        Remove-Item $Path -Force
+    process {
+        if (!$DestinationPath) {
+            $DestinationPath = Split-Path -Path $Path
+        }
+        for ($i = 0; $i -lt $Path.Length; $i++) {
+            $aPath = $Path[$i]
+            if ($aDestinationPath = $DestinationPath[$i]) {
+                $aDestinationPath = $DestinationPath[-1]
+            }
+            if ($ExtractDir) {
+                if ($aExtractDir = $ExtractDir[$i]) {
+                    $aExtractDir = $ExtractDir[-1]
+                }
+            }
+            $LogPath = "$(Split-Path $aPath)\innounp.log"
+            $ArgList = @('-x', "-d`"$aDestinationPath`"", "`"$aPath`"", '-y')
+            switch -Regex ($aExtractDir) {
+                "^[^{].*" { $ArgList += "-c{app}\$aExtractDir" }
+                "^{.*" { $ArgList += "-c$aExtractDir" }
+                Default { $ArgList += "-c{app}" }
+            }
+            if ($Switches) {
+                $ArgList += (-split $Switches)
+            }
+            $Status = Invoke-ExternalCommand (Get-HelperPath -Helper Innounp) $ArgList -LogPath $LogPath
+            if (!$Status) {
+                abort "Failed to extract files from $aPath.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+            }
+            if (Test-Path $LogPath) {
+                Remove-Item $LogPath -Force
+            }
+            if ($Removal) {
+                # Remove original archive file
+                Remove-Item $aPath -Force
+            }
+        }
     }
 }
 
@@ -206,55 +259,72 @@ function Expand-ZipArchive {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        [String]
+        [String[]]
         $Path,
-        [Parameter(Position = 1)]
-        [String]
-        $DestinationPath = (Split-Path $Path),
-        [String]
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
+        $DestinationPath,
+        [Parameter(Position = 2, ValueFromPipelineByPropertyName = $true)]
+        [String[]]
         $ExtractDir,
         [Switch]
         $Removal
     )
-    if ($ExtractDir) {
-        $OriDestinationPath = $DestinationPath
-        $DestinationPath = "$DestinationPath\_tmp"
-    }
-    # All methods to unzip the file require .NET4.5+
-    if ($PSVersionTable.PSVersion.Major -lt 5) {
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
-        try {
-            [System.IO.Compression.ZipFile]::ExtractToDirectory($Path, $DestinationPath)
-        } catch [System.IO.PathTooLongException] {
-            # try to fall back to 7zip if path is too long
-            if (Test-HelperInstalled -Helper 7zip) {
-                Expand-7zipArchive $Path $DestinationPath -Removal
-                return
-            } else {
-                abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
-            }
-        } catch [System.IO.IOException] {
-            if (Test-HelperInstalled -Helper 7zip) {
-                Expand-7zipArchive $Path $DestinationPath -Removal
-                return
-            } else {
-                abort "Unzip failed: Windows can't handle the file names in this zip file.`nRun 'scoop install 7zip' and try again."
-            }
-        } catch {
-            abort "Unzip failed: $_"
+    process {
+        if (!$DestinationPath) {
+            $DestinationPath = Split-Path -Path $Path
         }
-    } else {
-        # Use Expand-Archive to unzip in PowerShell 5+
-        # Compatible with Pscx (https://github.com/Pscx/Pscx)
-        Microsoft.PowerShell.Archive\Expand-Archive -Path $Path -DestinationPath $DestinationPath -Force
-    }
-    if ($ExtractDir) {
-        movedir "$DestinationPath\$ExtractDir" $OriDestinationPath | Out-Null
-        Remove-Item $DestinationPath -Recurse -Force
-    }
-    if ($Removal) {
-        # Remove original archive file
-        Remove-Item $Path -Force
+        for ($i = 0; $i -lt $Path.Length; $i++) {
+            $aPath = $Path[$i]
+            if ($aDestinationPath = $DestinationPath[$i]) {
+                $aDestinationPath = $DestinationPath[-1]
+            }
+            if ($ExtractDir) {
+                if ($aExtractDir = $ExtractDir[$i]) {
+                    $aExtractDir = $ExtractDir[-1]
+                }
+            }
+            if ($aExtractDir) {
+                $OriDestinationPath = $aDestinationPath
+                $aDestinationPath = "$aDestinationPath\_tmp"
+            }
+            # All methods to unzip the file require .NET4.5+
+            if ($PSVersionTable.PSVersion.Major -lt 5) {
+                Add-Type -AssemblyName System.IO.Compression.FileSystem
+                try {
+                    [System.IO.Compression.ZipFile]::ExtractToDirectory($aPath, $aDestinationPath)
+                } catch [System.IO.PathTooLongException] {
+                    # try to fall back to 7zip if path is too long
+                    if (Test-HelperInstalled -Helper 7zip) {
+                        Expand-7zipArchive $aPath $aDestinationPath -Removal
+                        return
+                    } else {
+                        abort "Unzip failed: Windows can't handle the long paths in this zip file.`nRun 'scoop install 7zip' and try again."
+                    }
+                } catch [System.IO.IOException] {
+                    if (Test-HelperInstalled -Helper 7zip) {
+                        Expand-7zipArchive $aPath $aDestinationPath -Removal
+                        return
+                    } else {
+                        abort "Unzip failed: Windows can't handle the file names in this zip file.`nRun 'scoop install 7zip' and try again."
+                    }
+                } catch {
+                    abort "Unzip failed: $_"
+                }
+            } else {
+                # Use Expand-Archive to unzip in PowerShell 5+
+                # Compatible with Pscx (https://github.com/Pscx/Pscx)
+                Microsoft.PowerShell.Archive\Expand-Archive -Path $aPath -DestinationPath $aDestinationPath -Force
+            }
+            if ($aExtractDir) {
+                movedir "$aDestinationPath\$aExtractDir" $OriDestinationPath | Out-Null
+                Remove-Item $aDestinationPath -Recurse -Force
+            }
+            if ($Removal) {
+                # Remove original archive file
+                Remove-Item $aPath -Force
+            }
+        }
     }
 }
 

--- a/test/Scoop-Decompress.Tests.ps1
+++ b/test/Scoop-Decompress.Tests.ps1
@@ -68,6 +68,13 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
+        It "accept array path param" -Skip:$isUnix {
+            $to = test_extract "Expand-7zipArchive" @($test1, $test2, $test3, $test4)
+            $to | Should -Exist
+            Join-Path -Path $to -ChildPath "empty" | Should -Exist
+            (Get-ChildItem $to).Count | Should -Be 4
+        }
+
         It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
             $test1 | Should -Exist
             test_extract "Expand-7zipArchive" $test1 $true
@@ -101,6 +108,12 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
             $to | Should -Exist
         }
 
+        It "accept array path param" -Skip:$isUnix {
+            mock get_config { $true }
+            $to = test_extract "Expand-MsiArchive" @($test1, $test2)
+            $to | Should -Exist
+        }
+
         It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
             mock get_config { $false }
             $test1 | Should -Exist
@@ -127,6 +140,13 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
             (Get-ChildItem $to).Count | Should -Be 1
         }
 
+        It "accept array path param" -Skip:$isUnix {
+            $to = test_extract "Expand-InnoArchive" @($test)
+            $to | Should -Exist
+            "$to\empty" | Should -Exist
+            (Get-ChildItem $to).Count | Should -Be 1
+        }
+
         It "works with '-Removal' switch (`$removal param)" -Skip:$isUnix {
             $test | Should -Exist
             test_extract "Expand-InnoArchive" $test $true
@@ -142,6 +162,13 @@ Describe 'Decompression function' -Tag 'Scoop', 'Decompress' {
 
         It "extract compressed file" -Skip:$isUnix {
             $to = test_extract "Expand-ZipArchive" $test
+            $to | Should -Exist
+            "$to\empty" | Should -Exist
+            (Get-ChildItem $to).Count | Should -Be 1
+        }
+
+        It "accept array path param" -Skip:$isUnix {
+            $to = test_extract "Expand-ZipArchive" @($test)
             $to | Should -Exist
             "$to\empty" | Should -Exist
             (Get-ChildItem $to).Count | Should -Be 1


### PR DESCRIPTION
Now `Expand-xxx` functions accept [Array] params (`Path`, `DestinationPath`, `ExtractDir`), and work for pipeline params (`aa, bb, cc | Expand-xxx` or `@(aa, bb, cc) | Expand-xxx`.

No more `ForEach-Object { Expand-xxx $_ }`.