### PR TITLE
fix(autoupdate): Decode basename when extract hash

### DIFF
--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -172,7 +172,7 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
     $hash = $null
 
     $hashmode = $config.mode
-    $basename = url_remote_filename($url)
+    $basename = [System.Web.HttpUtility]::UrlDecode((url_remote_filename($url)))
 
     $substitutions = $substitutions.Clone()
     $substitutions.Add('$url', (strip_fragment $url))


### PR DESCRIPTION
Firefox, Thunderbird and uget can benefit.