### PR TITLE
fix scoop info Binaries output

### DIFF
--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -94,7 +94,7 @@ if($status.installed) {
     Write-Output "Installed: No"
 }
 
-$binaries = arch_specific 'bin' $manifest $install.architecture
+$binaries = @(arch_specific 'bin' $manifest $install.architecture)
 if($binaries) {
     $binary_output = "Binaries:`n  "
     $binaries | ForEach-Object {


### PR DESCRIPTION
Before:
```
> scoop info firefox-beta
...
Binaries:
   firefox.exe firefox-beta
```

Now:

```
> scoop info firefox-beta
...
Binaries:
   firefox-beta.exe
```
