### PR TITLE
Shim with link

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -899,12 +899,12 @@ function shim($path, $global, $name, $arg) {
     if ($path -match '\.(exe|com)$') {
         # for programs with no awareness of any shell
         warn_on_overwrite "$shim.shim" $path
-        Copy-Item (get_shim_path) "$shim.exe" -Force
         Write-Output "path = `"$resolved_path`"" | Out-UTF8File "$shim.shim"
         if ($arg) {
             Write-Output "args = $arg" | Out-UTF8File "$shim.shim" -Append
         }
 
+        Copy-Item (get_shim_path) "$shim.exe" -Force
         $target_subsystem = Get-PESubsystem $resolved_path
         if ($target_subsystem -eq 2) { # we only want to make shims GUI
             Write-Output "Making $shim.exe a GUI binary."

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -900,6 +900,9 @@ function shim($path, $global, $name, $arg) {
         # for programs with no awareness of any shell
         warn_on_overwrite "$shim.shim" $path
         Write-Output "path = `"$resolved_path`"" | Out-UTF8File "$shim.shim"
+        if ((-not $arg) -and (get_config SHIM_WITH_LINK)) {
+            cmd.exe /d /c "mklink `"$shim.exe`" `"$resolved_path`""
+        } else {
         if ($arg) {
             Write-Output "args = $arg" | Out-UTF8File "$shim.shim" -Append
         }
@@ -909,6 +912,7 @@ function shim($path, $global, $name, $arg) {
         if ($target_subsystem -eq 2) { # we only want to make shims GUI
             Write-Output "Making $shim.exe a GUI binary."
             Set-PESubsystem "$shim.exe" $target_subsystem | Out-Null
+        }
         }
     } elseif ($path -match '\.(bat|cmd)$') {
         # shim .bat, .cmd so they can be used by programs with no awareness of PSH

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -74,6 +74,9 @@
 # shim: kiennq|scoopcs|71
 #       Choose scoop shim build.
 #
+# shim_with_link: $true|$false
+#       When set to $true, Scoop will use 'mklink' to create shims without arguments. Default is $false.
+#
 # root_path: $Env:UserProfile\scoop
 #       Path to Scoop root directory.
 #


### PR DESCRIPTION
#### Description
Create exe shims using a symlink to actual exe.

#### Motivation and Context
My work antivirus has flagged kiennq shim as problematic.
I thus tried and made exe shims using symlinks instead.

#### How Has This Been Tested?
This has been tested:
- with https://github.com/ScoopInstaller/Scoop/pull/6374
- currently on my work station

#### Checklist:
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
