### PR TITLE
Fix: it's not correct when url is new type of eclipse

### DIFF
--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -680,7 +680,9 @@ function ftp_file_size($url) {
 }
 
 function url_filename($url) {
-    (Split-Path $url -Leaf).split('?') | Select-Object -First 1
+    # eclipse-mat mirror auto selected parameter "&r=1"
+    # regularly, "&" should be a part of URL
+    (Split-Path $url -Leaf).split('?').Split('&') | Select-Object -First 1
 }
 
 function url_remote_filename($url) {
@@ -688,7 +690,7 @@ function url_remote_filename($url) {
     # URL fragment (e.g. #/dl.7z, useful for coercing a local filename),
     # this function extracts the original filename from the URL.
     $uri = (New-Object URI $url)
-    $basename = Split-Path $uri.PathAndQuery -Leaf
+    $basename = url_filename $url
     If ($basename -match '.*[?=]+([\w._-]+)') {
         $basename = $matches[1]
     }


### PR DESCRIPTION
Eclipse has updated its website address and interface. In the new download address, there is a "&r=1" parameter to automatically select a mirror site. This will be incorrectly processed as a file name and needs to be corrected.

https://wiki.eclipse.org/CBI/How_to_check_integrity_of_downloads_from_the_Eclipse_Foundation

link to [15977](https://github.com/ScoopInstaller/Extras/pull/15977)

tested:

```powershell
.\bin\checkver.ps1 eclipse-mat  -D "D:\Scoop\buckets\Extras\"  -u
scoop install  D:\scoop\buckets\extras\bucket\eclipse-mat.json
scoop uninstall eclipse-mat
scoop install extras/eclipse-sdk
scoop install extras/eclipse-java
scoop install main/python
python.exe -v
scoop uninstall python
scoop install main/python
scoop uninstall python
scoop install extras/010editor
scoop uninstall 010editor
```

