### PR TITLE
fix(import-bucket-tests): fix `Get-GitChangedFile` `Include` pattern for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/v0.5.3...develop)
 
 ### Bug Fixes
@@ -6,6 +8,7 @@
 - **autoupdate:** Use origin URL to handle URLs with fragment in GitHub mode ([#6455](https://github.com/ScoopInstaller/Scoop/issues/6455))
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
+- **import-bucket-tests:** fix `Get-GitChangedFile` `Include` pattern for CI ([93b9bae](https://github.com/ScoopInstaller/Scoop/commit/93b9bae33a88ccde6590c4df3f589f47c58a527e))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/test/Import-Bucket-Tests.ps1
+++ b/test/Import-Bucket-Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Manifest validates against the schema' {
         }
         if ($env:CI -eq $true) {
             Set-BuildEnvironment -Force
-            $manifestFiles = @(Get-GitChangedFile -Path $bucketDir -Include '*.json' -Commit $env:BHCommitHash)
+            $manifestFiles = @(Get-GitChangedFile -Path $bucketDir -Include "$((Get-Item $bucketDir).Name)/*.json" -Commit $env:BHCommitHash)
         } else {
             $manifestFiles = (Get-ChildItem $bucketDir -Filter '*.json' -Recurse).FullName
         }


### PR DESCRIPTION
#### Description

Prepend the name of the `$bucketDir` to `Get-GitChangedFile`'s `Include` pattern to narrow the pattern to include only bucket manifests (i.e. include `"./bucket/*.json"` instead of `"./**/*.json"`).

Previously, when `$ENV:CI` is `$true`, the "Manifest validates against the schema" test would test _all_ changed JSON files in the repo (e.g. ".vscode/settings.json"). `Get-GitChangedFile`'s `Path` parameter seemed to have been used to specify the bucket directory, but `Get-GitChangedFile` only uses it for finding a repo root.


#### Motivation and Context

Fixes #6394 

#### How Has This Been Tested?

Local debug runs of "Scoop-Bucket.Tests.ps1" with `$env:CI` set to `$true`.
Additionally, `. ./test/bin/test.ps1` succeeds locally in PowerShell 7.5.1 and Windows PowerShell 5.1.22621.4391

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes CI import-bucket behavior by tightening the file include pattern, improving test accuracy and CI reliability.
* **Tests**
  * Restricts manifest discovery in CI to bucket-specific subpaths while leaving local test discovery unchanged.
* **Chores**
  * Adds a new Bug Fixes entry to the top of the Unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->