### PR TITLE
feat(cache): Add "tidy" as older cache removal command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 **autoupdate:** GitHub predefined hashes support ([#6416](https://github.com/ScoopInstaller/Scoop/issues/6416), [#6435](https://github.com/ScoopInstaller/Scoop/issues/6435))
 
+### BREAKING CHANGE
+
+- **scoop-install|update**: `-k`option that skipped cache and forced redownload is replaced by `-d`. `-k` now keeps older cache after app update
+
+### Features
+
+- **scoop-cache|update**: New tidy command that removes older packages from cache. Automatically run it after app update ([#6068](https://github.com/ScoopInstaller/Scoop/issues/6068))
+
 ### Bug Fixes
 
 - **scoop-download|install|update:** Fallback to default downloader when aria2 fails ([#4292](https://github.com/ScoopInstaller/Scoop/issues/4292))

--- a/lib/cache.ps1
+++ b/lib/cache.ps1
@@ -1,0 +1,35 @@
+# Remove older cache of the given app
+function tidy_cache([String] $app, [bool] $total_log = $false) {
+    if ($app -like "*.json") { return }
+
+    # Dependencies of the format "bucket/dependency" install in a directory of form
+    # "dependency". So we need to extract the bucket from the name and only use the app
+    # name
+    $app = ($app -split '/|\\')[-1]
+
+    $files = @(Get-ChildItem $cachedir | Where-Object -Property Name -Value "^$app#" -Match | Sort-Object LastWriteTime )
+    if ($files.Count -le 2) {
+        return
+    }
+
+    # do not remove last two files
+    $files = $files[0..($files.Count - 3)]
+    # remove only items more than one month old
+    $files = $files| Where-Object {$_.LastWriteTime -lt (Get-Date).AddMonths(-1)}
+    if ($files.Count -le 0) {
+        if ($total_log) { Write-Host "No old cache to remove" -ForegroundColor Yellow }
+        return
+    }
+    Write-Host -f yellow "Removing older cache for $app`:" -NoNewline
+
+    $totalLength = ($files | Measure-Object -Property Length -Sum).Sum
+    $files | ForEach-Object {
+        Write-Host " $(($_ -split '#')[1])" -NoNewline
+        Remove-Item $_.FullName
+    }
+
+    Write-Host ''
+    if ($total_log) {
+        Write-Host "Deleted: $($files.Count) $(pluralize $files.Count 'file' 'files'), $(filesize $totalLength)" -ForegroundColor Yellow
+    }
+}

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -1,4 +1,4 @@
-# Usage: scoop cache show|rm [app(s)]
+# Usage: scoop cache show|rm|tidy [app(s)]
 # Summary: Show or clear the download cache
 # Help: Scoop caches downloads so you don't need to download the same files
 # when you uninstall and re-install the same version of an app.
@@ -7,12 +7,18 @@
 #     scoop cache show
 # to see what's in the cache, and
 #     scoop cache rm <app> to remove downloads for a specific app.
+# Or to only remove downloads that older,
+#     scoop cache tidy <app> removes ones older than a month, keeping the two most recent
 #
 # To clear everything in your cache, use:
 #     scoop cache rm *
+# To remove older items for all apps, use:
+#     scoop cache tidy *
 # You can also use the `-a/--all` switch in place of `*` here
 
 param($cmd)
+
+. "$PSScriptRoot\..\lib\cache.ps1"
 
 function cacheinfo($file) {
     $app, $version, $url = $file.Name -split '#'
@@ -58,9 +64,41 @@ function cacheremove($app) {
     Write-Host "Deleted: $($files.Length) $(pluralize $files.Length 'file' 'files'), $(filesize $totalLength)" -ForegroundColor Yellow
 }
 
+function cache_remove_older($app) {
+    if (!$app) {
+        'ERROR: <app(s)> missing'
+        my_usage
+        exit 1
+    } elseif ($app -eq '*' -or $app -eq '-a' -or $app -eq '--all') {
+        $files = @(Get-ChildItem $cachedir)
+        $totalLength = ($files | Measure-Object -Property Length -Sum).Sum
+        # Get all apps with cache, and remove their older packages
+        $apps = @()
+        $files | ForEach-Object {
+            $apps += ($_ -split '#', 2)[0]
+        }
+        $apps = $apps | Select-Object -Unique
+
+        $apps | ForEach-Object {
+            tidy_cache $_
+        }
+
+        $filesAfter = @(Get-ChildItem $cachedir)
+        $totalLengthAfter = ($filesAfter | Measure-Object -Property Length -Sum).Sum
+        $filesRemoved = $files.Length - $filesAfter.length
+        $sizeRemoved = $totalLength - $totalLengthAfter
+        Write-Host "Deleted: $($filesRemoved) $(pluralize $filesRemoved 'file' 'files'), $(filesize $sizeRemoved)" -ForegroundColor Yellow
+    } else {
+        tidy_cache $app $true
+    }
+}
+
 switch($cmd) {
     'rm' {
         cacheremove $Args
+    }
+    'tidy' {
+        cache_remove_older $Args
     }
     'show' {
         cacheshow $Args

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -22,7 +22,7 @@
 # Options:
 #   -g, --global                    Install the app globally
 #   -i, --independent               Don't install dependencies automatically
-#   -k, --no-cache                  Don't use the download cache
+#   -d, --no-cache                  Force redownload by not using the download cache
 #   -s, --skip-hash-check           Skip hash validation (use with caution!)
 #   -u, --no-update-scoop           Don't update Scoop before installing if it's outdated
 #   -a, --arch <32bit|64bit|arm64>  Use the specified architecture, if the app supports it
@@ -49,7 +49,7 @@ if ($err) { "scoop install: $err"; exit 1 }
 $global = $opt.g -or $opt.global
 $check_hash = !($opt.s -or $opt.'skip-hash-check')
 $independent = $opt.i -or $opt.independent
-$use_cache = !($opt.k -or $opt.'no-cache')
+$use_cache = !($opt.d -or $opt.'no-cache')
 $architecture = Get-DefaultArchitecture
 try {
     $architecture = Format-ArchitectureString ($opt.a + $opt.arch)


### PR DESCRIPTION
- Keep two items in cache for every app
- Files that are less than one month old are not deleted
- Automatically remove older cache of the app after an update
- Short option to do not use cache changed form `-k` to `-d` (for "download")
- Add option to keep older cache, with `-k` (for "keep") as short option to `update` command
- Add long option `--keep-cache` to `update` command

#### Description
The new `cache tidy` command enables to clean all packages older than one month, except the two most recent ones, of all the apps (with "*"), or a given one. This cache "tidying" is automatically ran after an app is updated, for this app only.
No option to change the one month period or the minimum number to keep is present at the moment.

#### Motivation and Context
Files in the cache folder were never automatically removed. It makes it grow in size and many (most?) do not know about it or or how to clean it. Besides, the only way to manage the cache was by removing all of it. 

* Closes [[Feature] Remove older files from cache after installation  #6068](https://github.com/ScoopInstaller/Scoop/issues/6068)

#### How Has This Been Tested?
I have overwritten my local scoop scripts with the ones I modified in the repository.
I modified the date of a copy of a recent "which" package in cache with `(Get-Item which#2.16#607562b.zip).lastwritetime=$(Get-Date -Year 2020 -Month 12 -Day 31)`. Then I used the new tidy command with `scoop tidy which`. Only the package that is supposed to be older was removed.
Then I modified the version in the manifest of the "current" package of which, so that scoop suppose it is outdated. I did the same procedure of copying a recent package and editing its date. Then I ran `scoop update which`. "which" was reinstalled. Again, only the package that is supposed to be older was removed.

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
