### PR TITLE
opt(Invoke-ExternalCommand): Small tweak

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -373,7 +373,7 @@ function run($exe, $arg, $msg, $continue_exit_codes) {
 }
 
 function Invoke-ExternalCommand {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = "Default")]
     [OutputType([Boolean])]
     param (
         [Parameter(Mandatory = $true,
@@ -386,6 +386,7 @@ function Invoke-ExternalCommand {
         [Alias("Args")]
         [String[]]
         $ArgumentList,
+        [Parameter(ParameterSetName = "UseShellExecute")]
         [Switch]
         $RunAs,
         [Alias("Msg")]
@@ -394,6 +395,7 @@ function Invoke-ExternalCommand {
         [Alias("cec")]
         [Hashtable]
         $ContinueExitCodes,
+        [Parameter(ParameterSetName = "Default")]
         [Alias("Log")]
         [String]
         $LogPath
@@ -414,6 +416,7 @@ function Invoke-ExternalCommand {
         }
     }
     if ($RunAs) {
+        $Process.StartInfo.UseShellExecute = $true
         $Process.StartInfo.Verb = 'RunAs'
     }
     try {

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -410,6 +410,7 @@ function Invoke-ExternalCommand {
             $Process.StartInfo.Arguments += " /lwe `"$LogPath`""
         } else {
             $Process.StartInfo.RedirectStandardOutput = $true
+            $Process.StartInfo.RedirectStandardError = $true
         }
     }
     if ($RunAs) {


### PR DESCRIPTION
- Also redirect standard error to log file.
- Fix `-RunAs` error.
  - `-RunAs` and `-Log` cannot be used together.