### PR TITLE
refactor: First step on `abort` function deprication

### DIFF
--- a/bin/refresh.ps1
+++ b/bin/refresh.ps1
@@ -5,7 +5,7 @@ $src = relpath ".."
 $dest = ensure (versiondir 'scoop' 'current')
 
 # make sure not running from the installed directory
-if("$src" -eq "$dest") { abort "$(strip_ext $myinvocation.mycommand.name) is for development only" }
+if("$src" -eq "$dest") { Stop-ScoopExecution "$(strip_ext $myinvocation.mycommand.name) is for development only" }
 
 'copying files...'
 $output = robocopy $src $dest /mir /njh /njs /nfl /ndl /xd .git tmp /xf .DS_Store last_updated

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -128,8 +128,8 @@ function Stop-ScoopExecution {
         This function should be used only as the last thing, where there is not possible to recover from error state or
         if you can freely exit entire execution without causing problems to user.
         If it is called there is no failsafe / error state handling.
-        For Example. When there is installation of multiple application happening, and first failed, rest of
-        applications are not installed, which is not user friendly.
+        For Example. When there is installation of multiple applications happening, and first failed. On fail this function
+        is called, and rest of applications are not installed, which is not user friendly.
     .PARAMETER Message
         Message, which will be printed to user.
     .PARAMETER ExitCode

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -120,6 +120,34 @@ function is_admin {
     ([security.principal.windowsprincipal]($id)).isinrole($admin)
 }
 
+function Stop-ScoopExecution {
+    <#
+    .SYNOPSIS
+        Print error message and exit whole scoop execution.
+    .DESCRIPTION
+        This function should be used only as the last thing, where there is not possible to recover from error state or
+        if you can freely exit entire execution without causing problems to user.
+        If it is called there is no failsafe / error state handling.
+        For Example. When there is installation of multiple application happening, and first failed, rest of
+        applications are not installed, which is not user friendly.
+    .PARAMETER Message
+        Message, which will be printed to user.
+    .PARAMETER ExitCode
+        Exit code
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0, ValueFromPipeline = $true, Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [String[]] $Message,
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName = $true)]
+        [Int] $ExitCode = 1
+    )
+
+    process { $Message | ForEach-Object { error $_ } }
+
+    end { exit $ExitCode }
+}
+
 # messages
 function abort($msg, [int] $exit_code=1) { write-host $msg -f red; exit $exit_code }
 function error($msg) { write-host "ERROR $msg" -f darkred }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -135,7 +135,7 @@ function Stop-ScoopExecution {
     .PARAMETER ExitCode
         Exit code
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Position = 0, ValueFromPipeline = $true, Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [String[]] $Message,

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -9,17 +9,21 @@ param($app)
 
 reset_aliases
 
+$exitCode = 0
+
 if($app) {
     $manifest, $bucket = find_manifest $app
     if($manifest) {
-        if([string]::isnullorempty($manifest.homepage)) {
-            abort "Could not find homepage in manifest for '$app'."
+        if ([string]::isnullorempty($manifest.homepage)) {
+            error "Could not find homepage in manifest for '$app'."
+            $exitCode = 1
+        } else {
+            Start-Process $manifest.homepage
         }
-        Start-Process $manifest.homepage
-    }
-    else {
-        abort "Could not find manifest for '$app'."
+    } else {
+        error "Could not find manifest for '$app'."
+        $exitCode = 1
     }
 } else { my_usage }
 
-exit 0
+exit $exitCode

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -31,7 +31,7 @@ if ($app -match '^(ht|f)tps?://|\\\\') {
 }
 
 if (!$manifest) {
-    abort "Could not find manifest for '$(show_app $app $bucket)'."
+    Stop-ScoopExecution "Could not find manifest for '$(show_app $app $bucket)'."
 }
 
 $install = install_info $app $status.version $global

--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -16,10 +16,12 @@ if(!(Test-Path $app_path)) {
     $app_path = versiondir $app 'current' $true
 }
 
+$exitCode = 0
 if(Test-Path $app_path) {
     Write-Output $app_path
 } else {
-    abort "Could not find app path for '$app'."
+    error "Could not find app path for '$app'."
+    $exitCode = 1
 }
 
-exit 0
+exit $exitCode

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -227,9 +227,10 @@ $apps | ForEach-Object {
                 Submit-ToVirusTotal $url $app ($opt.scan -or $opt.s)
             } else {
                 if ($_.Exception.Message -match "\(204|429\)") {
-                    abort "$app`: VirusTotal request failed`: $($_.Exception.Message)", $exit_code
+                    error "$app`: VirusTotal request failed`: $($_.Exception.Message)"
+                } else {
+                    warn "$app`: VirusTotal request failed`: $($_.Exception.Message)"
                 }
-                warn "$app`: VirusTotal request failed`: $($_.Exception.Message)"
             }
         }
     }

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -12,7 +12,7 @@ if(!$command) { 'ERROR: <command> missing'; my_usage; exit 1 }
 try {
     $gcm = Get-Command "$command" -ea stop
 } catch {
-    abort "'$command' not found" 3
+    Stop-ScoopExecution "'$command' not found" 3
 }
 
 $path = "$($gcm.path)"


### PR DESCRIPTION
`abort` function is causing lots of troubles for user and is used across whole codebase.

Main problem is update/installation of multiple applications. `scoop install man1 man2`. Currently if installtion of `man1` fail, then `man2` is not installed and you need to install it manually. But without abort, and proper try/catching, throwing it is easy to recover from failed installation and continue with `man2` installation

This PR is first step of whole process of removing/limiting usage of it.

I added new function, which has same behaviour, but it support pipeline and is verb-noun, because sometimes you can simply exit whole execution.

I will deprecate other usage of `abort` in other PRs (except decompress; I will leave it to @niheaven since he wrote almost all of it) Additional removal of other abort references will be harder as there is need to reimplement all functions to throw exception instead of aborting and then try catching.

This is just fast patch of few simple abort usage, which could be fixed easily. 