### PR TITLE
Update scoop-update.ps1

### DIFF
--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -13,9 +13,7 @@ reset_aliases
 # TODO: remove this in a few weeks
 if ((Get-LocalBucket) -notcontains 'main') {
     warn "The main bucket of Scoop has been separated to 'https://github.com/ScoopInstaller/Main'"
-    warn "You don't have the main bucket added, adding main bucket for you..."
-    add_bucket 'main'
-    exit
+    warn "Run 'scoop bucket add main' to install from main bucket"
 }
 
 $commands = commands

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -129,9 +129,8 @@ function update_scoop() {
     }
 
     if ((Get-LocalBucket) -notcontains 'main') {
-        info "The main bucket of Scoop has been separated to 'https://github.com/ScoopInstaller/Main'"
-        info "Adding main bucket..."
-        add_bucket 'main'
+        warn "The main bucket of Scoop has been separated to 'https://github.com/ScoopInstaller/Main'"
+        warn "Run 'scoop bucket add main' to install from main bucket"
     }
 
     ensure_scoop_in_path


### PR DESCRIPTION
Removed forced installation of main bucket. 
Bumped notification to warning
Added information on how to install main bucket manually

This will allow users to remove the main bucket

Fixes #3893 