### PR TITLE
fix(update): Do not uninstall the entire app when updating, add `pre_update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v0.3.2](https://github.com/ScoopInstaller/Scoop/compare/v0.3.1...v0.3.2) - 2023-09-18
+
+### Features
+
+- **update:** To prevent user data loss, do not uninstall the entire app when updating, i.e. don't trigger `pre_uninstall`, `post_uninstall` and `uninstaller`
+- **update:** Add support for `pre_update` (instead of `post_uninstall` in the update process)
+
 ## [v0.3.1](https://github.com/ScoopInstaller/Scoop/compare/v0.3.0...v0.3.1) - 2022-11-15
 
 ### Features

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -258,16 +258,12 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
     $dir = versiondir $app $old_version $global
     $persist_dir = persistdir $app $global
 
-    Invoke-HookScript -HookType 'pre_uninstall' -Manifest $old_manifest -Arch $architecture
-
     #region Workaround for #2952
     if (test_running_process $app $global) {
         return
     }
     #endregion Workaround for #2952
 
-    Write-Host "Uninstalling '$app' ($old_version)"
-    run_uninstaller $old_manifest $architecture $dir
     rm_shims $app $old_manifest $global $architecture
     env_rm_path $old_manifest $dir $global $architecture
     env_rm $old_manifest $global $architecture
@@ -291,7 +287,7 @@ function update($app, $global, $quiet = $false, $independent, $suggested, $use_c
         }
     }
 
-    Invoke-HookScript -HookType 'post_uninstall' -Manifest $old_manifest -Arch $architecture
+    Invoke-HookScript -HookType 'pre_update' -Manifest $old_manifest -Arch $architecture
 
     if ($bucket) {
         # add bucket name it was installed from

--- a/schema.json
+++ b/schema.json
@@ -140,6 +140,9 @@
                 "pre_install": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
+                "pre_update": {
+                    "$ref": "#/definitions/stringOrArrayOfStrings"
+                },
                 "pre_uninstall": {
                     "$ref": "#/definitions/stringOrArrayOfStrings"
                 },
@@ -617,6 +620,9 @@
             "$ref": "#/definitions/stringOrArrayOfStrings"
         },
         "pre_install": {
+            "$ref": "#/definitions/stringOrArrayOfStrings"
+        },
+        "pre_update": {
             "$ref": "#/definitions/stringOrArrayOfStrings"
         },
         "pre_uninstall": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
To prevent user data loss, don't trigger `pre_uninstall`, `post_uninstall` and `uninstaller` when updating (example: Spotify). The `pre_update` hook will be triggered instead of `post_uninstall`, so that separate operations before an update can (still) be specified.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
People will lose their user data with the current handling of updates.
Relates to #5648

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
NO. I do not have the means or the knowledge to properly test this.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
