### PR TITLE
fix(versions): Hotfix for #3333

### DIFF
--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -29,14 +29,29 @@ function Compare-Version {
         return 0
     }
 
+    $ReferenceVersion = ($ReferenceVersion -replace '[a-zA-Z]+', '.$&.').Replace('..', '.').Trim('.')
+    $DifferenceVersion = ($DifferenceVersion -replace '[a-zA-Z]+', '.$&.').Replace('..', '.').Trim('.')
+
     $SplitReferenceVersion = @($ReferenceVersion -split $Delimiter | ForEach-Object { if ($_ -match "^\d+$") { [int]$_ } else { $_ } })
     $SplitDifferenceVersion = @($DifferenceVersion -split $Delimiter | ForEach-Object { if ($_ -match "^\d+$") { [int]$_ } else { $_ } })
 
-    for ($i = 0; $i -lt [Math]::Max($ReferenceVersion.Length, $DifferenceVersion.Length); $i++) {
-        if ($i -gt $ReferenceVersion.Length) {
-            return 1
+    for ($i = 0; $i -lt [Math]::Max($SplitReferenceVersion.Length, $SplitDifferenceVersion.Length); $i++) {
+        if ($i -ge $SplitReferenceVersion.Length) {
+            if ($SplitDifferenceVersion[$i] -match "alpha|beta|rc|pre") {
+                return -1
+            } else {
+                return 1
+            }
         }
-        if ($SplitReferenceVersion[$i] -match '\.' -or $SplitDifferenceVersion[$i] -match '\.') {
+        if ($i -ge $SplitDifferenceVersion.Length) {
+            if ($SplitReferenceVersion[$i] -match "alpha|beta|rc|pre") {
+                return 1
+            } else {
+                return -1
+            }
+        }
+
+        if (($SplitReferenceVersion[$i] -match "\.") -or ($SplitDifferenceVersion[$i] -match "\.")) {
             $Result = Compare-Version $SplitReferenceVersion[$i] $SplitDifferenceVersion[$i] -Delimiter '\.'
             if ($Result -ne 0) {
                 return $Result
@@ -45,9 +60,14 @@ function Compare-Version {
             }
         }
 
-        # don't try to compare int to string
-        if ($SplitReferenceVersion[$i] -is [string] -and $SplitDifferenceVersion[$i] -isnot [string]) {
-            $SplitDifferenceVersion[$i] = "$($SplitDifferenceVersion[$i])"
+        if ($null -ne $SplitReferenceVersion[$i] -and $null -ne $SplitDifferenceVersion[$i]) {
+            # don't try to compare int to string
+            if ($SplitReferenceVersion[$i] -is [string] -and $SplitDifferenceVersion[$i] -isnot [string]) {
+                $SplitDifferenceVersion[$i] = "$($SplitDifferenceVersion[$i])"
+            }
+            if ($SplitDifferenceVersion[$i] -is [string] -and $SplitReferenceVersion[$i] -isnot [string]) {
+                $SplitReferenceVersion[$i] = "$($SplitReferenceVersion[$i])"
+            }
         }
 
         if ($SplitDifferenceVersion[$i] -gt $SplitReferenceVersion[$i]) { return 1 }

--- a/lib/versions.ps1
+++ b/lib/versions.ps1
@@ -29,11 +29,12 @@ function Compare-Version {
         return 0
     }
 
-    $ReferenceVersion = ($ReferenceVersion -replace '[a-zA-Z]+', '.$&.').Replace('..', '.').Trim('.')
-    $DifferenceVersion = ($DifferenceVersion -replace '[a-zA-Z]+', '.$&.').Replace('..', '.').Trim('.')
+    $SplitReferenceVersion = @($ReferenceVersion -split $Delimiter | ForEach-Object { if ($_ -match "^\d+$") { [int]$_ } else { ($_ -replace '[a-zA-Z]+', '.$&.').Replace('..', '.').Trim('.') } })
+    $SplitDifferenceVersion = @($DifferenceVersion -split $Delimiter | ForEach-Object { if ($_ -match "^\d+$") { [int]$_ } else { ($_ -replace '[a-zA-Z]+', '.$&.').Replace('..', '.').Trim('.') } })
 
-    $SplitReferenceVersion = @($ReferenceVersion -split $Delimiter | ForEach-Object { if ($_ -match "^\d+$") { [int]$_ } else { $_ } })
-    $SplitDifferenceVersion = @($DifferenceVersion -split $Delimiter | ForEach-Object { if ($_ -match "^\d+$") { [int]$_ } else { $_ } })
+    if ($SplitReferenceVersion[0] -eq 'nightly' -and $SplitDifferenceVersion[0] -eq 'nightly') {
+        return 0
+    }
 
     for ($i = 0; $i -lt [Math]::Max($SplitReferenceVersion.Length, $SplitDifferenceVersion.Length); $i++) {
         if ($i -ge $SplitReferenceVersion.Length) {

--- a/test/Scoop-Versions.Tests.ps1
+++ b/test/Scoop-Versions.Tests.ps1
@@ -43,5 +43,6 @@ describe "versions" -Tag 'Scoop' {
     it 'handles equal versions' {
         Compare-Version '12.0' '12.0' | Should -Be 0
         Compare-Version '7.0.4-9' '7.0.4-9' | Should -Be 0
+        Compare-Version 'nightly-20190801' 'nightly' | Should -Be 0
     }
 }

--- a/test/Scoop-Versions.Tests.ps1
+++ b/test/Scoop-Versions.Tests.ps1
@@ -8,19 +8,25 @@ describe "versions" -Tag 'Scoop' {
 
     it 'handles plain string version comparison to int version' {
         Compare-Version 'latest' '20150405' | Should -Be -1
+        Compare-Version '0.5alpha' '0.5' | Should -Be 1
+        Compare-Version '0.5' '0.5Beta' | Should -Be -1
     }
 
     it 'handles dashed version components' {
         Compare-Version '7.0.4-9' '7.0.4-10' | Should -Be 1
         Compare-Version '7.0.4' '7.0.4-9' | Should -Be 1
+        Compare-Version '7.0.4-beta9' '7.0.4' | Should -Be 1
         Compare-Version '7.0.4-9' '7.0.4-8' | Should -Be -1
+        Compare-Version '7.0.4' '7.0.4-beta9' | Should -Be -1
     }
 
     it 'handle example comparisons' {
         Compare-Version '1' '1.1' | Should -Be 1
         Compare-Version '1.0' '1.1' | Should -Be 1
+        Compare-Version '1.9.8' '1.10.0' | Should -Be 1
         Compare-Version '1.1' '1.0' | Should -Be -1
         Compare-Version '1.1' '1' | Should -Be -1
+        Compare-Version '1.10.0' '1.9.8' | Should -Be -1
         Compare-Version '1.1.1_8' '1.1.1' | Should -Be -1
         Compare-Version '1.1.1b' '1.1.1a' | Should -Be -1
         Compare-Version '1.1.1a' '1.1.1b' | Should -Be 1


### PR DESCRIPTION
Hotfix for #3333

Fixed out of bounds error for updates like `1.0.0-beta4 -> 1.0.0`, `1.16.0-rc2 -> 1.16.0`, i.e., one is dashed version with alphabet while another is undashed version. (by L63-L70 in `versions.ps1`)

Also make alpha/beta/rc/prev versions lower than vanilla ones, see new test cases in `Scoop-Versions.Tests.ps1`.