### PR TITLE
fix(checkurls): Trim renaming suffix in url

### DIFF
--- a/bin/checkurls.ps1
+++ b/bin/checkurls.ps1
@@ -50,6 +50,9 @@ Write-Host ']ailed'
 Write-Host ' |  |  |'
 
 function test_dl([String] $url, $cookies) {
+    # Trim renaming suffix, prevent getting 40x response
+    $url = ($url -split '#/')[0]
+
     $wreq = [Net.WebRequest]::Create($url)
     $wreq.Timeout = $Timeout * 1000
     if ($wreq -is [Net.HttpWebRequest]) {


### PR DESCRIPTION
Prevent 40x response.

**Before:**
```
Desktop main (master)
$ .\bin\checkurls.ps1 -app apktool
[U]RLs
 | [O]kay
 |  | [F]ailed
 |  |  |
[1][0][1] apktool
       > The remote server returned an error: (403) Forbidden. (https://github.com/iBotPeaches/Apktool/releases/download/v2.4.0/apktool_2.4.0.jar#/apktool.jar)
```

**After:**
```
Desktop main (master)
$ .\bin\checkurls.ps1 -app apktool
[U]RLs
 | [O]kay
 |  | [F]ailed
 |  |  |
[1][1][0] apktool
```