### PR TITLE
fix(core|manifest): Avoid error when searching non-existent 'deprecated' directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **autoupdate:** Use origin URL to handle URLs with fragment in GitHub mode ([#6455](https://github.com/ScoopInstaller/Scoop/issues/6455))
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
+- **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -555,7 +555,7 @@ function app_status($app, $global) {
     $status.hold = ($install_info.hold -eq $true)
 
     $deprecated_dir = (Find-BucketDirectory -Name $install_info.bucket -Root) + "\deprecated"
-    $status.deprecated = (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse).FullName
+    $status.deprecated = (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse -ErrorAction Ignore).FullName
 
     $manifest = manifest $app $install_info.bucket $install_info.url
     $status.removed = (!$manifest)

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -69,7 +69,7 @@ function Get-Manifest($app) {
                     $manifest = manifest $app $bucket
                     if (!$manifest) {
                         $deprecated_dir = (Find-BucketDirectory -Name $bucket -Root) + '\deprecated'
-                        $manifest = parse_json (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse).FullName
+                        $manifest = parse_json (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse -ErrorAction Ignore).FullName
                     }
                 }
             }


### PR DESCRIPTION
#### Motivation and Context
- Closes #6467

Even though the bucket of an installed app has been removed, Scoop will still try to access the 'deprecated' folder of this bucket.

#### Description
This PR makes the following changes:
- fix(core|manifest): Avoid error messages when searching non-existent 'deprecated' directory.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Eliminates noisy error messages when checking for a non-existent deprecated directory during app status and manifest lookups.
  - Prevents interruptions when deprecated manifests are missing, resulting in cleaner output and smoother workflows.

- Documentation
  - Updated changelog to note the fix for suppressed errors when searching a non-existent deprecated directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->