### PR TITLE
fix(install): Aria2 inline progress negative values

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -287,8 +287,10 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
         Invoke-Expression $aria2 | ForEach-Object {
             # Skip blank lines
             if ([String]::IsNullOrWhiteSpace($_)) { return }
+
             # Prevent potential overlaping of text when one line is shorter
-            $blank = ' ' * ($Host.UI.RawUI.WindowSize.Width - $_.Length - 20)
+            $len = $Host.UI.RawUI.WindowSize.Width - $_.Length - 20
+            $blank = if ($len -gt 0) { ' ' * $len } else { '' }
             $color = 'Gray'
 
             if ($_.StartsWith('(OK):')) {


### PR DESCRIPTION
I do not remember exact example, but sometimes there is possible the value is negative. Most likely if the terminal is too narrow, which lead to `' ' * -10` and out of range error.