### PR TITLE
fix some problems in core.ps1 - set_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ If you've built software that you'd like others to use, Scoop is an alternative 
 
 ## Installation
 
-Run this command from your PowerShell to install scoop to its default location (`C:\Users\<user>\scoop`)
+Run the following command from your PowerShell to install scoop to its default location (`C:\Users\<user>\scoop`)
 
 ```powershell
-iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+
+# or shorter
+iwr -useb get.scoop.sh | iex
 ```
 
 Once installed, run `scoop help` for instructions.
@@ -76,19 +79,20 @@ The default setup is configured so all user installed programs and Scoop itself 
 Globally installed programs (`--global`) live in `C:\ProgramData\scoop`.
 These settings can be changed through environment variables.
 
-### Install Scoop to a Custom Directory
+### Install Scoop to a Custom Directory by changing `SCOOP`
 
 ```powershell
 $env:SCOOP='D:\Applications\Scoop'
 [Environment]::SetEnvironmentVariable('SCOOP', $env:SCOOP, 'User')
-iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+# run the installer
 ```
 
-### Configure Scoop to install global programs to a Custom Directory
+### Configure Scoop to install global programs to a Custom Directory by changing `SCOOP_GLOBAL`
 
 ```powershell
 $env:SCOOP_GLOBAL='F:\GlobalScoopApps'
 [Environment]::SetEnvironmentVariable('SCOOP_GLOBAL', $env:SCOOP_GLOBAL, 'Machine')
+# run the installer
 ```
 
 ## [Documentation](https://github.com/lukesampson/scoop/wiki)
@@ -146,11 +150,11 @@ The following buckets are known to scoop:
 
 The main bucket is installed by default. To add any of the other buckets, type:
 ```
-> scoop bucket add bucketname
+scoop bucket add bucketname
 ```
 For example, to add the extras bucket, type:
 ```
-> scoop bucket add extras
+scoop bucket add extras
 ```
 
 ## Other application buckets

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5
 
 # remote install:
-#   iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+#   Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 $old_erroractionpreference = $erroractionpreference
 $erroractionpreference = 'stop' # quit if anything goes wrong
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -54,27 +54,33 @@ function get_config($name, $default) {
     return $scoopConfig.$name
 }
 
-function set_config($name, $value) {
-    if($null -eq $scoopConfig -or $scoopConfig.Count -eq 0) {
-        ensure (Split-Path -Path $configFile) | Out-Null
-        $scoopConfig = New-Object PSObject
-        $scoopConfig | Add-Member -MemberType NoteProperty -Name $name -Value $value
-    } else {
-        if($value -eq [bool]::TrueString -or $value -eq [bool]::FalseString) {
-            $value = [System.Convert]::ToBoolean($value)
-        }
-        if($null -eq $scoopConfig.$name) {
-            $scoopConfig | Add-Member -MemberType NoteProperty -Name $name -Value $value
-        } else {
-            $scoopConfig.$name = $value
-        }
+function set_config {
+    Param (
+        [ValidateNotNullOrEmpty()]
+        $name,
+        $value
+    )
+
+    if ($null -eq $scoopConfig -or $scoopConfig.Count -eq 0) {
+        $null = ensure (Split-Path -Path $configFile)
+        $scoopConfig = New-Object -TypeName PSObject
     }
 
-    if($null -eq $value) {
+    if ($value -eq [bool]::TrueString -or $value -eq [bool]::FalseString) {
+        $value = [System.Convert]::ToBoolean($value)
+    }
+
+    if ($null -eq $scoopConfig.$name) {
+        $scoopConfig | Add-Member -MemberType NoteProperty -Name $name -Value $value
+    } else {
+        $scoopConfig.$name = $value
+    }
+
+    if ($null -eq $value) {
         $scoopConfig.PSObject.Properties.Remove($name)
     }
 
-    ConvertTo-Json $scoopConfig | Set-Content $configFile -Encoding ASCII
+    ConvertTo-Json $scoopConfig | Set-Content -Path $configFile -Encoding ASCII
     return $scoopConfig
 }
 


### PR DESCRIPTION
- `Out-Null` is slow, casting to `[void]` or assigning to `$null` is much faster
- Add parameter names instead of relying on position
- Do not allow null or empty string for `$name` - function would previously thow an error if that occured, and it doesn't make sense to allow for it
- if `$scoopConfig` was `$null` and `$value` was a boolean-string ("True"/"False") it would previously not have been converted to a bool-type and saved in the JSON as a string-value instead. Fixed by moving the bool-conversion logic outside of the unrelated if-statement