### PR TITLE
Added simple no proxy functionality

### DIFF
--- a/lib/git.ps1
+++ b/lib/git.ps1
@@ -1,8 +1,9 @@
 function git_proxy_cmd {
     $proxy = get_config 'proxy'
+    $no_proxy = get_config 'no_proxy'
     $cmd = "git $($args | ForEach-Object { "$_ " })"
     if($proxy -and $proxy -ne 'none') {
-        $cmd = "SET HTTPS_PROXY=$proxy&&SET HTTP_PROXY=$proxy&&$cmd"
+        $cmd = "SET HTTPS_PROXY=$proxy&&SET HTTP_PROXY=$proxy&&SET NO_PROXY=$no_proxy&&$cmd"
     }
     & "$env:COMSPEC" /c $cmd
 }

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -353,17 +353,18 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
 
 # download with filesize and progress indicator
 function dl($url, $to, $cookies, $progress) {
+    $no_proxy = get_config 'no_proxy'
+
     $reqUrl = ($url -split "#")[0]
     $wreq = [net.webrequest]::create($reqUrl)
-    if($wreq -is [net.httpwebrequest]) {
-        $wreq.useragent = Get-UserAgent
-        if (-not ($url -imatch "sourceforge\.net" -or $url -imatch "portableapps\.com")) {
-            $wreq.referer = strip_filename $url
-        }
-        if($cookies) {
-            $wreq.headers.add('Cookie', (cookie_header $cookies))
+
+    if($no_proxy) {
+        if($reqUrl -like "*$no_proxy*") {
+            $wreq.proxy = $null
+            Write-Host "Removing proxy for installation from url: $url"
         }
     }
+
 
     $wres = $wreq.getresponse()
     $total = $wres.ContentLength

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -18,6 +18,7 @@
 # --------
 #
 # proxy: [username:password@]host:port
+# no_proxy: host
 #
 # By default, Scoop will use the proxy settings from Internet Options, but with anonymous authentication.
 #


### PR DESCRIPTION
I tried to implement a simnple no proxy mechanism. It sets the no proxy environment variable for git requests and removed the proxy on installation of the url matches  (like) the no proxy host.

I am not aware of othere parts in the code where these changes have to be done but so far it works for me. This should also fix https://github.com/lukesampson/scoop/issues/1820