### PR TITLE
Escape dir vars when calling COMSPEC cmds

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -893,7 +893,7 @@ function unlink_current($versiondir) {
         attrib $currentdir -R /L
 
         # remove the junction
-        & "$env:COMSPEC" /c "rmdir $currentdir"
+        & "$env:COMSPEC" /c "rmdir `"$currentdir`""
         return $currentdir
     }
     return $versiondir
@@ -1144,10 +1144,10 @@ function unlink_persist_data($dir) {
                 # remove read-only attribute on the link
                 attrib -R /L $filepath
                 # remove the junction
-                & "$env:COMSPEC" /c "rmdir /s /q $filepath"
+                & "$env:COMSPEC" /c "rmdir /s /q `"$filepath`""
             } else {
                 # remove the hard link
-                & "$env:COMSPEC" /c "del $filepath"
+                & "$env:COMSPEC" /c "del `"$filepath`""
             }
         }
     }

--- a/lib/psmodules.ps1
+++ b/lib/psmodules.ps1
@@ -23,10 +23,10 @@ function install_psmodule($manifest, $dir, $global) {
 
     if(test-path $linkfrom) {
         warn "$(friendly_path $linkfrom) already exists. It will be replaced."
-        & "$env:COMSPEC" /c "rmdir $linkfrom"
+        & "$env:COMSPEC" /c "rmdir `"$linkfrom`""
     }
 
-    & "$env:COMSPEC" /c "mklink /j $linkfrom $dir" | out-null
+    & "$env:COMSPEC" /c "mklink /j `"$linkfrom`" `"$dir`"" | out-null
 }
 
 function uninstall_psmodule($manifest, $dir, $global) {
@@ -40,7 +40,7 @@ function uninstall_psmodule($manifest, $dir, $global) {
     if(test-path $linkfrom) {
         write-host "Removing $(friendly_path $linkfrom)"
         $linkfrom = resolve-path $linkfrom
-        & "$env:COMSPEC" /c "rmdir $linkfrom"
+        & "$env:COMSPEC" /c "rmdir `"$linkfrom`""
     }
 }
 


### PR DESCRIPTION
COMSPEC commands fail when called with unescaped directory arguments which contain white spaces (typically a compound user name).

This PR
- Closes lukesampson/scoop-extras#1781
- Closes lukesampson/scoop-extras#2389
- Closes #2801