### PR TITLE
feat(core): Substitute curly bracket variables

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -844,11 +844,17 @@ function substitute($entity, [Hashtable] $params, [Bool]$regexEscape = $false) {
     } elseif ($entity -is [String]) {
         $params.GetEnumerator() | ForEach-Object {
             if($regexEscape -eq $false -or $null -eq $_.Value) {
-                $entity = $entity.Replace($_.Name, $_.Value)
+                $value = $_.Value
             } else {
-                $entity = $entity.Replace($_.Name, [Regex]::Escape($_.Value))
+                $value = [Regex]::Escape($_.Value)
             }
+
+            $curly = '${'  + $_.Name.TrimStart('$') + '}'
+
+            $entity = $entity.Replace($curly, $value)
+            $entity = $entity.Replace($_.Name, $value)
         }
+
         return $entity
     }
 }


### PR DESCRIPTION
This will make autoupdate values more readable in case advanced variable usage.

```diff
-https://www.ghisler.ch/install/beta/totalcmd$cleanVersionb$matchBetax32.cab#/cosi.7z
+https://www.ghisler.ch/install/beta/totalcmd${cleanVersion}b${matchBeta}x32.cab#/cosi.7z
```

As substitution is simple string replacing it is not needed to take care of this (compare to normal language substitution of `$cleanVersionb` lead to empty replace when variable do not exists), but supporting it will make values more readable and less error-prone.
In manifest below you could easily miss `b` between `cleanVersion` and `$matchBeta`.

```json
{
    "version": "9.50",
    "architecture": {
        "64bit": {
            "url": "https://www.ghisler.ch/install/beta/totalcmd950b2x64.cab#/cosi.7z",
            "hash": "73d005466d307813362dc3f4634b615d3ce1e8d6346dc802d133c8acff2b2940",
        },
        "32bit": {
            "url": "https://www.ghisler.ch/install/beta/totalcmd950b2x32.cab#/cosi.7z",
            "hash": "3e6753116cc64e4a36700a5cd8b399e9d5f38fdad1d1bbfb9bf8f28731be709d",
        }
    },
    "checkver": {
        "url": "https://www.ghisler.com/whatsnew.htm",
        "regex": "Total\\s+Commander\\s+([\\d.]+)\\s+beta\\s+(?<beta>\\d+)"
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://www.ghisler.ch/install/beta/totalcmd${cleanVersion}b${matchBeta}x64.cab#/cosi.7z"
            },
            "32bit": {
                "url": "https://www.ghisler.ch/install/beta/totalcmd$cleanVersionb$matchBetax32.cab#/cosi.7z"
            }
        }
    }
}
```

![A](https://i.imgur.com/6UrExDx.png)