### PR TITLE
fix(install): Allow $version to be used in uninstaller scripts

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -744,6 +744,7 @@ function install_prog($fname, $dir, $installer, $global) {
 function run_uninstaller($manifest, $architecture, $dir) {
     $msi = msi $manifest $architecture
     $uninstaller = uninstaller $manifest $architecture
+    $version = $manifest.version
     if($uninstaller.script) {
         write-output "Running uninstaller script..."
         Invoke-Expression (@($uninstaller.script) -join "`r`n")


### PR DESCRIPTION
Fix #3588 

Use `$version` as old version indicator in `uninstaller`.