### PR TITLE
fix #3963, aria2 only reads BOM-less UTF-8 file

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -275,7 +275,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
 
     if($has_downloads) {
         # write aria2 input file
-        Set-Content -Path $urlstxt $urlstxt_content
+        [IO.File]::WriteAllLines($urlstxt, $urlstxt_content)
 
         # build aria2 command
         $aria2 = "& '$(Get-HelperPath -Helper Aria2)' $($options -join ' ')"


### PR DESCRIPTION
aria2 can only handle BOM-less UTF-8 file (`--input-file`) correctly. Use .NET method to fix #3963.

see the [comment](https://github.com/lukesampson/scoop/issues/3963#issuecomment-641725241) in #3963.

I'm new to PowerShell and .NET. I hope this fix is the proper way.