### PR TITLE
fix hash with space

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -58,7 +58,7 @@ function find_hash_in_textfile([String] $url, [Hashtable] $substitutions, [Strin
     $regex = substitute $regex $substitutions $true
     debug $regex
     if ($hashfile -match $regex) {
-        $hash = $matches[1] -replace ' ',''
+        $hash = $matches[1] -replace '\s',''
     }
 
     # convert base64 encoded hash values


### PR DESCRIPTION
Now freecad can extract hash as

```
        "hash": {
            "url": "$url-SHA256.txt",
            "regex": "(?sm):\\s+([a-f\\d\\s]+)CertUtil"
        }
```

