### PR TITLE
fix(download): Fix function `nightly_version` not defined error in scoop-download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/master...develop)
+
+### Bug Fixes
+
+- **download**: Fix function `nightly_version` not defined error in scoop-download ([#6385](https://github.com/ScoopInstaller/Scoop/issues/6385))
+
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2024-12-31
 
 ### Bug Fixes

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -24,6 +24,7 @@
 . "$PSScriptRoot\..\lib\autoupdate.ps1" # 'generate_user_manifest' (indirectly)
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'generate_user_manifest' 'Get-Manifest'
 . "$PSScriptRoot\..\lib\download.ps1"
+. "$PSScriptRoot\..\lib\install.ps1" # 'nightly_version'
 if (get_config USE_SQLITE_CACHE) {
     . "$PSScriptRoot\..\lib\database.ps1"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
Import `\lib\install.ps1` in `\libexec\scoop-download.ps1`

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6385

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Download a nightly build, which use `"version": "nightly"` in manifest
Here I'm testing with `rust-nightly` in `versions` bucket

Before changes
```
> scoop download rust-nightly
INFO  Downloading 'rust-nightly' [64bit] from versions bucket
nightly_version : The term 'nightly_version' is not recognized as the name of a cmdlet, function, script file, or opera
ble program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Users\A1\scoop\apps\scoop\current\libexec\scoop-download.ps1:91 char:20
+         $version = nightly_version
+                    ~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (nightly_version:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException

Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 1f66a2|OK  |    29MiB/s|C:/Users/A1/scoop/cache/rust-nightly#nightly#842e246.msi
Download: Status Legend:
Download: (OK):download completed.
'rust-nightly' (nightly) was downloaded successfully!
```

After changes
```
> scoop download rust-nightly
INFO  Downloading 'rust-nightly' [64bit] from versions bucket
WARN  This is a nightly version. Downloaded files won't be verified.
Starting download with aria2 ...
Download: Download Results:
Download: gid   |stat|avg speed  |path/URI
Download: ======+====+===========+=======================================================
Download: 1326bd|OK  |    29MiB/s|C:/Users/A1/scoop/cache/rust-nightly#nightly-20250611#842e246.msi
Download: Status Legend:
Download: (OK):download completed.
'rust-nightly' (nightly-20250611) was downloaded successfully!
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
