### PR TITLE
feat(install): Add separator at the end of notes, highlight suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/ScoopInstaller/Scoop/compare/v0.5.3...develop)
 
+### Features
+
+- **install:** Add separator at the end of notes, highlight suggestions ([#6418](https://github.com/ScoopInstaller/Scoop/issues/6418))
+
 ### Bug Fixes
 
 - **scoop-download:** Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -359,6 +359,7 @@ function show_notes($manifest, $dir, $original_dir, $persist_dir) {
         Write-Output 'Notes'
         Write-Output '-----'
         Write-Output (wraptext (substitute $manifest.notes @{ '$dir' = $dir; '$original_dir' = $original_dir; '$persist_dir' = $persist_dir }))
+        Write-Output '-----'
     }
 }
 
@@ -419,7 +420,7 @@ function show_suggestions($suggested) {
             }
 
             if (!$fulfilled) {
-                Write-Host "'$app' suggests installing '$([string]::join("' or '", $feature_suggestions))'."
+                Write-Host "'$app' suggests installing '$([string]::join("' or '", $feature_suggestions))'." -ForegroundColor DarkYellow
             }
         }
     }


### PR DESCRIPTION
#### Description
This PR makes the following changes:
- `feat(install)`: Add separator at the end of notes, highlight suggestions.

#### Motivation and Context
- Closes #6417 
The suggestion and note sections lack proper visual separation, and suggestion section isn't highlighted, making it easy to be ignored.
    - Before: <img width="1107" height="244" alt="Image" src="https://github.com/user-attachments/assets/67b218d2-d474-4dce-b6a8-5b90f5890a2d" />
    - After: <img width="1100" height="267" alt="Image" src="https://github.com/user-attachments/assets/a53de18d-5a26-49c5-9cf5-1240f0bc0b9d" />

#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Installer now adds a separator after displayed notes for clearer readability.
  - Unmet feature suggestions are highlighted in DarkYellow for improved visibility.

- Documentation
  - Updated changelog under Unreleased to reflect the new installer display enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->