### PR TITLE
fix(scoop-download): Fix incorrect download success state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **core:** Fix the grep parameter in the `Invoke-GitLog` function ([#6407](https://github.com/ScoopInstaller/Scoop/issues/6407))
 - **buckets:** Fix the filtering condition when retrieving the number of manifests ([#6509](https://github.com/ScoopInstaller/Scoop/issues/6509))
 - **scoop-download:** Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))
+- **scoop-download:** Fix incorrect download success state ([#6473](https://github.com/ScoopInstaller/Scoop/issues/6473))
 - **scoop-uninstall:** Correct `-Global` Switch ([#6454](https://github.com/ScoopInstaller/Scoop/issues/6454))
 - **scoop-update:** Force sync tags w/ remote branch while scoop update ([#6439](https://github.com/ScoopInstaller/Scoop/issues/6439))
 - **autoupdate:** Use origin URL to handle URLs with fragment in GitHub mode ([#6455](https://github.com/ScoopInstaller/Scoop/issues/6455))

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -42,6 +42,8 @@ try {
     abort "ERROR: $_"
 }
 
+$apps = $apps | Select-Object -Unique
+
 if (!$apps) { error '<app> missing'; my_usage; exit 1 }
 
 if (is_scoop_outdated) {
@@ -100,6 +102,8 @@ foreach ($curr_app in $apps) {
         continue
     }
 
+    $dl_failure = $false
+
     if(Test-Aria2Enabled) {
         Invoke-CachedAria2Download $app $version $manifest $architecture $cachedir $manifest.cookie $use_cache $curr_check_hash
     } else {
@@ -129,6 +133,7 @@ foreach ($curr_app in $apps) {
                         warn 'SourceForge.net is known for causing hash validation fails. Please try again before opening a ticket.'
                     }
                     error (new_issue_msg $app $bucket "hash check failed")
+                    $dl_failure = $true
                     continue
                 }
             } else {


### PR DESCRIPTION
## Description

#### Motivation and Context
- Patch for #4822.
- Closes #6413.

The `scoop download` command has the following problems:
1. Download is marked as successful even when hash verification fails.
2. After a failed download, subsequent successful downloads do not show the success prompt.
3. Duplicate downloads of the same app.

#### changes
This PR makes the following changes:
- fix(scoop-download):
  - Fix incorrect download success state.
  - Prevent duplicate downloads.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed download success notifications so the final success message is shown only when every individual download and validation check completes successfully; partial or per-item failures now prevent a misleading overall success report.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->