### PR TITLE
fix bucket check

### DIFF
--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -21,13 +21,15 @@ function deps($app, $arch) {
 
 function dep_resolve($app, $arch, $resolved, $unresolved) {
     $app, $bucket, $null = parse_app $app
+
+    if(((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
+        abort "Bucket '$bucket' not installed. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
+    }
+
     $unresolved += $app
     $null, $manifest, $null, $null = Find-Manifest $app $bucket
 
     if(!$manifest) {
-        if(((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
-            warn "Bucket '$bucket' not installed. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
-        }
         abort "Couldn't find manifest for '$app'$(if(!$bucket) { '.' } else { " from '$bucket' bucket." })"
     }
 


### PR DESCRIPTION
When there is no `no-bucket` but a `no.json` in one of my buckets:
Before

```
scoop install no-bucket/no
The remote server returned an error: (500) Internal Server Error.
URL https://test.com is not valid
```

Now

```
scoop install no-bucket/no
Bucket 'no-bucket' not installed. Add it with 'scoop bucket add no-bucket' or 'scoop bucket add no-bucket <repo>'.cket <repo>'.
```