### PR TITLE
fix(install): add config to skip aria2 cert check

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -286,6 +286,10 @@ function Test-Aria2Enabled {
     return (Test-HelperInstalled -Helper Aria2) -and (get_config 'aria2-enabled' $true)
 }
 
+function Test-Aria2SkipCertificateCheck {
+    return (Test-HelperInstalled -Helper Aria2) -and (get_config 'aria2-skipCertificateCheck' $false)
+}
+
 function app_status($app, $global) {
     $status = @{}
     $status.installed = (installed $app $global)

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -227,6 +227,13 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         "--continue"
     )
 
+    if (Test-Aria2SkipCertificateCheck) {
+        Write-Host "Download by aria2 without certificate check. To enforce the check, use: scoop config rm aria2-skipCertificateCheck"
+        $options += "--check-certificate=false"
+    } else {
+        Write-Host "Download by aria2 with certificate check. To skip the check, use: scoop config aria2-skipCertificateCheck true"
+    }
+
     if($cookies) {
         $options += "--header='Cookie: $(cookie_header $cookies)'"
     }


### PR DESCRIPTION
When using aria2 to download the packages, and if the target certificate check is failed for x reason (for ex: `80092013` as per https://github.com/aria2/aria2/issues/1362), aria2 exit code will be `1` which is marked as unknown code as per: https://github.com/lukesampson/scoop/blob/a9fa775d59b14e7dce335313faa0eff855469764/lib/install.ps1#L137

In such case, we can provide a possibility to let aria2 to ignore the certificate check by `--check-certificate=false`

It seems that the list of settings that can be set by `scoop config` is not well documented, users might not aware how to ignore the aria2 certificate check, that's why in the `if (Test-Aria2SkipCertificateCheck) {` block, I added two `Write-Host` to guide users to set the `aria2-skipCertificateCheck`.
