### PR TITLE
feat(install): Follow HTTP redirections when downloading a file

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -378,12 +378,12 @@ function dl($url, $to, $cookies, $progress) {
             throw $exc
         }
         $newUrl = $redirectRes.Headers['Location']
-        info "Following redirect to ${newUrl}..."
+        info "Following redirect to $newUrl..."
 
         # Handle manual file rename
         if ($url -like '*#/*') {
             $null, $postfix = $url -split '#/'
-            $newUrl = "${newUrl}#/${postfix}"
+            $newUrl = "$newUrl#/$postfix"
         }
 
         dl $newUrl $to $cookies $progress


### PR DESCRIPTION
In some cases, such as when an HTTPS URL redirects to an HTTP URL, the `HTTPWebRequest` client may not follow 302 error codes. This change explicitly catches that error, and attempts to find another URL for the same file in the body of the 302 response.

This specifically fixes the error when installing or updating [Krita](https://github.com/lukesampson/scoop-extras/blob/master/bucket/krita.json) (from the extras bucket), which has an HTTPS download URL that can redirect to HTTP mirrors.

Closes https://github.com/lukesampson/scoop/issues/3886
Closes https://github.com/lukesampson/scoop/issues/3535
Closes https://github.com/lukesampson/scoop-extras/issues/2728
Closes https://github.com/lukesampson/scoop-extras/issues/2932
Replaces https://github.com/lukesampson/scoop-extras/pull/2933