### PR TITLE
fix(checkver): Allow script to run when URL fetch fails but script exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
+- **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
 
 ### Code Refactoring
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -281,11 +281,16 @@ while ($in_progress -gt 0) {
         }
         $err = $ev.SourceEventArgs.Error
         if ($err) {
-            next "$($err.message)`r`nURL $url is not valid"
-            continue
+            if (!$script) {
+                next "$($err.message)`r`nURL $url is not valid"
+                continue
+            } else {
+                # Run script despite URL download failure
+                Write-Host "$($err.message)`r`nURL $url is not valid. Falling back to checkver.script ..."
+            }
         }
 
-        if ($url) {
+        if ($url -and !$err) {
             $ms = New-Object System.IO.MemoryStream
             $ms.Write($result, 0, $result.Length)
             $ms.Seek(0, 0) | Out-Null


### PR DESCRIPTION
#### Description
This PR makes the following changes:
- `fix(checkver)`: Allow script to run when URL fetch fails but script exists.

#### Motivation and Context
- Closes #5704
- Closes #6480
- Closes #6274

Failing to fetch homepage/checkver.url prevents checkver.script from running.

Sometimes, the homepage is unreachable duo to anti-bot mechanisms or IP blocks targeting GitHub's hosted runner networks.

For this situation, we have to change the homepage, or use a fake url as checkver.url.
e.g.
- https://github.com/abgox/abyss/commit/604f294e6e9b6b12a5d4606e2faafdef2a9c1269
- https://github.com/Calinou/scoop-games/blob/master/bucket/epic-games-launcher.json
```json
    "checkver": {
        "url": "https://scoop.sh",
        "useragent": "$app/$version",
        "script": [
            "$redirUrl = [Net.HttpWebRequest]::Create('https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/installer/download/EpicGamesLauncherInstaller.msi')",
            "$redirUrl.method = 'head'",
            "[Web.HttpUtility]::ParseQueryString($redirUrl.GetResponse().ResponseUri.Query).Get('launcherfilename')"
        ],
        "regex": "\\AEpicInstaller-([\\d.]+)\\.msi\\Z"
    }
```

#### How Has This Been Tested?
Tested it locally with [Calinou/scoop-games/epic-games-launcher.json](https://github.com/Calinou/scoop-games/blob/master/bucket/epic-games-launcher.json)(checkver.url removed).
- Before: <img width="867" height="67" alt="image" src="https://github.com/user-attachments/assets/ebca3660-097c-4381-802f-9d41943d4210" />
- After: <img width="848" height="184" alt="image" src="https://github.com/user-attachments/assets/10610437-a749-48d8-80fd-a2f8e0d0f1f4" />


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a URL fetch fails, provided fallback scripts are now run so checks continue instead of being skipped; downloaded content is only processed on successful fetches.
  * Logs and source labels now reflect when content comes from fallback output to avoid misleading results.

* **New Features**
  * Added a fallback flow that uses script-derived content on download failures while preserving normal behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->