### PR TITLE
fix(install): fix 'failed' function

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1021,7 +1021,11 @@ function prune_installed($apps, $global) {
 
 # check whether the app failed to install
 function failed($app, $global) {
-    return !(install_info $app (current_version $app $global) $global)
+    if (is_directory (appdir $app $global)) {
+        return !(install_info $app (current_version $app $global) $global)
+    } else {
+        return $false
+    }
 }
 
 function ensure_none_failed($apps, $global) {


### PR DESCRIPTION
:bangbang: HOTFIX :bangbang:

Sorry, /cc @r15ch13 @Ash258 

Fix #3866 

```
# uninstall 7zip-zstd (which needs 7zip)
λ  scoop uninstall 7zip-zstd                                                                     
Uninstalling '7zip-zstd' (19.00-v1.4.4-R1).                                                      
Removing shim for '7z'.                                                                          
Removing shim for '7zG'.                                                                         
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\7-Zip.lnk   
Unlinking ~\scoop\apps\7zip-zstd\current                                                         
'7zip-zstd' was uninstalled.                                                                     

# destroy 7zip
λ  rm .\scoop\apps\7zip\* -Force

# install 7zip-zstd   
λ  scoop install 7zip-zstd                                                                       
'7zip' install failed previously. Please uninstall it and try again.                             

# uninstall 7zip
λ  scoop uninstall 7zip                                                                          
Uninstalling '7zip' ().                                                                          
'7zip' was uninstalled.                                                                          

# install 7zip-zstd
λ  scoop install 7zip-zstd                                                                       
Installing '7zip' (19.00) [64bit]                                                                
Loading 7z1900-x64.msi from cache                                                                
Checking hash of 7z1900-x64.msi ... ok.                                                          
Extracting 7z1900-x64.msi ... done.                                                              
Linking ~\scoop\apps\7zip\current => ~\scoop\apps\7zip\19.00                                     
Creating shim for '7z'.                                                                          
Creating shortcut for 7-Zip (7zFM.exe)                                                           
'7zip' (19.00) was installed successfully!                                                       
Installing '7zip-zstd' (19.00-v1.4.4-R1) [64bit]                                                 
Loading 7z19.00-zstd-x64.exe from cache                                                          
Checking hash of 7z19.00-zstd-x64.exe ... ok.                                                    
Extracting dl.7z ... done.                                                                       
Linking ~\scoop\apps\7zip-zstd\current => ~\scoop\apps\7zip-zstd\19.00-v1.4.4-R1                 
Creating shim for '7z'.                                                                          
WARN  Overwriting shim to 7z.exe installed from 7zip                                             
Creating shim for '7zG'.                                                                         
Creating shortcut for 7-Zip (7zFM.exe)                                                           
'7zip-zstd' (19.00-v1.4.4-R1) was installed successfully!                             
```           