### PR TITLE
fix(install): fix wrong output of 'install/failed'

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1021,11 +1021,7 @@ function prune_installed($apps, $global) {
 
 # check whether the app failed to install
 function failed($app, $global) {
-    $ver = current_version $app $global
-    if(!$ver) { return $false }
-    $info = install_info $app $ver $global
-    if(!$info) { return $true }
-    return $false
+    return !(install_info $app (current_version $app $global) $global)
 }
 
 function ensure_none_failed($apps, $global) {


### PR DESCRIPTION
Fix https://github.com/ScoopInstaller/Main/issues/642

This was caused by https://github.com/lukesampson/scoop/blob/cb2ff446e6a3b5367db7ed85c284ac083fd5f450/lib/install.ps1#L603, should be `return $true`... Replace the `failed` function with single line.