### PR TITLE
refactor: replace raw prints with functions for standardized output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **scoop-download**: Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))
 
+### Code Refactoring
+
+- **output**: replace raw prints with functions for standardized output
+
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Code Refactoring
 
-- **output**: replace raw prints with functions for standardized output
+- **output**: replace raw prints with functions for standardized output ([#6450](https://github.com/ScoopInstaller/Scoop/issues/6450))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Code Refactoring
 
-- **output**: replace raw prints with functions for standardized output ([#6450](https://github.com/ScoopInstaller/Scoop/issues/6450))
+- **output**: Replace raw prints with functions for standardized output ([#6450](https://github.com/ScoopInstaller/Scoop/issues/6450))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Code Refactoring
 
-- **output**: Replace raw prints with functions for standardized output ([#6450](https://github.com/ScoopInstaller/Scoop/issues/6450))
+- **output**: Replace raw prints with functions for standardized output ([#6449](https://github.com/ScoopInstaller/Scoop/issues/6449))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -90,7 +90,7 @@ function load_cfg($file) {
         $content = [System.IO.File]::ReadAllLines($file)
         return ($content | ConvertFrom-Json -ErrorAction Stop)
     } catch {
-        Write-Host "ERROR loading $file`: $($_.exception.message)"
+        error "loading $file`: $($_.exception.message)"
     }
 }
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -285,7 +285,7 @@ function ensure_install_dir_not_in_path($dir, $global) {
 
     $fixed, $removed = find_dir_or_subdir $path "$dir"
     if ($removed) {
-        $removed | ForEach-Object { "Installer added '$(friendly_path $_)' to path. Removing." }
+        $removed | ForEach-Object { Write-Output "Installer added '$(friendly_path $_)' to path. Removing." }
         Set-EnvVar -Name 'PATH' -Value $fixed -Global:$global
     }
 

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -40,7 +40,7 @@ if ($SubCommand -notin $SubCommands) {
 }
 
 $opt, $other, $err = getopt $Args 'v' 'verbose'
-if ($err) { "scoop alias: $err"; exit 1 }
+if ($err) { error "scoop alias: $err"; exit 1 }
 
 $name, $command, $description = $other
 $verbose = $opt.v -or $opt.verbose

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -34,14 +34,14 @@ $usage_rm = 'usage: scoop bucket rm <name>'
 switch ($cmd) {
     'add' {
         if (!$name) {
-            '<name> missing'
+            error '<name> missing'
             $usage_add
             exit 1
         }
         if (!$repo) {
             $repo = known_bucket_repo $name
             if (!$repo) {
-                "Unknown bucket '$name'. Try specifying <repo>."
+                error "Unknown bucket '$name'. Try specifying <repo>."
                 $usage_add
                 exit 1
             }
@@ -51,7 +51,7 @@ switch ($cmd) {
     }
     'rm' {
         if (!$name) {
-            '<name> missing'
+            error '<name> missing'
             $usage_rm
             exit 1
         }
@@ -73,7 +73,7 @@ switch ($cmd) {
         exit 0
     }
     default {
-        "scoop bucket: cmd '$cmd' not supported"
+        error "scoop bucket: cmd '$cmd' not supported"
         my_usage
         exit 1
     }

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -35,7 +35,7 @@ function cacheshow($app) {
 
 function cacheremove($app) {
     if (!$app) {
-        'ERROR: <app(s)> missing'
+        error '<app(s)> missing'
         my_usage
         exit 1
     } elseif ($app -eq '*' -or $app -eq '-a' -or $app -eq '--all') {

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -16,15 +16,15 @@
 . "$PSScriptRoot\..\lib\install.ps1" # persist related
 
 $opt, $apps, $err = getopt $args 'agk' 'all', 'global', 'cache'
-if ($err) { "scoop cleanup: $err"; exit 1 }
+if ($err) { error "scoop cleanup: $err"; exit 1 }
 $global = $opt.g -or $opt.global
 $cache = $opt.k -or $opt.cache
 $all = $opt.a -or $opt.all
 
-if (!$apps -and !$all) { 'ERROR: <app> missing'; my_usage; exit 1 }
+if (!$apps -and !$all) { error '<app> missing'; my_usage; exit 1 }
 
 if ($global -and !(is_admin)) {
-    'ERROR: you need admin rights to cleanup global apps'; exit 1
+    error 'you need admin rights to cleanup global apps'; exit 1
 }
 
 function cleanup($app, $global, $verbose, $cache) {

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -27,17 +27,17 @@ function print_summaries {
 
 $commands = commands
 
-if(!($cmd)) {
+if (!($cmd)) {
     Write-Host "Usage: scoop <command> [<args>]
 
 Available commands are listed below.
 
 Type 'scoop help <command>' to get more help for a specific command."
     print_summaries
-} elseif($commands -contains $cmd) {
+} elseif ($commands -contains $cmd) {
     print_help $cmd
 } else {
-    warn "scoop help: no such command '$cmd'"
+    error "scoop help: no such command '$cmd'"
     exit 1
 }
 

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -15,7 +15,7 @@
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 $opt, $apps, $err = getopt $args 'g' 'global'
-if ($err) { "scoop hold: $err"; exit 1 }
+if ($err) { error "scoop hold: $err"; exit 1 }
 
 $global = $opt.g -or $opt.global
 

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -44,7 +44,7 @@ if (get_config USE_SQLITE_CACHE) {
 }
 
 $opt, $apps, $err = getopt $args 'giksua:' 'global', 'independent', 'no-cache', 'skip-hash-check', 'no-update-scoop', 'arch='
-if ($err) { "scoop install: $err"; exit 1 }
+if ($err) { error "scoop install: $err"; exit 1 }
 
 $global = $opt.g -or $opt.global
 $check_hash = !($opt.s -or $opt.'skip-hash-check')

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -17,7 +17,7 @@ $global = installed_apps $true | ForEach-Object { @{ name = $_; global = $true }
 
 $apps = @($local) + @($global)
 if (-not $apps) {
-    Write-Host "There aren't any apps installed."
+    warn "There aren't any apps installed."
     exit 1
 }
 
@@ -48,7 +48,7 @@ $apps | Where-Object { !$query -or ($_.name -match $query) } | ForEach-Object {
     $item.Updated = $updated
 
     $info = @()
-    if ((app_status $app $global).deprecated) { $info += 'Deprecated package'}
+    if ((app_status $app $global).deprecated) { $info += 'Deprecated package' }
     if ($global) { $info += 'Global install' }
     if (failed $app $global) { $info += 'Install failed' }
     if ($install_info.hold) { $info += 'Held package' }

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -14,7 +14,7 @@
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 
 $opt, $apps, $err = getopt $args 'a' 'all'
-if($err) { "scoop reset: $err"; exit 1 }
+if($err) { error "scoop reset: $err"; exit 1 }
 $all = $opt.a -or $opt.all
 
 if(!$apps -and !$all) { error '<app> missing'; my_usage; exit 1 }

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -48,7 +48,7 @@ if ($SubCommand -notin @('add', 'rm', 'list', 'info', 'alter')) {
 }
 
 $opt, $other, $err = getopt $Args 'g' 'global'
-if ($err) { "scoop shim: $err"; exit 1 }
+if ($err) { error "scoop shim: $err"; exit 1 }
 
 $global = $opt.g -or $opt.global
 

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -147,8 +147,7 @@ switch ($SubCommand) {
                 $pattern = $_
                 [void][Regex]::New($pattern)
             } catch {
-                Write-Host "ERROR: Invalid pattern: " -ForegroundColor Red -NoNewline
-                Write-Host $pattern -ForegroundColor Magenta
+                error "Invalid pattern: `e[35m$pattern"
                 exit 1
             }
         }

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -147,7 +147,7 @@ switch ($SubCommand) {
                 $pattern = $_
                 [void][Regex]::New($pattern)
             } catch {
-                error "Invalid pattern: `e[35m$pattern"
+                error "Invalid pattern: $([char]0x1b)[35m$pattern$([char]0x1b)[0m"
                 exit 1
             }
         }

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -15,7 +15,7 @@
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
 
 $opt, $apps, $err = getopt $args 'g' 'global'
-if ($err) { "scoop unhold: $err"; exit 1 }
+if ($err) { error "scoop unhold: $err"; exit 1 }
 
 $global = $opt.g -or $opt.global
 

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -30,7 +30,7 @@ if (get_config USE_SQLITE_CACHE) {
 }
 
 $opt, $apps, $err = getopt $args 'gfiksqa' 'global', 'force', 'independent', 'no-cache', 'skip-hash-check', 'quiet', 'all'
-if ($err) { "scoop update: $err"; exit 1 }
+if ($err) { error "scoop update: $err"; exit 1 }
 $global = $opt.g -or $opt.global
 $force = $opt.f -or $opt.force
 $check_hash = !($opt.s -or $opt.'skip-hash-check')
@@ -400,7 +400,7 @@ if (-not ($apps -or $all)) {
     success 'Scoop was updated successfully!'
 } else {
     if ($global -and !(is_admin)) {
-        'ERROR: You need admin rights to update global apps.'; exit 1
+        error 'You need admin rights to update global apps.'; exit 1
     }
 
     $outdated = @()

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -36,7 +36,7 @@
 . "$PSScriptRoot\..\lib\depends.ps1" # 'Get-Dependency'
 
 $opt, $apps, $err = getopt $args 'asnup' @('all', 'scan', 'no-depends', 'no-update-scoop', 'passthru')
-if ($err) { "scoop virustotal: $err"; exit 1 }
+if ($err) { error "scoop virustotal: $err"; exit 1 }
 $all = $apps -eq '*' -or $opt.a -or $opt.all
 if (!$apps -and !$all) { my_usage; exit 1 }
 $architecture = Get-DefaultArchitecture


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Replace raw prints with functions for standardized output.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6450 


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added update flags: --no-cache, --quiet, --independent, and --all.

* **Refactor**
  * Standardized error/warning output across commands for more consistent messaging and visibility.
  * “No apps installed” now surfaces as a warning; help command now exits explicitly with success.
  * Removal messages for install-path cleanup now emit to standard output.

* **Documentation**
  * Changelog updated with a “Code Refactoring” note about standardized output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->