### PR TITLE
feat(checkver): Present script property

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -196,11 +196,10 @@ while ($in_progress -gt 0) {
     $expected_ver = $json.version
     $ver = ''
 
+    $page = $ev.SourceEventArgs.Result
+    $err = $ev.SourceEventArgs.Error
     if ($json.checkver.script) {
         $page = $json.checkver.script -join "`r`n" | Invoke-Expression
-    } else {
-        $err = $ev.SourceEventArgs.Error
-        $page = $ev.SourceEventArgs.Result
     }
 
     if ($err) {

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -196,8 +196,12 @@ while ($in_progress -gt 0) {
     $expected_ver = $json.version
     $ver = ''
 
-    $err = $ev.SourceEventArgs.Error
-    $page = $ev.SourceEventArgs.Result
+    if ($json.checkver.script) {
+        $page = $json.checkver.script -join "`r`n" | Invoke-Expression
+    } else {
+        $err = $ev.SourceEventArgs.Error
+        $page = $ev.SourceEventArgs.Result
+    }
 
     if ($err) {
         next "$($err.message)`r`nURL $url is not valid"

--- a/schema.json
+++ b/schema.json
@@ -260,6 +260,10 @@
                         },
                         "useragent": {
                             "type": "string"
+                        },
+                        "script": {
+                            "$ref": "#/definitions/stringOrArrayOfStrings",
+                            "description": "Custom PowerShell script to retrieve application version using more complex approach."
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
Related #3869

This is usefull when vendors provide complex webpages/requires specific request method / have webpage encoded / or you just want to create simplier structure for matching

I want to keep it simple and support the functionality of matching, so the script should always return the string, which represent the actual page.

![A](https://i.imgur.com/VT03Dtl.png)

Examples:

```json
{
    "version": "8.0.3-1",
    "homepage": "https://www.swi-prolog.org",
    "description": "Comprehensive Prolog environment",
    "license": "MIT",
    "architecture": {
        "64bit": {
            "url": "https://www.swi-prolog.org/download/stable/bin/swipl-8.0.3-1.x64.exe#/dl.7z",
            "hash": "f3b4783dd05a746219600185e8404238ee451708f3512c601a2c99cf549b0fa5"
        },
        "32bit": {
            "url": "https://www.swi-prolog.org/download/stable/bin/swipl-8.0.3-1.x86.exe#/dl.7z",
            "hash": "7b6b7295a8a19d350f16b38b00201725091e5d8272d4694c8df8696eabe45767"
        }
    },
    "bin": [
        "bin\\swipl.exe",
        "bin\\swipl-ld.exe"
    ],
    "shortcuts": [
        [
            "bin\\swipl-win.exe",
            "SWI-Prolog"
        ]
    ],
    "checkver": {
        "script": "return (iwr 'https://www.swi-prolog.org/download/stable/bin/').Content",
        "regex": "swipl-([\\d.-]+)\\.x64\\.exe"
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://www.swi-prolog.org/download/stable/bin/swipl-$version.x64.exe#/dl.7z"
            },
            "32bit": {
                "url": "https://www.swi-prolog.org/download/stable/bin/swipl-$version.x86.exe#/dl.7z"
            }
        },
        "hash": {
            "url": "$url.sha256"
        }
    }
}
```

```json
{
    "description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK)",
    "homepage": "https://aws.amazon.com/corretto/",
    "version": "11.0.6.10.1-1",
    "license": "GPL-2.0-only WITH Classpath-exception-2.0",
    "architecture": {
        "64bit": {
            "url": "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-windows-jdk.zip",
            "hash": "md5:9d590d3e1d4fe8b927f0b8498f992d53"
        }
    },
    "extract_to": "tmp",
    "installer": {
        "script": [
            "(Get-ChildItem -Directory \"$dir\\tmp\").FullName | % { Move-Item \"$_\\*\" \"$dir\" }",
            "Remove-Item -Recurse \"$dir\\tmp\""
        ]
    },
    "env_add_path": "bin",
    "env_set": {
        "JAVA_HOME": "$dir"
    },
    "checkver": {
        "script": [
            "$cosi = curl.exe -v 'https://corretto.aws/downloads/latest/amazon-corretto-11-x64-windows-jdk.zip' *>&1",
            "return $cosi | select-string '< Location: ' -Raw"
        ],
        "regex": "Location:\\s+.*?/[\\d.]+/(?<file>amazon-corretto-([\\d.-]+)-windows)-x64-jdk.zip"
    },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-windows-jdk.zip",
                "hash": {
                    "url": "https://corretto.aws/downloads/latest_checksum/amazon-corretto-11-x64-windows-jdk.zip"
                }
            }
        }
    }
}
```