### PR TITLE
config.json file Nested configuration Conversion exception problem

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -41,7 +41,7 @@ function load_cfg($file) {
     }
 
     try {
-        return (Get-Content $file -Raw | ConvertFrom-Json -ErrorAction Stop)
+        return (Get-Content $file -Raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop)
     } catch {
         Write-Host "ERROR loading $file`: $($_.exception.message)"
     }


### PR DESCRIPTION
### When I was developing the mirroring function, I found a configuration file parsing problem
### When the `config.json` file is converted to hashtable, the keys, values ​​and attributes will be lost

For example
The content of `config.json` is as follows
```json
{
  "SCOOP_BRANCH": "master",
  "lastupdate": "2021-07-11T01:03:58.096058+08:00",
  "SCOOP_REPO": "https://github.com/lukesampson/scoop",
  "aria2-enabled": true,
  "list": "all",
  "test-map": {
    "k1":"v1",
    "k2":"v2",
    "k3":"v3"
  },
  "test-list": [
    "v1",
    "v2",
    "v3"
  ]
}
```
![image](https://user-images.githubusercontent.com/30598952/125174918-23e23400-e1fb-11eb-932c-612f4cbb6c81.png)

### After adding this parameter
![image](https://user-images.githubusercontent.com/30598952/125175058-3c068300-e1fc-11eb-998a-178459362cf0.png)



