### PR TITLE
fix(buckets|scoop-info): Switch git log date format to ISO 8601 to avoid locale issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - **scoop-download**: Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))
+- **buckets|scoop-info**: Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/pull/6446))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -108,7 +108,7 @@ function list_buckets {
         $path = Find-BucketDirectory $_ -Root
         if ((Test-Path (Join-Path $path '.git')) -and (Get-Command git -ErrorAction SilentlyContinue)) {
             $bucket.Source = Invoke-Git -Path $path -ArgumentList @('config', 'remote.origin.url')
-            $bucket.Updated = Invoke-Git -Path $path -ArgumentList @('log', '--format=%aD', '-n', '1') | Get-Date
+            $bucket.Updated = Invoke-Git -Path $path -ArgumentList @('log', '--format=%aI', '-n', '1') | Get-Date
         } else {
             $bucket.Source = friendly_path $path
             $bucket.Updated = (Get-Item "$path\bucket" -ErrorAction SilentlyContinue).LastWriteTime

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -122,7 +122,7 @@ if ($manifest.depends) {
 
 if (Test-Path $manifest_file) {
     if (Get-Command git -ErrorAction Ignore) {
-        $gitinfo = (Invoke-Git -Path (Split-Path $manifest_file) -ArgumentList @('log', '-1', '-s', '--format=%aD#%an', $manifest_file) 2> $null) -Split '#'
+        $gitinfo = (Invoke-Git -Path (Split-Path $manifest_file) -ArgumentList @('log', '-1', '-s', '--format=%aI#%an', $manifest_file) 2> $null) -Split '#'
     }
     if ($gitinfo) {
         $item.'Updated at' = $gitinfo[0] | Get-Date


### PR DESCRIPTION
#### Motivation and Context
- Closes #6429
- Closes #6607

#### Description
```powershell
git log -1 --format='%aD' | Get-Date
```
```powershell
git log -1 --format='%aI' | Get-Date
```
Passing an RFC2822-formatted (`%aD`) time string to _Get-Date_ may result in parsing failures depending on the system locale.

Switching to ISO 8601 format (`%aI`) ensures consistent parsing across all regions, as it uses a standardized format like `2025-08-12T08:02:16+02:00`.

See also:
- https://github.com/git/git/commit/466fb6742d7fb7d3e6994b2d0d8db83a8786ebcf
- https://git-scm.com/docs/git-log#Documentation/git-log.txt-aI
- https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-date?view=powershell-5.1#description

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.
