### PR TITLE
Shorter installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you've built software that you'd like others to use, Scoop is an alternative 
 Run this command from your PowerShell to install scoop to its default location (`C:\Users\<user>\scoop`)
 
 ```powershell
-iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+iwr -useb get.scoop.sh | iex
 ```
 
 Once installed, run `scoop help` for instructions.
@@ -81,7 +81,7 @@ These settings can be changed through environment variables.
 ```powershell
 $env:SCOOP='D:\Applications\Scoop'
 [Environment]::SetEnvironmentVariable('SCOOP', $env:SCOOP, 'User')
-iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+iwr -useb get.scoop.sh | iex
 ```
 
 ### Configure Scoop to install global programs to a Custom Directory

--- a/README.md
+++ b/README.md
@@ -64,9 +64,12 @@ If you've built software that you'd like others to use, Scoop is an alternative 
 
 ## Installation
 
-Run this command from your PowerShell to install scoop to its default location (`C:\Users\<user>\scoop`)
+Run the following command from your PowerShell to install scoop to its default location (`C:\Users\<user>\scoop`)
 
 ```powershell
+Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+
+# or shorter
 iwr -useb get.scoop.sh | iex
 ```
 
@@ -76,19 +79,20 @@ The default setup is configured so all user installed programs and Scoop itself 
 Globally installed programs (`--global`) live in `C:\ProgramData\scoop`.
 These settings can be changed through environment variables.
 
-### Install Scoop to a Custom Directory
+### Install Scoop to a Custom Directory by changing `SCOOP`
 
 ```powershell
 $env:SCOOP='D:\Applications\Scoop'
 [Environment]::SetEnvironmentVariable('SCOOP', $env:SCOOP, 'User')
-iwr -useb get.scoop.sh | iex
+# run the installer
 ```
 
-### Configure Scoop to install global programs to a Custom Directory
+### Configure Scoop to install global programs to a Custom Directory by changing `SCOOP_GLOBAL`
 
 ```powershell
 $env:SCOOP_GLOBAL='F:\GlobalScoopApps'
 [Environment]::SetEnvironmentVariable('SCOOP_GLOBAL', $env:SCOOP_GLOBAL, 'Machine')
+# run the installer
 ```
 
 ## [Documentation](https://github.com/lukesampson/scoop/wiki)
@@ -146,11 +150,11 @@ The following buckets are known to scoop:
 
 The main bucket is installed by default. To add any of the other buckets, type:
 ```
-> scoop bucket add bucketname
+scoop bucket add bucketname
 ```
 For example, to add the extras bucket, type:
 ```
-> scoop bucket add extras
+scoop bucket add extras
 ```
 
 ## Other application buckets

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5
 
 # remote install:
-#   iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+#   Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 $old_erroractionpreference = $erroractionpreference
 $erroractionpreference = 'stop' # quit if anything goes wrong
 


### PR DESCRIPTION
replace
```ps1
iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
```
to
```ps1
iwr -useb get.scoop.sh | iex
```
More elegant, isn't it?