### PR TITLE
fix(update,uninstall): Regression from get-process workaround

### DIFF
--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -56,10 +56,12 @@ if (!$apps) { exit 0 }
     $dir = versiondir $app $version $global
     $persist_dir = persistdir $app $global
 
-
     #region Workaround for #2952
     # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
-    if (Get-Process | Where-Object { $_.Path -like "$(Split-Path $dir)\*" }) {
+    $split = Split-Path $dir
+    # Do not get whole $env:SCOOP\apps. When there is broken installation it will be just application root `$env:SCOOP\<app>\`
+    if ((Split-Path $split -Leaf) -eq 'apps') { $split = $dir }
+    if (Get-Process | Where-Object { $_.Path -like "$split\*" }) {
         error "Application is still running. Close all instances and try again."
         continue
     }

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -57,11 +57,8 @@ if (!$apps) { exit 0 }
     $persist_dir = persistdir $app $global
 
     #region Workaround for #2952
-    # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
-    $split = Split-Path $dir
-    # Do not get whole $env:SCOOP\apps. When there is broken installation it will be just application root `$env:SCOOP\<app>\`
-    if ((Split-Path $split -Leaf) -eq 'apps') { $split = $dir }
-    if (Get-Process | Where-Object { $_.Path -like "$split\*" }) {
+    $processdir = appdir $app $global | Resolve-Path | Select-Object -ExpandProperty Path
+    if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
         error "Application is still running. Close all instances and try again."
         continue
     }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -239,7 +239,10 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
 
     #region Workaround for #2952
     # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
-    if (Get-Process | Where-Object { $_.Path -like "$(Split-Path $dir)\*" }) {
+    $split = Split-Path $dir
+    # Do not get whole $env:SCOOP\apps. When there is broken installation it will be just application root `$env:SCOOP\<app>\`
+    if ((Split-Path $split -Leaf) -eq 'apps') { $split = $dir }
+    if (Get-Process | Where-Object { $_.Path -like "$split\*" }) {
         error "Application is still running. Close all instances and try again."
         return
     }

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -238,11 +238,8 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     $dir = versiondir $app $old_version $global
 
     #region Workaround for #2952
-    # Split-path for getting $env:SCOOP\apps\<app> and not current or specific version
-    $split = Split-Path $dir
-    # Do not get whole $env:SCOOP\apps. When there is broken installation it will be just application root `$env:SCOOP\<app>\`
-    if ((Split-Path $split -Leaf) -eq 'apps') { $split = $dir }
-    if (Get-Process | Where-Object { $_.Path -like "$split\*" }) {
+    $processdir = appdir $app $global | Resolve-Path | Select-Object -ExpandProperty Path
+    if (Get-Process | Where-Object { $_.Path -like "$processdir\*" }) {
         error "Application is still running. Close all instances and try again."
         return
     }


### PR DESCRIPTION
Get-process with path on splited `$dir` resolved to `$env:SCOOP\apps` when application installation was broken.

Broken installations have path `$env:SCOOP\apps\<app>\` and splited result in location of all applications.

Since this is just workaround I splitted path twice to check leaf. Every opinon is welcomed. (Maybe `EndsWith` could work 🤔)

![A](https://i.imgur.com/86uf5rz.png)