### PR TITLE
VSCode - Don't create `.sln` project file automatically + some other settings changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+    // Apply formatting on save for constistency
+    "[powershell]": {
+        "editor.formatOnSave": true
+    },
     // Don't automatically create dotnet project .sln file
     "dotnet.automaticallyCreateSolutionInWorkspace": false,
     // Files to hide from VSCode file explorer
@@ -10,8 +14,11 @@
         "**/.DS_Store": true,
         "**/tmp": true
     },
+    // Insert final newline, .editorconfig is not consistent on this
+    "files.insertFinalNewline": true,
     // Configure PSScriptAnalyzer settings
     "powershell.scriptAnalysis.settingsPath": "../PSScriptAnalyzerSettings.psd1",
+    // Set vscode-powershell settings
     "powershell.codeFormatting.preset": "OTBS",
     "powershell.codeFormatting.alignPropertyValuePairs": true,
     "powershell.codeFormatting.ignoreOneLineBlock": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
         "**/tmp": true
     },
     // Configure PSScriptAnalyzer settings
-    "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
+    "powershell.scriptAnalysis.settingsPath": "../PSScriptAnalyzerSettings.psd1",
     "powershell.codeFormatting.preset": "OTBS",
     "powershell.codeFormatting.alignPropertyValuePairs": true,
     "powershell.codeFormatting.ignoreOneLineBlock": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
-// Configure PSScriptAnalyzer settings
 {
+    // Configure PSScriptAnalyzer settings
     "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
     "powershell.codeFormatting.preset": "OTBS",
     "powershell.codeFormatting.alignPropertyValuePairs": true,
@@ -7,6 +7,7 @@
     "powershell.codeFormatting.useConstantStrings": true,
     "powershell.codeFormatting.useCorrectCasing": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": true,
+    // Files to hide from VSCode file explorer
     "files.exclude": {
         "**/.git": true,
         "**/.svn": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,6 @@
 {
-    // Configure PSScriptAnalyzer settings
-    "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
-    "powershell.codeFormatting.preset": "OTBS",
-    "powershell.codeFormatting.alignPropertyValuePairs": true,
-    "powershell.codeFormatting.ignoreOneLineBlock": true,
-    "powershell.codeFormatting.useConstantStrings": true,
-    "powershell.codeFormatting.useCorrectCasing": true,
-    "powershell.codeFormatting.whitespaceBetweenParameters": true,
+    // Don't automatically create dotnet project .sln file
+    "dotnet.automaticallyCreateSolutionInWorkspace": false,
     // Files to hide from VSCode file explorer
     "files.exclude": {
         "**/.git": true,
@@ -15,5 +9,13 @@
         "**/CVS": true,
         "**/.DS_Store": true,
         "**/tmp": true
-    }
+    },
+    // Configure PSScriptAnalyzer settings
+    "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
+    "powershell.codeFormatting.preset": "OTBS",
+    "powershell.codeFormatting.alignPropertyValuePairs": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": true,
+    "powershell.codeFormatting.useConstantStrings": true,
+    "powershell.codeFormatting.useCorrectCasing": true,
+    "powershell.codeFormatting.whitespaceBetweenParameters": true
 }


### PR DESCRIPTION
#### Description

1. Set VSCode `settings.json` to not create `.sln` project file automatically.
   ```json
   {
       "dotnet.automaticallyCreateSolutionInWorkspace": false
   }
   ```
1. Fix reference to PSScriptAnalyzer settings file, which is located one dir up from VSCode `settings.json`.
1. Add format on save for PowerShell files `"[powershell]": {"editor.formatOnSave": true}` for consistency, else why specify formatting settings in `.vscode/settings.json`?
1. Add `"files.insertFinalNewline": true`, because EditorConfig did not seem to apply that consistently.

#### Motivation and Context

Closes #6492

#### How Has This Been Tested?

It's just a small VSCode settings change.

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.
  - This does not change anything in Scoop?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated editor workspace settings for code analysis and formatting.
  - Consolidated analyzer configuration into a dedicated settings block.
  - Changed workspace behavior to stop automatic .NET solution file creation.
  - Preserved and reorganized file exclusion rules for consistency.
  - No user-facing functionality or UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->