### PR TITLE
fix bucket check

### DIFF
--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -21,13 +21,13 @@ function deps($app, $arch) {
 
 function dep_resolve($app, $arch, $resolved, $unresolved) {
     $app, $bucket, $null = parse_app $app
+    if(((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
+        abort "Bucket '$bucket' not installed. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
+    }
     $unresolved += $app
     $null, $manifest, $null, $null = Find-Manifest $app $bucket
 
     if(!$manifest) {
-        if(((Get-LocalBucket) -notcontains $bucket) -and $bucket) {
-            warn "Bucket '$bucket' not installed. Add it with 'scoop bucket add $bucket' or 'scoop bucket add $bucket <repo>'."
-        }
         abort "Couldn't find manifest for '$app'$(if(!$bucket) { '.' } else { " from '$bucket' bucket." })"
     }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -86,9 +86,13 @@ function Find-Manifest($app, $bucket) {
         $manifest = url_manifest $url
     } else {
         # check buckets
-        $manifest, $bucket = find_manifest $app $bucket
+        if (!$bucket) {
+            $manifest, $bucket = find_manifest $app $bucket
+        } else {
+            $manifest, $null = find_manifest $app $bucket            
+        }
 
-        if(!$manifest) {
+        if(!$manifest -and !$bucket) {
             # couldn't find app in buckets: check if it's a local path
             $path = $app
             if(!$path.endswith('.json')) { $path += '.json' }


### PR DESCRIPTION
- Abort immediately when bucket is specified but there is no such a bucket.
- Do not check manifest from local path when bucket is specified.