### PR TITLE
only lookup directories in buckets folder

### DIFF
--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -59,7 +59,7 @@ function Get-LocalBucket {
         List all local buckets.
     #>
 
-    return (Get-ChildItem $bucketsdir).Name
+    return (Get-ChildItem -Directory $bucketsdir).Name
 }
 
 function buckets {


### PR DESCRIPTION
IntelliJ is putting a project file in the `buckets` folder when setting up a project there. The bucket lookup then tries to open this as a folder as it lacks directory filter.