### PR TITLE
Update scoop-alias.ps1

### DIFF
--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -26,6 +26,7 @@ param(
 . "$psscriptroot\..\lib\core.ps1"
 . "$psscriptroot\..\lib\help.ps1"
 . "$psscriptroot\..\lib\install.ps1"
+. "$psscriptroot\..\lib\commands.ps1"
 
 $script:config_alias = "alias"
 


### PR DESCRIPTION
Add include commands.ps1 to get the function command_path to work properly. Otherwise it gives error on scoop alias list