### PR TITLE
feat: Add configuration option for default architecture

### DIFF
--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -59,8 +59,15 @@ function install_info($app, $version, $global) {
 }
 
 function default_architecture {
-    if ([Environment]::Is64BitOperatingSystem) { return "64bit" }
-    "32bit"
+    if (get_config 'prefer-32bit' $false) {
+        $arch = '32bit'
+    } elseif ([Environment]::Is64BitOperatingSystem) {
+        $arch = '64bit'
+    } else {
+        $arch = '32bit'
+    }
+
+    return $arch
 }
 
 function arch_specific($prop, $manifest, $architecture) {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -60,11 +60,15 @@ function install_info($app, $version, $global) {
 
 function default_architecture {
     $arch = get_config 'default-architecture'
+    $system = if ([Environment]::Is64BitOperatingSystem) { '64bit' } else { '32bit' }
     if ($null -eq $arch) {
-        if ([Environment]::Is64BitOperatingSystem) {
-            $arch = '64bit'
-        } else {
-            $arch = '32bit'
+        $arch = $system
+    } else {
+        try {
+            $arch = ensure_architecture $arch
+        } catch {
+            warn 'Invalid default architecture configured. Determining default system architecture'
+            $arch = $system
         }
     }
 

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -59,12 +59,13 @@ function install_info($app, $version, $global) {
 }
 
 function default_architecture {
-    if (get_config 'prefer-32bit' $false) {
-        $arch = '32bit'
-    } elseif ([Environment]::Is64BitOperatingSystem) {
-        $arch = '64bit'
-    } else {
-        $arch = '32bit'
+    $arch = get_config 'default-architecture'
+    if ($null -eq $arch) {
+        if ([Environment]::Is64BitOperatingSystem) {
+            $arch = '64bit'
+        } else {
+            $arch = '32bit'
+        }
     }
 
     return $arch


### PR DESCRIPTION
- Closes #3770

Configuration name is subject of change. I am following dash notation for naming, until config is reworked and united (Related #3401)

~~Is boolean enough or it is prefered to go with `scoop config 'default-architecture' '32bit|64bit'` which could be more suitable for additional arch support (arm for example)~~

![image](https://user-images.githubusercontent.com/13260377/70826427-33af5180-1de7-11ea-8281-fe6c53732d22.png)
