### PR TITLE
fix(decompress): fix bugs on extract_dir

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -68,7 +68,7 @@ function Expand-7zipArchive {
     $ArgList = @('x', "`"$Path`"", "-o`"$DestinationPath`"", '-y')
     $IsTar = ((strip_ext $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
     if (!$IsTar -and $ExtractDir) {
-        $ArgList += "-ir!$ExtractDir\*"
+        $ArgList += "`"-ir!$ExtractDir\`"*"
     }
     if ($Switches) {
         $ArgList += (-split $Switches)

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -68,7 +68,7 @@ function Expand-7zipArchive {
     $ArgList = @('x', "`"$Path`"", "-o`"$DestinationPath`"", '-y')
     $IsTar = ((strip_ext $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
     if (!$IsTar -and $ExtractDir) {
-        $ArgList += "`"-ir!$ExtractDir\`"*"
+        $ArgList += "-ir!`"$ExtractDir\*`""
     }
     if ($Switches) {
         $ArgList += (-split $Switches)


### PR DESCRIPTION
This fixes the error when `extract_dir` contains spaces, such as "ISLC v1.0.1.2"
(encountered in: https://github.com/lukesampson/scoop-extras/pull/2398)

Please let me know if there are any problems. Thanks.