### PR TITLE
feat(core): Add pre_uninstall and post_uninstall hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
 
+### Features
+
+- **core:** Add pre_uninstall and post_uninstall hooks ([#4957](https://github.com/ScoopInstaller/Scoop/issues/4957))
+
 ### Bug Fixes
 
 - **chore:** Deprecate tls1 and tls1.1 ([#4950](https://github.com/ScoopInstaller/Scoop/pull/4950))

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1043,7 +1043,7 @@ function pre_uninstall($manifest, $arch) {
     $pre_uninstall = arch_specific 'pre_uninstall' $manifest $arch
     if($pre_uninstall) {
         write-output "Running pre-uninstall script..."
-        Invoke-Expression (@($pre_uninstall) -join "`r`n")
+        Invoke-Command ([scriptblock]::Create($pre_uninstall -join "`r`n"))
     }
 }
 
@@ -1059,7 +1059,7 @@ function post_uninstall($manifest, $arch) {
     $post_uninstall = arch_specific 'post_uninstall' $manifest $arch
     if($post_uninstall) {
         write-output "Running post-uninstall script..."
-        Invoke-Expression (@($post_uninstall) -join "`r`n")
+        Invoke-Command ([scriptblock]::Create($post_uninstall -join "`r`n"))
     }
 }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -1039,11 +1039,27 @@ function pre_install($manifest, $arch) {
     }
 }
 
+function pre_uninstall($manifest, $arch) {
+    $pre_uninstall = arch_specific 'pre_uninstall' $manifest $arch
+    if($pre_uninstall) {
+        write-output "Running pre-uninstall script..."
+        Invoke-Expression (@($pre_uninstall) -join "`r`n")
+    }
+}
+
 function post_install($manifest, $arch) {
     $post_install = arch_specific 'post_install' $manifest $arch
     if($post_install) {
         write-output "Running post-install script..."
         Invoke-Command ([scriptblock]::Create($post_install -join "`r`n"))
+    }
+}
+
+function post_uninstall($manifest, $arch) {
+    $post_uninstall = arch_specific 'post_uninstall' $manifest $arch
+    if($post_uninstall) {
+        write-output "Running post-uninstall script..."
+        Invoke-Expression (@($post_uninstall) -join "`r`n")
     }
 }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -51,7 +51,8 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     $persist_dir = persistdir $app $global
 
     $fname = dl_urls $app $version $manifest $bucket $architecture $dir $use_cache $check_hash
-    pre_install $manifest $architecture
+    Invoke-HookScript -HookType 'pre_install' -Manifest $manifest -Arch $architecture
+
     run_installer $fname $manifest $architecture $dir $global
     ensure_install_dir_not_in_path $dir $global
     $dir = link_current $dir
@@ -65,7 +66,7 @@ function install_app($app, $architecture, $global, $suggested, $use_cache = $tru
     persist_data $manifest $original_dir $persist_dir
     persist_permission $manifest $global
 
-    post_install $manifest $architecture
+    Invoke-HookScript -HookType 'post_install' -Manifest $manifest -Arch $architecture
 
     # save info for uninstall
     save_installed_manifest $app $bucket $dir $url
@@ -1031,35 +1032,25 @@ function env_rm($manifest, $global, $arch) {
     }
 }
 
-function pre_install($manifest, $arch) {
-    $pre_install = arch_specific 'pre_install' $manifest $arch
-    if($pre_install) {
-        write-output "Running pre-install script..."
-        Invoke-Command ([scriptblock]::Create($pre_install -join "`r`n"))
-    }
-}
+function Invoke-HookScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('pre_install', 'post_install',
+                     'pre_uninstall', 'post_uninstall')]
+        [String] $HookType,
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [PSCustomObject] $Manifest,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('32bit', '64bit')]
+        [String] $Arch
+    )
 
