### PR TITLE
fix(tests): Force pester v4

### DIFF
--- a/test/bin/init.ps1
+++ b/test/bin/init.ps1
@@ -1,7 +1,7 @@
 Write-Host "PowerShell: $($PSVersionTable.PSVersion)"
 (7z.exe | Select-String -Pattern '7-Zip').ToString()
 Write-Host "Install dependencies ..."
-Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name Pester -SkipPublisherCheck
+Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name Pester -RequiredVersion 4.10.1 -SkipPublisherCheck
 Install-Module -Repository PSGallery -Scope CurrentUser -Force -Name PSScriptAnalyzer,BuildHelpers
 
 if ($env:CI_WINDOWS -eq $true) {


### PR DESCRIPTION
- Closes lukesampson/scoop-extras#4200
- Closes #4027

Full rework of tests needs to be done to fully adapt v5, but this should make Ci usable again for time being.

Master branch target is intended.

Pipeline failing due to bug in PSScriptAnalyzer PowerShell/PSScriptAnalyzer#1472