### PR TITLE
fix(git): enforce pull without rebase

### DIFF
--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -20,7 +20,7 @@ function git_checkout {
 }
 
 function git_pull {
-    git_proxy_cmd pull $args
+    git_proxy_cmd pull --rebase=false $args
 }
 
 function git_fetch {


### PR DESCRIPTION
Hello,
in my global gitconfig, the option `pull.rebase` is set to `interactive`.

This means that whenever I `git pull`, the editor starts up asking me about rebasing my local branch.
While this functionality is questionable, it exists, and it means that whenever I try to install something with scoop, the editor pops up twice (update scoop and update the package list).

This is mildly annoying, so I fixed it locally by setting the option on the two repositories to `false`, which works.

This PR would fix the issue for everyone (included - or maybe limited to :D - myself in the future).