### PR TITLE
fix(scoop-download): Fail download when hash mismatch

### DIFF
--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -127,7 +127,7 @@ foreach ($curr_app in $apps) {
                     if ($url -like '*sourceforge.net*') {
                         warn 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
-                    error (new_issue_msg $app $bucket "hash check failed")
+                    abort $(new_issue_msg $app $bucket "hash check failed")
                     continue
                 }
             } else {


### PR DESCRIPTION
#### Motivation and Context
- Closes #6413

#### Description
When downloaded file is removed due to hash verification failure, scoop still reports the download as successful.

This PR makes the following changes:
- `fix(scoop-download)`: change to abort instead of continue when hash check fails.
    - Before: <img width="1225" height="481" alt="Image" src="https://github.com/user-attachments/assets/34181d7f-92ee-4197-a87d-491ce91b5be1" />
    - After: <img width="1216" height="449" alt="image" src="https://github.com/user-attachments/assets/0a8c3acd-b4fc-497b-817e-e14ef1e52eeb" />

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
