### PR TITLE
fix(core): Fosshub download

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -900,6 +900,7 @@ function handle_special_urls($url)
         $Body = @{
             projectUri      = $Matches.name;
             fileName        = $Matches.filename;
+            source          = 'CF';
             isLatestVersion = $true
         }
         if ((Invoke-RestMethod -Uri $url) -match '"p":"(?<pid>[a-f0-9]{24}).*?"r":"(?<rid>[a-f0-9]{24})') {


### PR DESCRIPTION
- Closes lukesampson/scoop-extras#4249
- Closes lukesampson/scoop-extras#4152
- Closes lukesampson/scoop-extras#4157
- Closes #4050

Have no idea why is it needed now.

Please test Excavator and normal execution

Before

![image](https://user-images.githubusercontent.com/13260377/86165056-1045bd00-bb13-11ea-904b-1a9b084d71da.png)

After

![image](https://user-images.githubusercontent.com/13260377/86165070-150a7100-bb13-11ea-9e90-8435a31f4bbc.png)

It should work in Excavator:

![image](https://user-images.githubusercontent.com/13260377/86165725-01133f00-bb14-11ea-8725-b34c22d61ffe.png)
![image](https://user-images.githubusercontent.com/13260377/86165770-12f4e200-bb14-11ea-8e43-75c99d38e335.png)
