### PR TITLE
feat(autoupdate): predefined hash case for GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2024-12-31
 
+### Features
+
+- **autoupdate:** Remove `sha256:` prefix in `format_hash()` ([#6381](https://github.com/ScoopInstaller/Scoop/issues/6381))
+- **autoupdate:** Add GitHub support in `get_hash_for_app()` ([#6381](https://github.com/ScoopInstaller/Scoop/issues/6381))
+
 ### Bug Fixes
 
 - **scoop-download|install|update:** Fallback to default downloader when aria2 fails ([#4292](https://github.com/ScoopInstaller/Scoop/issues/4292))

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -2,11 +2,15 @@
 
 function format_hash([String] $hash) {
     $hash = $hash.toLower()
+
+    if ($hash -like 'sha256:*') {
+        $hash = $hash.Substring(7)  # Remove prefix 'sha256:'
+    }
+
     switch ($hash.Length) {
         32 { $hash = "md5:$hash" } # md5
         40 { $hash = "sha1:$hash" } # sha1
         64 { $hash = $hash } # sha256
-        71 { $hash = $hash -replace 'sha256:', '' } # sha256
         128 { $hash = "sha512:$hash" } # sha512
         default { $hash = $null }
     }

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -6,6 +6,7 @@ function format_hash([String] $hash) {
         32 { $hash = "md5:$hash" } # md5
         40 { $hash = "sha1:$hash" } # sha1
         64 { $hash = $hash } # sha256
+        71 { $hash = $hash -replace 'sha256:', '' } # sha256
         128 { $hash = "sha512:$hash" } # sha512
         default { $hash = $null }
     }
@@ -259,6 +260,10 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
         $hashmode = 'sourceforge'
     }
 
+    if ($url -match 'https:\/\/github\.com\/(?<owner>[^\/]+)\/(?<repo>[^\/]+)\/releases\/download\/[^\/]+\/[^\/]+') {
+        $hashmode = 'github'
+    }
+
     switch ($hashmode) {
         'extract' {
             $hash = find_hash_in_textfile $hashfile_url $substitutions $regex
@@ -285,6 +290,10 @@ function get_hash_for_app([String] $app, $config, [String] $version, [String] $u
             # change the URL because downloads.sourceforge.net doesn't have checksums
             $hashfile_url = (strip_filename (strip_fragment "https://sourceforge.net/projects/$($matches['project'])/files/$($matches['file'])")).TrimEnd('/')
             $hash = find_hash_in_textfile $hashfile_url $substitutions '"$basename":.*?"sha1":\s*"([a-fA-F0-9]{40})"'
+        }
+        'github' {
+            $hashfile_url = "https://api.github.com/repos/$($matches['owner'])/$($matches['repo'])/releases"
+            $hash = find_hash_in_json $hashfile_url $substitutions ("$..assets[?(@.browser_download_url == '" + $url + "')].digest")
         }
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->
- Remove `sha256:` prefix in `format_hash()`
- Add GitHub support in `get_hash_for_app()`

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- or -->
Close #6381

Use digests that automatically computed by GitHub.
[Releases now expose digests for release assets - GitHub Changelog](https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/)

Just like `fosshub` and `sourceforge` did: [Special cases for FossHub and SourceForge - App Manifest Autoupdate · ScoopInstaller/Scoop Wiki](https://github.com/ScoopInstaller/Scoop/wiki/App-Manifest-Autoupdate#special-cases-for-fosshub-and-sourceforge)

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
```
(develop) $ .\bin\checkver.ps1 -Dir D:\apps\scoop\apps\peerbanhelper -u -f
manifest: 8.0.2 (scoop version is 8.0.2)
Forcing autoupdate!
Autoupdating manifest
Found: a6233a0f9c0f6d4fc37d9355177727f264be582b10cd54797f84b8801fd9f825 using Github Mode
Found: a6233a0f9c0f6d4fc37d9355177727f264be582b10cd54797f84b8801fd9f825 using Github Mode
Writing updated manifest manifest
```

PeerBanHelper is not merged yet. Manifest here: ScoopInstaller/Extras/pull/15764

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] ~~I have updated the documentation accordingly.~~ No, I don't have permission to edit wiki.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
