### PR TITLE
fix(update): support $persist_dir in uninstaller.script

### DIFF
--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -236,6 +236,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     # endregion Workaround
 
     $dir = versiondir $app $old_version $global
+    $persist_dir = persistdir $app $global
 
     #region Workaround for #2952
     $processdir = appdir $app $global | Resolve-Path | Select-Object -ExpandProperty Path


### PR DESCRIPTION
$persist_dir in uninstaller.script only works when uninstall but not when update.