### PR TITLE
Execute cmd but don't execute autostart programs

### DIFF
--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -4,7 +4,7 @@ function git_proxy_cmd {
     if($proxy -and $proxy -ne 'none') {
         $cmd = "SET HTTPS_PROXY=$proxy&&SET HTTP_PROXY=$proxy&&$cmd"
     }
-    & "$env:COMSPEC" /c $cmd
+    & "$env:COMSPEC" /d /c $cmd
 }
 
 function git_clone {


### PR DESCRIPTION
The way the current code works is that it has side effects when trying to execute a git command.
(This comes from the file git.ps1 in the lib directory).
(i.e current code
& "$env:COMSPEC" /c $cmd
)
Without the /d parameter, it also executes code that is in the windows autostart sections of the registry. 
HKEY_LOCAL_MACHINE\Software\Microsoft\Command Processor\AutoRun
and/or
HKEY_CURRENT_USER\Software\Microsoft\Command Processor\AutoRun

by adding the /d switch
& "$env:COMSPEC" /d /c $cmd
no extra autorun programs will be executed.

Normally, this does not have any adverse effects (it is just possibly slower), however, if there is an error in the autostart entries, it ends up returning errors to scoop that get interpreted incorrectly. In my case, I also had invalid entries left in the autostart and was receiving the error message -

"The system cannot find the path specified". And scoop was failing.

I have seen this reported on several bugs as well.

Of course, there are several fixes to this - remove the entries from the registry, but I believe by adding the /d switch to the line below, will save scoop reporting errors that are non-related to scoop and it will run potentially faster when the autostart programs are time-consuming.