### PR TITLE
fix(uninstall,update): Do not uninstall when application is running

### DIFF
--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -60,7 +60,7 @@ if (!$apps) { exit 0 }
     #region Workaround for #2952
     # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
     if (Get-Process | Where-Object { $_.Path -like "$(Split-Path $dir)\*" }) {
-        error "Aplication is still running. Close all instances and try again."
+        error "Application is still running. Close all instances and try again."
         continue
     }
     #endregion Workaround for #2952

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -56,6 +56,15 @@ if (!$apps) { exit 0 }
     $dir = versiondir $app $version $global
     $persist_dir = persistdir $app $global
 
+
+    #region Workaround for #2952
+    # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
+    if (Get-Process | Where-Object { $_.Path -like "$(Split-Path $dir)\*" }) {
+        error "Aplication is still running. Close all instances and try again."
+        continue
+    }
+    #endregion Workaround for #2952
+
     try {
         Test-Path $dir -ErrorAction Stop | Out-Null
     } catch [UnauthorizedAccessException] {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -237,6 +237,14 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
 
     $dir = versiondir $app $old_version $global
 
+    #region Workaround for #2952
+    # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
+    if (Get-Process | Where-Object { $_.Path -like "$(Split-Path $dir)\*" }) {
+        error "Aplication is still running. Close all instances and try again."
+        return
+    }
+    #endregion Workaround for #2952
+
     write-host "Uninstalling '$app' ($old_version)"
     run_uninstaller $old_manifest $architecture $dir
     rm_shims $old_manifest $global $architecture

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -240,7 +240,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     #region Workaround for #2952
     # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
     if (Get-Process | Where-Object { $_.Path -like "$(Split-Path $dir)\*" }) {
-        error "Aplication is still running. Close all instances and try again."
+        error "Application is still running. Close all instances and try again."
         return
     }
     #endregion Workaround for #2952


### PR DESCRIPTION
Workaround until #2952 is properly implemented.

No more `taskkill` in `uninstall.script`

#### Update

![image](https://user-images.githubusercontent.com/13260377/63605855-143db000-c5cf-11e9-91d8-9f64e6b9c9c0.png)

#### Uninstallation

![image](https://user-images.githubusercontent.com/13260377/63605657-b01aec00-c5ce-11e9-839c-283a7b05a2b9.png)