### PR TITLE
schema: remove uri-confirmance for autoupdate urls

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -168,7 +168,6 @@
                                     "type": "string"
                                 },
                                 "url": {
-                                    "format": "uri",
                                     "type": "string"
                                 },
                                 "hash": {
@@ -184,7 +183,6 @@
                                     "type": "string"
                                 },
                                 "url": {
-                                    "format": "uri",
                                     "type": "string"
                                 },
                                 "hash": {
@@ -206,7 +204,6 @@
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
                 "url": {
-                    "format": "uri",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
So myself and @Calinou have come across a package here https://github.com/Calinou/scoop-games/pull/108 that should technically be correct, but fails the schema validation.  The package in question extracts the complete autoupdate URL from the page text, and thus the value is just a regex match, which doesn't resemble a URL.  We have come to the conclusion this is a problem with the schema which can be fixed like so.  Unfortunately this makes it slightly less rigorous but I think it's necessary unless support for checkver regex matches is removed from the autoupdate URLs which would be a bad idea.