### PR TITLE
core(install): Readd "Don't send referer to portableapps.com"

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -357,7 +357,7 @@ function dl($url, $to, $cookies, $progress) {
     $wreq = [net.webrequest]::create($reqUrl)
     if($wreq -is [net.httpwebrequest]) {
         $wreq.useragent = Get-UserAgent
-        if (-not ($url -imatch "sourceforge\.net")) {
+        if (-not ($url -imatch "sourceforge\.net" -or $url -imatch "portableapps\.com")) {
             $wreq.referer = strip_filename $url
         }
         if($cookies) {


### PR DESCRIPTION
Close https://github.com/lukesampson/scoop/issues/3960
Do not send referer to portableapps.com.
There are still many software hosted in https://download3.portableapps.com