### PR TITLE
fix(getopt, shim add): PowerShell uses `--%` not POSIX `--`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **autoupdate:** Use origin URL to handle URLs with fragment in GitHub mode ([#6455](https://github.com/ScoopInstaller/Scoop/issues/6455))
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
+- **getopt|shim add:** Teach getopt to respect the `--%` token ([#6476](https://github.com/ScoopInstaller/Scoop/issues/6476))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -11,8 +11,8 @@
 # NOTES:
 #    The first "--" or "--%" in $argv, if any, will terminate all options; any
 # following arguments are treated as non-option arguments, even if
-# they begin with a hyphen. The "--" itself will not be included in
-# the returned $opts. (POSIX-compatible)
+# they begin with a hyphen. The terminator token itself ("--" or "--%") will not be included.
+# (POSIX-compatible)function getopt([String[]]$argv, [String]$shortopts, [String[]]$longopts) {
 function getopt([String[]]$argv, [String]$shortopts, [String[]]$longopts) {
     $opts = @{}; $rem = @()
 
@@ -32,7 +32,7 @@ function getopt([String[]]$argv, [String]$shortopts, [String[]]$longopts) {
         if ($arg -is [Int]) { $rem += $arg; continue }
         if ($arg -is [Decimal]) { $rem += $arg; continue }
 
-        if ($arg -match '^--%?$') {
+        if ($arg -eq '--' -or $arg -eq '--%') {
             if ($i -lt $argv.Length - 1) {
                 $rem += $argv[($i + 1)..($argv.Length - 1)]
             }

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -9,7 +9,7 @@
 #    a parameter should end with '='
 # returns @(opts hash, remaining_args array, error string)
 # NOTES:
-#    The first "--" in $argv, if any, will terminate all options; any
+#    The first "--" or "--%" in $argv, if any, will terminate all options; any
 # following arguments are treated as non-option arguments, even if
 # they begin with a hyphen. The "--" itself will not be included in
 # the returned $opts. (POSIX-compatible)
@@ -32,7 +32,7 @@ function getopt([String[]]$argv, [String]$shortopts, [String[]]$longopts) {
         if ($arg -is [Int]) { $rem += $arg; continue }
         if ($arg -is [Decimal]) { $rem += $arg; continue }
 
-        if ($arg -eq '--') {
+        if ($arg -match '^--%?$') {
             if ($i -lt $argv.Length - 1) {
                 $rem += $argv[($i + 1)..($argv.Length - 1)]
             }

--- a/lib/getopt.ps1
+++ b/lib/getopt.ps1
@@ -10,9 +10,9 @@
 # returns @(opts hash, remaining_args array, error string)
 # NOTES:
 #    The first "--" or "--%" in $argv, if any, will terminate all options; any
-# following arguments are treated as non-option arguments, even if
-# they begin with a hyphen. The terminator token itself ("--" or "--%") will not be included.
-# (POSIX-compatible)function getopt([String[]]$argv, [String]$shortopts, [String[]]$longopts) {
+#    following arguments are treated as non-option arguments, even if
+#    they begin with a hyphen. The terminator token itself ("--" or "--%")
+#    will not be included. (POSIX-compatible)
 function getopt([String[]]$argv, [String]$shortopts, [String[]]$longopts) {
     $opts = @{}; $rem = @()
 

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -4,7 +4,7 @@
 #
 # To add a custom shim, use the 'add' subcommand:
 #
-#     scoop shim add <shim_name> <command_path> [--%] [<args>...]
+#     scoop shim add <shim_name> <command_path> [[--|--%] <args>...]
 #
 # To remove shims, use the 'rm' subcommand: (CAUTION: this could remove shims added by an app manifest)
 #
@@ -25,11 +25,14 @@
 # Options:
 #   -g, --global       Manipulate global shim(s)
 #
-# HINT: The FIRST double-hyphen '--', if any, will be treated as the POSIX-style command option terminator
-# and will NOT be included in arguments, so if you want to pass arguments like '-g' or '--global' to
-# the shim, put them after a '--'. Note that in PowerShell, you must use a QUOTED '--', e.g.,
-#
-#     scoop shim add myapp 'D:\path\myapp.exe' '--' myapp_args --global
+# HINT: The FIRST terminator token ('--' or PowerShell '--%'), if any, is treated as the option
+# terminator and will NOT be included; everything after it is passed to the shim.
+# Examples:
+#     POSIX-style:    scoop shim add myapp 'D:\path\myapp.exe' '--' myapp_args --global
+#     PowerShell:     scoop shim add myapp D:\path\myapp.exe --% myapp_args --global
+# Notes:
+#   - In PowerShell, '--' should be quoted to avoid parsing.
+#   - '--%' disables PowerShell parsing of the remainder; pass literals as needed.
 
 param($SubCommand)
 

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -4,7 +4,7 @@
 #
 # To add a custom shim, use the 'add' subcommand:
 #
-#     scoop shim add <shim_name> <command_path> [<args>...]
+#     scoop shim add <shim_name> <command_path> [--%] [<args>...]
 #
 # To remove shims, use the 'rm' subcommand: (CAUTION: this could remove shims added by an app manifest)
 #

--- a/libexec/scoop-shim.ps1
+++ b/libexec/scoop-shim.ps1
@@ -27,6 +27,7 @@
 #
 # HINT: The FIRST terminator token ('--' or PowerShell '--%'), if any, is treated as the option
 # terminator and will NOT be included; everything after it is passed to the shim.
+# So if you want to pass arguments like '-g' or '--global' to the shim, put them after a '--' or '--%'.
 # Examples:
 #     POSIX-style:    scoop shim add myapp 'D:\path\myapp.exe' '--' myapp_args --global
 #     PowerShell:     scoop shim add myapp D:\path\myapp.exe --% myapp_args --global

--- a/test/Scoop-GetOpts.Tests.ps1
+++ b/test/Scoop-GetOpts.Tests.ps1
@@ -81,13 +81,32 @@ Describe 'getopt' -Tag 'Scoop' {
         $opt, $rem, $err = getopt '--long-arg', '--' '' 'long-arg'
         $err | Should -BeNullOrEmpty
         $opt.'long-arg' | Should -BeTrue
-        $rem[0] | Should -BeNullOrEmpty
+        $rem | Should -BeNullOrEmpty
+    }
+
+    It 'handles remainder args after the option terminator' {
         $opt, $rem, $err = getopt '--long-arg', '--', '-x', '-y' 'xy' 'long-arg'
         $err | Should -BeNullOrEmpty
         $opt.'long-arg' | Should -BeTrue
-        $opt.'x' | Should -BeNullOrEmpty
-        $opt.'y' | Should -BeNullOrEmpty
+        $opt.Keys | Should -Not -Contain 'x'
+        $opt.Keys | Should -Not -Contain 'y'
         $rem[0] | Should -Be '-x'
         $rem[1] | Should -Be '-y'
     }
+
+    It 'handles PowerShell stop-parsing token' {
+        $opt, $rem, $err = getopt '--long-arg', '--%' '' 'long-arg'
+        $err | Should -BeNullOrEmpty
+        $opt.'long-arg' | Should -BeTrue
+        $rem | Should -BeNullOrEmpty
+    }
+
+    It 'handles remainder args after PowerShell stop-parsing token' {
+        $opt, $rem, $err = getopt @('--long-arg', '--%', '--from', 'there', '--to', 'here') '' 'long-arg'
+        $err | Should -BeNullOrEmpty
+        $opt.Keys | Should -Not -Contain 'from'
+        $opt.Keys | Should -Not -Contain 'to'
+        $rem | Should -Be @('--from', 'there', '--to', 'here')
+    }
+
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
getopt will now treat `--%` the same as `--`

#### Motivation and Context
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6476


#### How Has This Been Tested?
```console
> .\bin\scoop.ps1 shim add lnkparse C:\code\scoop\apps\uv\current\uvx.exe --% --from LnkParse3 lnkparse
Adding local shim lnkparse...
> get-shimContent lnkparse
path = "C:\code\scoop\apps\uv\current\uvx.exe"
args = --from LnkParse3 lnkparse
> lnkparse "C:\tools\baretailpro.lnk"
Windows Shortcut Information:
   Guid: 00021401-0000-0000-C000-000000000046
   .
   .
   .
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Option parsing now treats both `--` and PowerShell `--%` as end-of-options terminators.

* **Documentation**
  * Usage docs updated with examples for POSIX and PowerShell terminators; clarifies the terminator itself is not passed as an argument.

* **Tests**
  * Added/updated tests to verify terminator behavior and preservation of remaining tokens.

* **Chore**
  * Unreleased changelog entry added noting the `--%` support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->