### PR TITLE
fix help collision

### DIFF
--- a/lib/help.ps1
+++ b/lib/help.ps1
@@ -6,7 +6,7 @@ function summary($text) {
     $text | Select-String '(?m)^# Summary: ([^\n]*)$' | ForEach-Object { $_.matches[0].groups[1].value }
 }
 
-function help($text) {
+function scoop_help($text) {
     $help_lines = $text | Select-String '(?ms)^# Help:(.(?!^[^#]))*' | ForEach-Object { $_.matches[0].value; }
     $help_lines -replace '(?ms)^#\s?(Help: )?', ''
 }

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -13,7 +13,7 @@ function print_help($cmd) {
 
     $usage = usage $file
     $summary = summary $file
-    $help = help $file
+    $help = scoop_help $file
 
     if($usage) { "$usage`n" }
     if($help) { $help }


### PR DESCRIPTION
Fix command `scoop help` when alias `help` is declared.

When a user has an alias named help, scoop help does not work anymore.
This PR renames the function `help` to `scoop_help` to prevent collision with a user alias.

Steps to reproduce:
```
PS> Set-Alias help Get-Help
PS> scoop help install
help : The term 'local:help' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Users\Eric\scoop\apps\scoop\current\libexec\scoop-help.ps1:16 char:13
+     $help = help $file
+             ~~~~
+ CategoryInfo          : ObjectNotFound: (local:help:String) [], CommandNotFoundException
+ FullyQualifiedErrorId : CommandNotFoundException

Usage: scoop install <app> [options]
```