### PR TITLE
feat(checkver): Add `gitlab` support to `checkver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 
+### Features
+
+**checkver**: Add GitLab to `checkver` ([#5508](https://github.com/ScoopInstaller/Scoop/issues/5508))
+
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 
 ### Features

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -162,6 +162,24 @@ $Queue | ForEach-Object {
         if ($json.checkver.PSObject.Properties.Count -eq 1) { $useGithubAPI = $true }
     }
 
+    # GitLab
+    if ($regex) {
+        $gitlabRegex = $regex
+    } else {
+        $regex = '/-/tags/(?:v|V)?([\d.]+)'
+    }
+    if ($json.checkver -eq 'gitlab') {
+        if (!$json.homepage.StartsWith('https://gitlab.com/')) {
+            error "$name checkvar expects the homepage to be a GitLab"
+        }
+        $url = $json.checkver.gitlab.TrimEnd('/') + '/-/tags?format=atom'
+        $regex = $gitlabRegex
+    }
+    if ($json.checkver.gitlab) {
+        $url = $json.checkver.gitlab.TrimEnd('/') + '/-/tags?format=atom'
+        $regex = $gitlabRegex
+    }
+
     # SourceForge
     if ($regex) {
         $sourceforgeRegex = $regex

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -170,7 +170,7 @@ $Queue | ForEach-Object {
     }
     if ($json.checkver -eq 'gitlab') {
         if (!$json.homepage.StartsWith('https://gitlab.com/')) {
-            error "$name checkver expects the homepage to be a GitLab"
+            error "$name checkver expects the homepage to be a GitLab repository"
         }
         $url = $json.checkver.gitlab.TrimEnd('/') + '/-/releases?format=atom'
         $regex = $gitlabRegex

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -170,7 +170,7 @@ $Queue | ForEach-Object {
     }
     if ($json.checkver -eq 'gitlab') {
         if (!$json.homepage.StartsWith('https://gitlab.com/')) {
-            error "$name checkvar expects the homepage to be a GitLab"
+            error "$name checkver expects the homepage to be a GitLab"
         }
         $url = $json.checkver.gitlab.TrimEnd('/') + '/-/releases?format=atom'
         $regex = $gitlabRegex

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -166,17 +166,17 @@ $Queue | ForEach-Object {
     if ($regex) {
         $gitlabRegex = $regex
     } else {
-        $regex = '/-/tags/(?:v|V)?([\d.]+)'
+        $gitlabRegex = '/-/releases/(?:v|V)?([\d.]+)'
     }
     if ($json.checkver -eq 'gitlab') {
         if (!$json.homepage.StartsWith('https://gitlab.com/')) {
             error "$name checkvar expects the homepage to be a GitLab"
         }
-        $url = $json.checkver.gitlab.TrimEnd('/') + '/-/tags?format=atom'
+        $url = $json.checkver.gitlab.TrimEnd('/') + '/-/releases?format=atom'
         $regex = $gitlabRegex
     }
     if ($json.checkver.gitlab) {
-        $url = $json.checkver.gitlab.TrimEnd('/') + '/-/tags?format=atom'
+        $url = $json.checkver.gitlab.TrimEnd('/') + '/-/releases?format=atom'
         $regex = $gitlabRegex
     }
 

--- a/schema.json
+++ b/schema.json
@@ -293,7 +293,7 @@
                             "type": "string"
                         },
                         "gitlab": {
-                            "format": "url",
+                            "format": "uri",
                             "type": "string"
                         },
                         "re": {

--- a/schema.json
+++ b/schema.json
@@ -292,6 +292,10 @@
                             "format": "uri",
                             "type": "string"
                         },
+                        "gitlab": {
+                            "format": "url",
+                            "type": "string"
+                        },
                         "re": {
                             "format": "regex",
                             "type": "string",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Add `gitlab` property to `checkver` and Scoop manifest schema.

#### Description
<!-- Describe your changes in detail -->
This PR adds `checkver` support for GitLab or GitLab self-hosted services with parsing atom feed of releases in that services with the predefined Regex or customized Regex.

If the value of `checkver` is `gitlab` and `homepage` URL is starting with https://gitlab.com, it will make use of the homepage value as a URL to retrieve data.
Or, `checkver` contains `gitlab` property with URL from GitLab or GitLab self-hosted services, it will utilize the value to do the same thing.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently as of September 2025, About 10 manifests in main bucket are parsing checkver from GitLab. Including other buckets, more manifests refer the GitLab URL to check the version information.

Also, I remember that someone made an issue for this topic.
(Closes #5508 )

That's why I made this PR.

#### How Has This Been Tested?
Manifests which contains GitLab or GitLab Self-Hosted Services in `checkver` are used in the testing.
Each URL must contain maintainer and repository name separated by slash, then change the property to `gitlab`.
Then I ran `checkver.ps1` to check the new version with `-f` switch to get the version forcibly to see whether the changes are working well.

Tested Environment information retrieved from `$PSVersionTable`:
```powershell
Name                           Value
----                           -----
PSVersion                      7.5.3
PSEdition                      Core
GitCommitId                    7.5.3
OS                             Microsoft Windows 10.0.26100
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```

Other areas are not affected at all, But to use this feature, we need to add a new definition `gitlab` on `checkver` property in the schema.
Also, manifests containing GitLab would be updated after the release of future version.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab support to automatic version checking, matching existing GitHub behavior.
  * You can now specify a GitLab URL in checkver settings to fetch releases and detect versions.
  * Schema updated to accept a gitlab configuration alongside github.

* **Documentation**
  * CHANGELOG updated to note GitLab support in checkver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->