### PR TITLE
fix(install): Use Join-Path instead of string gluing.

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -203,7 +203,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
     $urls = @(url $manifest $architecture)
 
     # aria2 input file
-    $urlstxt = "$cachedir\$app.txt"
+    $urlstxt = Join-Path $cachedir "$app.txt"
     $urlstxt_content = ''
     $has_downloads = $false
 


### PR DESCRIPTION
While working on Actions I encounter problem with aria2 downloading. I can pretty simply [override function `Get-AppFilePath`](https://github.com/Ash258/Scoop-GithubActions/blob/08a2765fc4eb31f380bdefce28251c8b280d3dd0/Entrypoint.ps1#L815-L833) without problem so I can feed it with whatever I want to get correct path, but Aria2 is having problems with mixing `\` and `/`

### Before

https://github.com/Ash258/Scoop-GithubActions/issues/38#issuecomment-513490329

![A](https://i.imgur.com/Hp0UvLP.png)

### After

https://github.com/Ash258/Scoop-GithubActions/issues/38#issuecomment-513490551

![B](https://user-images.githubusercontent.com/13260377/61582786-808c4600-ab2f-11e9-92d1-ffe434b0c4dc.png)