### PR TITLE
feat(list): Display main bucket name

### DIFF
--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -32,7 +32,7 @@ if($apps) {
         if (!$install_info) { Write-Host ' *failed*' -ForegroundColor DarkRed -NoNewline }
         if ($install_info.hold) { Write-Host ' *hold*' -ForegroundColor DarkMagenta -NoNewline }
 
-        if ($install_info.bucket -and ($install_info.bucket -ne 'main')) {
+        if ($install_info.bucket) {
             write-host -f Yellow " [$($install_info.bucket)]" -NoNewline
         } elseif ($install_info.url) {
             write-host -f Yellow " [$($install_info.url)]" -NoNewline


### PR DESCRIPTION
Always display bucket name of installed apps, even main bucket. The list should be more **explicit** by keeping the main bucket name.

The main bucket has been separated into an independent repository. It should be treated the same as other buckets.