### PR TITLE
fix(install): Prefer internal functions over external scoop command

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -815,7 +815,7 @@ function show_app($app, $bucket, $version) {
 
 function last_scoop_update() {
     # PowerShell 6 returns an DateTime Object
-    $last_update = (scoop config lastupdate)
+    $last_update = (get_config lastupdate)
 
     if ($null -ne $last_update -and $last_update.GetType() -eq [System.String]) {
         try {
@@ -831,7 +831,7 @@ function is_scoop_outdated() {
     $last_update = $(last_scoop_update)
     $now = [System.DateTime]::Now
     if($null -eq $last_update) {
-        scoop config lastupdate $now.ToString('o')
+        set_config lastupdate $now.ToString('o')
         # enforce an update for the first time
         return $true
     }

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -68,7 +68,7 @@ if ($global -and !(is_admin)) {
 }
 
 if (is_scoop_outdated) {
-    scoop update
+    & "$PSScriptRoot\scoop-update.ps1"
 }
 
 if ($apps.length -eq 1) {


### PR DESCRIPTION
- Closes #3616

I am not sure If I should add default to #L818. It could be empty string, but result `$null` should be same. Also this config have to exists all the time, unless use will delete it manually or remove config file.