### PR TITLE
builds(schema): Set manifest schema to be stricter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.log
 .DS_Store
 ._.DS_Store
 scoop.sublime-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Bug Fixes
+
+- **schema**: Set manifest schema to be stricter ([#5093](https://github.com/ScoopInstaller/Scoop/issues/5093))
+
 ## [v0.2.4](https://github.com/ScoopInstaller/Scoop/compare/v0.2.3...v0.2.4) - 2022-08-08
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 - **schema**: Set manifest schema to be stricter ([#5093](https://github.com/ScoopInstaller/Scoop/issues/5093))
 
-
 ## [v0.2.4](https://github.com/ScoopInstaller/Scoop/compare/v0.2.3...v0.2.4) - 2022-08-08
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **scoop-update:** Stash uncommitted changes before update ([#5091](https://github.com/ScoopInstaller/Scoop/issues/5091))
 - **install:** Show the running process ([#5102](https://github.com/ScoopInstaller/Scoop/issues/5102))
 
-### Bug Fixes
+### Builds
 
 - **schema**: Set manifest schema to be stricter ([#5093](https://github.com/ScoopInstaller/Scoop/issues/5093))
 

--- a/schema.json
+++ b/schema.json
@@ -224,6 +224,9 @@
                         }
                     }
                 },
+                "bin": {
+                    "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
+                },
                 "extract_dir": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },

--- a/schema.json
+++ b/schema.json
@@ -227,6 +227,12 @@
                 "bin": {
                     "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
                 },
+                "env_add_path": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
+                "env_set": {
+                    "type": "object"
+                },
                 "extract_dir": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },

--- a/schema.json
+++ b/schema.json
@@ -605,6 +605,29 @@
             "type": "string"
         }
     },
+    "if": {
+        "properties": {
+            "architecture": {
+                "properties": {
+                    "64bit": {
+                        "properties": {
+                            "url": false
+                        }
+                    },
+                    "32bit": {
+                        "properties": {
+                            "url": false
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "then": {
+        "required": [
+            "url"
+        ]
+    },
     "required": [
         "version",
         "homepage",

--- a/schema.json
+++ b/schema.json
@@ -179,91 +179,79 @@
             "type": "array"
         },
         "autoupdateArch": {
+            "type": "object",
             "additionalProperties": false,
             "properties": {
-                "url": {
-                    "$ref": "#/definitions/autoupdateUriOrArrayOfAutoupdateUris"
-                },
-                "hash": {
-                    "$ref": "#/definitions/hashExtractionOrArrayOfHashExtractions"
+                "bin": {
+                    "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
                 },
                 "extract_dir": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
-                "extract_to": {
-                    "$ref": "#/definitions/stringOrArrayOfStrings"
-                },
-                "env_add_path": {
-                    "$ref": "#/definitions/stringOrArrayOfStrings"
-                },
-                "env_set": {
-                    "type": "object"
-                },
-                "bin": {
-                    "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
-                },
-                "shortcuts": {
-                    "$ref": "#/definitions/shortcutsArray"
+                "hash": {
+                    "$ref": "#/definitions/hashExtractionOrArrayOfHashExtractions"
                 },
                 "installer": {
+                    "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "file": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
-                "post_install": {
-                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                "shortcuts": {
+                    "$ref": "#/definitions/shortcutsArray"
                 },
-                "psmodule": {
+                "url": {
+                    "$ref": "#/definitions/autoupdateUriOrArrayOfAutoupdateUris"
+                }
+            }
+        },
+        "autoupdate": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "architecture": {
+                    "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                        "name": {
-                            "type": "string"
+                        "32bit": {
+                            "$ref": "#/definitions/autoupdateArch"
+                        },
+                        "64bit": {
+                            "$ref": "#/definitions/autoupdateArch"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
-                "persist": {
-                    "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
+                "extract_dir": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
+                "hash": {
+                    "$ref": "#/definitions/hashExtractionOrArrayOfHashExtractions"
                 },
                 "license": {
                     "$ref": "#/definitions/license"
                 },
                 "notes": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
-                }
-            },
-            "type": "object"
-        },
-        "autoupdate": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/autoupdateArch"
                 },
-                {
+                "persist": {
+                    "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
+                },
+                "psmodule": {
+                    "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "notes": {
-                            "$ref": "#/definitions/stringOrArrayOfStrings"
-                        },
-                        "architecture": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "32bit": {
-                                    "$ref": "#/definitions/autoupdateArch"
-                                },
-                                "64bit": {
-                                    "$ref": "#/definitions/autoupdateArch"
-                                }
-                            }
+                        "name": {
+                            "type": "string"
                         }
                     }
+                },
+                "url": {
+                    "$ref": "#/definitions/autoupdateUriOrArrayOfAutoupdateUris"
                 }
-            ],
-            "type": "object"
+            }
         },
         "checkver": {
             "anyOf": [

--- a/schema.json
+++ b/schema.json
@@ -185,6 +185,12 @@
                 "bin": {
                     "$ref": "#/definitions/stringOrArrayOfStringsOrAnArrayOfArrayOfStrings"
                 },
+                "env_add_path": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
+                "env_set": {
+                    "type": "object"
+                },
                 "extract_dir": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },


### PR DESCRIPTION
#### Description
Set manifest schema to be stricter.

#### Context
The schema was updated to support multiple URLs autoupdate in #3518 , which played well on its primary purpose. However, it [introduced](https://github.com/ScoopInstaller/Scoop/pull/3518#issuecomment-513732887) many other meaningless fields for autoupdate, such as `psmodule` and `persist` fields in the `autoupdateArch`, following `license` field added in #4528, causing unexpected manifests could be elaborately constructed to be like this:

**meaningless.json**
```json
{
    "homepage": "https://github.com/boyter/scc",
    "license": "ISC",
    "version": "1.0.0",
    "architecture": {
        "64bit": {
            "url": "https://github.com/boyter/scc/releases/download/v3.0.0/scc-3.0.0-x86_64-pc-windows.zip",
            "hash": "f3972acf03c09ff836071d1d173cb49281c8bc0f9682217118565ca62c5559b8"
        }
    },
    "psmodule": {
        "name": "module1"
    },
    "persist": "real",
    "checkver": "github",
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://github.com/boyter/scc/releases/download/v$version/scc-$version-x86_64-pc-windows.zip",
                "psmodule": {
                    "name": "module2"
                },
                "persist": "fake",
                "license": "GPL"
            }
        }
    }
}
```
This passes the current manifest schema without any errors, but it does not work as you expected of updating `psmodule`, `persist`, and `license` fields since they are not valid fields for the `architecture`.

I'm pretty sure @niheaven was going to *reuse* the `autoupdateArch` definition to achieve the goal of supporting multiple URLs, persistence, license, etc. autoupdate. But he failed and misused it, causing the possibility of creating invalid manifests.

#### Important notes

I'm going to make it much stricter such as removing `shortcuts`, `bin` fields from autoupdate. But @niheaven commented https://github.com/ScoopInstaller/Scoop/pull/3518#issuecomment-513651821 with the opinion of providing every possible property to be auto-updatable which I'm not a fan of it. **Hence I choose not to implement it in this PR and do an RFC.** I wasn't involved in #3518 therefore I didn't notice those changes in the schema. I would've challenged it if I did notice.

RFC
I do not think they are necessary to achieve the goal of updating shortcuts and binaries while updating the package version, though they have been used in some manifests such as [Versions/python-alpha](https://github.com/ScoopInstaller/Versions/blob/master/bucket/python-alpha.json#L117) and [Extras/linqpad](https://github.com/ScoopInstaller/Extras/blob/master/bucket/linqpad.json#L74). It's unnecessary and not a good practice to let shortcuts be tied with version-specific binaries, renaming the bin to a version-less name is always a better practice. You never want to shim a version-specific binary making the shim name change every time it updates to a new version.

#### How Has This Been Tested?
Test the crafted *meaningless.json* manifest with the patched schema.json and it will fail.
Test all manifests from known buckets *plus your own bucket if available* with the patched schema.json. All should be good.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
