### PR TITLE
fix(checkver): Fix incorrect version returned when script fails without output

### DIFF
--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -274,6 +274,9 @@ while ($in_progress -gt 0) {
     $expected_ver = $json.version
     $ver = $Version
 
+    # Prevent per-iteration state leakage
+    $page, $match, $matchesHashtable = $null
+
     if (!$ver) {
         if (!$regexp -and $replace) {
             next "'replace' requires 're' or 'regex'"
@@ -284,9 +287,6 @@ while ($in_progress -gt 0) {
             next "$($err.message)`r`nURL $url is not valid"
             continue
         }
-
-        # Prevent variable leakage from previous iteration
-        $page, $match = $null
 
         if ($url) {
             $ms = New-Object System.IO.MemoryStream

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -285,6 +285,9 @@ while ($in_progress -gt 0) {
             continue
         }
 
+        # Prevent variable leakage from previous iteration
+        $page, $match = $null
+
         if ($url) {
             $ms = New-Object System.IO.MemoryStream
             $ms.Write($result, 0, $result.Length)


### PR DESCRIPTION
## Description

#### Motivation and Context
Closes:
- #6425
- https://github.com/ScoopInstaller/GithubActions/issues/36

Relats to:
- #4941

#### Changes
This PR makes the following changes:
- `fix(checkver)`: Fix incorrect version returned when checkver.script fails without output.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.