### PR TITLE
fix(scoop-info): check bucket of installed app

### DIFF
--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -35,7 +35,7 @@ if (!$manifest) {
 }
 
 $install = install_info $app $status.version $global
-if ($install.bucket -ne $bucket) {
+$status.installed = $install.bucket -eq $bucket
     $status.installed = $false
 }
 $version_output = $manifest.version

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -36,8 +36,6 @@ if (!$manifest) {
 
 $install = install_info $app $status.version $global
 $status.installed = $install.bucket -eq $bucket
-    $status.installed = $false
-}
 $version_output = $manifest.version
 if (!$manifest_file) {
     $manifest_file = manifest_path $app $bucket

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -35,6 +35,9 @@ if (!$manifest) {
 }
 
 $install = install_info $app $status.version $global
+if ($install.bucket -ne $bucket) {
+    $status.installed = $false
+}
 $version_output = $manifest.version
 if (!$manifest_file) {
     $manifest_file = manifest_path $app $bucket


### PR DESCRIPTION
When bucket is specified, check if the installed app belong to the same bucket. If app is not installed from the specified bucket, output `Installed: No`

Also fix another bug. When an app hash is wrong there is no manifest.json in app directory. So `$install.bucket` is none. `Find-BucketDirectory` will return main bucket path as default and `manifest_path` will return a wrong path.