### PR TITLE
add .zst to extension list (part to solve #3990)

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -16,7 +16,7 @@ function Test-7zipRequirement {
             return ($URL | Where-Object { Test-7zipRequirement -File $_ }).Count -gt 0
         }
     } else {
-        return $File -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(bz2)|(7z)|(rar)|(iso)|(xz)|(lzh)|(nupkg))$'
+        return $File -match '\.((gz)|(tar)|(tgz)|(lzma)|(bz)|(bz2)|(7z)|(rar)|(iso)|(xz)|(lzh)|(nupkg)|(zst))$'
     }
 }
 


### PR DESCRIPTION
Please integrate this PR as 1st step to make the workaround for #3990 some easier.
So only command line instructions are necessary and not patching a source file.

Workaround on my installation (in addition to the patch):
```
scoop bucket add versions
scoop install 7zip-zstd
scoop uninstall 7zip
scoop reset 7zip-zstd
```

Needed to fix openssh package: ScoopInstaller/Main#1494