-function pre_uninstall($manifest, $arch) {
-    $pre_uninstall = arch_specific 'pre_uninstall' $manifest $arch
-    if($pre_uninstall) {
-        write-output "Running pre-uninstall script..."
-        Invoke-Command ([scriptblock]::Create($pre_uninstall -join "`r`n"))
-    }
-}
-
-function post_install($manifest, $arch) {
-    $post_install = arch_specific 'post_install' $manifest $arch
-    if($post_install) {
-        write-output "Running post-install script..."
-        Invoke-Command ([scriptblock]::Create($post_install -join "`r`n"))
-    }
-}
-
-function post_uninstall($manifest, $arch) {
-    $post_uninstall = arch_specific 'post_uninstall' $manifest $arch
-    if($post_uninstall) {
-        write-output "Running post-uninstall script..."
-        Invoke-Command ([scriptblock]::Create($post_uninstall -join "`r`n"))
+    $script = arch_specific $HookType $Manifest $Arch
+    if ($script) {
+        Write-Output "Running $HookType script..."
+        Invoke-Command ([scriptblock]::Create($script -join "`r`n"))
     }
 }
 

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -71,7 +71,7 @@ if (!$apps) { exit 0 }
         $install = install_info $app $version $global
         $architecture = $install.architecture
 
-        pre_uninstall $manifest $architecture
+        Invoke-HookScript -HookType 'pre_uninstall' -Manifest $manifest -Arch $architecture
 
         run_uninstaller $manifest $architecture $dir
         rm_shims $app $manifest $global $architecture
@@ -98,7 +98,7 @@ if (!$apps) { exit 0 }
             }
         }
 
-        post_uninstall $manifest $architecture
+        Invoke-HookScript -HookType 'post_uninstall' -Manifest $manifest -Arch $architecture
     }
     # remove older versions
     $oldVersions = @(Get-ChildItem $appDir -Name -Exclude 'current')

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -71,6 +71,8 @@ if (!$apps) { exit 0 }
         $install = install_info $app $version $global
         $architecture = $install.architecture
 
+        pre_uninstall $manifest $architecture
+
         run_uninstaller $manifest $architecture $dir
         rm_shims $app $manifest $global $architecture
         rm_startmenu_shortcuts $manifest $global $architecture
@@ -95,6 +97,8 @@ if (!$apps) { exit 0 }
                 continue
             }
         }
+
+        post_uninstall $manifest $architecture
     }
     # remove older versions
     $oldVersions = @(Get-ChildItem $appDir -Name -Exclude 'current')

--- a/schema.json
+++ b/schema.json
@@ -134,7 +134,13 @@
                 "post_install": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
+                "post_uninstall": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
                 "pre_install": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
+                "pre_uninstall": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
                 "shortcuts": {
@@ -567,7 +573,13 @@
         "post_install": {
             "$ref": "#/definitions/stringOrArrayOfStrings"
         },
+        "post_uninstall": {
+            "$ref": "#/definitions/stringOrArrayOfStrings"
+        },
         "pre_install": {
+            "$ref": "#/definitions/stringOrArrayOfStrings"
+        },
+        "pre_uninstall": {
             "$ref": "#/definitions/stringOrArrayOfStrings"
         },
         "psmodule": {


### PR DESCRIPTION
#### Description
Introducing `pre_uninstall` and `post_uninstall` hooks.

#### Motivation and Context
Closes #1868
Closes #4218

#### How Has This Been Tested?

##### hooktest1.json
```json
{
    "version": "0.2.0",
    "description": "A description",
    "homepage": "https://scoop.sh",
    "license": "UNLICENSE-or-MIT",
    "url": "https://github.com/ScoopInstaller/Scoop/archive/refs/tags/v0.2.0.tar.gz",
    "hash": "2cb9c0db892d13fed5bc49507deadc9c98f1038a96edba2d71c33a91bdb984a7",
    "extract_dir": "Scoop-0.2.0",
    "pre_uninstall": "Write-Host 'hook pre_uninstall executed.'",
    "post_uninstall": "Write-Host 'hook post_uninstall executed.'"
}
```

```
.\bin\scoop.ps1 install .\hooktest1.json
.\bin\scoop.ps1 uninstall hooktest1
```

##### hooktest2.json
```json
{
    "version": "0.2.0",
    "description": "A description",
    "homepage": "https://scoop.sh",
    "license": "UNLICENSE-or-MIT",
    "architecture": {
        "64bit": {
            "url": "https://github.com/ScoopInstaller/Scoop/archive/refs/tags/v0.2.0.tar.gz",
            "hash": "2cb9c0db892d13fed5bc49507deadc9c98f1038a96edba2d71c33a91bdb984a7",
            "extract_dir": "Scoop-0.2.0",
            "pre_uninstall": "Write-Host 'hook pre_uninstall executed.'",
            "post_uninstall": "Write-Host 'hook post_uninstall executed.'"
        }
    }
}
```

```
.\bin\scoop.ps1 install .\hooktest2.json
.\bin\scoop.ps1 uninstall hooktest2
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
