### PR TITLE
Feature/support mirror configuration

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -41,7 +41,7 @@ function load_cfg($file) {
     }
 
     try {
-        return (Get-Content $file -Raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop)
+        return (Get-Content $file -Raw | ConvertFrom-Json -ErrorAction Stop)
     } catch {
         Write-Host "ERROR loading $file`: $($_.exception.message)"
     }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -41,7 +41,7 @@ function load_cfg($file) {
     }
 
     try {
-        return (Get-Content $file -Raw | ConvertFrom-Json -ErrorAction Stop)
+        return (Get-Content $file -Raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop)
     } catch {
         Write-Host "ERROR loading $file`: $($_.exception.message)"
     }

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -111,7 +111,15 @@ function generate_user_manifest($app, $bucket, $version) {
     return $null
 }
 
-function url($manifest, $arch) { arch_specific 'url' $manifest $arch }
+function url($manifest, $arch) {
+    $url = arch_specific 'url' $manifest $arch
+    $mirrors = get_config 'mirrors'
+    $keys = ($mirrors |  Get-Member -MemberType NoteProperty ).name
+    foreach ($mirror in $keys) {
+        $url = $url -replace ($mirror, $mirrors.$mirror)
+    }
+    $url
+}
 function installer($manifest, $arch) { arch_specific 'installer' $manifest $arch }
 function uninstaller($manifest, $arch) { arch_specific 'uninstaller' $manifest $arch }
 function msi($manifest, $arch) { arch_specific 'msi' $manifest $arch }


### PR DESCRIPTION
Sometimes the address in the bucket becomes invalid or inaccessible
Or it may be slow to visit in some areas, such as China

I modified the url parsing script and now it will parse the mirrirs property in config.json. which is a map type property
Below is my `config.json`file
```json
{
  "SCOOP_BRANCH": "master",
  "lastupdate": "2021-07-11T10:33:24.5707181+08:00",
  "SCOOP_REPO": "https://github.com/lukesampson/scoop",
  "aria2-enabled": false,
  "list": "all",
  "proxy": "127.0.0.1:10809",
  "mirrors": {
    "http://repo.msys2.org/": " https://repo.huaweicloud.com/msys2/"
  }
}

```
At this time, scoop will download files from `repo.huaweicloud.com` instead of `repo.msys2.org`
