### PR TITLE
fix get_shim_path

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -612,9 +612,9 @@ function get_shim_path() {
     $shim_path = "$(versiondir 'scoop' 'current')\supporting\shimexe\bin\shim.exe"
     $shim_version = get_config 'shim' 'default'
     switch ($shim_version) {
-        '71' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\71\shim.exe" }
-        'kiennq' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\kiennq\shim.exe" }
-        'default' { $true }
+        '71' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\71\shim.exe"; Break }
+        'kiennq' { $shim_path = "$(versiondir 'scoop' 'current')\supporting\shims\kiennq\shim.exe"; Break }
+        'default' { Break }
         default { warn "Unknown shim version: '$shim_version'" }
     }
     return $shim_path


### PR DESCRIPTION
get_shim_path return a list `[$ture, $shim_path]` when shim is default. Use `Break` instead.

![sshot-009](https://user-images.githubusercontent.com/36977733/97097978-c065a580-166f-11eb-883d-2a3a4edfcc9a.png)
