### PR TITLE
Fix #6515 "Expand-7zipArchive won't remove top folder if $ExtractDir depth exceeds 2" - Idea 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
+
+### BREAKING CHANGE
+
 - **decompress:** Expand to temp directory if `$ExtractDir` is specified with `Expand-7zipArchive` and `Expand-ZipArchive`, to make it more robust ([#6515](https://github.com/ScoopInstaller/Scoop/issues/6515))
+  - Changes extraction semantics when `extract_dir` is used; manifests relying on post-extraction cleanup workarounds may need updates.
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
-- **decompress:** Expand to temp directory if `$ExpandDir` is specified with `Expand-7zipArchive` and `Expand-ZipArchive`, to make it more robust ([#6515](https://github.com/ScoopInstaller/Scoop/issues/6515))
+- **decompress:** Expand to temp directory if `$ExtractDir` is specified with `Expand-7zipArchive` and `Expand-ZipArchive`, to make it more robust ([#6515](https://github.com/ScoopInstaller/Scoop/issues/6515))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
+- **decompress:** Expand to temp directory if `$ExpandDir` is specified with `Expand-7zipArchive` and `Expand-ZipArchive`, to make it more robust ([#6515](https://github.com/ScoopInstaller/Scoop/issues/6515))
 
 ### Code Refactoring
 

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -95,7 +95,7 @@ function Expand-7zipArchive {
     $IsTar = ((strip_ext -fname $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
     $DestinationPath = $DestinationPath.TrimEnd('\')
     if ($ExtractDir) {
-        $DestinationPathTemp = [System.IO.Path]::Combine($DestinationPath, [guid]::NewGuid().'Guid')
+        $DestinationPathTemp = [System.IO.Path]::Combine($DestinationPath, '_tmp')
         $ArgList = @('x', $Path, "-o$DestinationPathTemp", '-xr!*.nsis', '-y')
         if (-not $IsTar) {
             $ArgList += "-ir!$ExtractDir\*"

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -95,7 +95,7 @@ function Expand-7zipArchive {
     $IsTar = ((strip_ext -fname $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
     $DestinationPath = $DestinationPath.TrimEnd('\')
     if ($ExtractDir) {
-        $DestinationPathTemp = [System.IO.Path]::Combine($DestinationPath, '_tmp')
+        $DestinationPathTemp = [System.IO.Path]::Combine($env:TEMP, [guid]::NewGuid().'Guid')
         $ArgList = @('x', $Path, "-o$DestinationPathTemp", '-xr!*.nsis', '-y')
         if (-not $IsTar) {
             $ArgList += "-ir!$ExtractDir\*"
@@ -128,12 +128,13 @@ function Expand-7zipArchive {
         }
     }
     if ($ExtractDir -and -not $IsTar) {
+        # Move content to destination path
         $null = movedir -from "$DestinationPathTemp\$ExtractDir" -to $DestinationPath
-        # Remove temporary directory if it is empty
+        # Remove temporary directory
         Remove-Item -Path $DestinationPathTemp -Recurse -Force -ErrorAction Ignore
     }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
+    if (Test-Path -Path $LogPath -PathType 'Leaf') {
+        Remove-Item -Path $LogPath -Force
     }
     if ($Removal) {
         if (($Path -replace '.*\.([^\.]*)$', '$1') -eq '001') {
@@ -283,9 +284,10 @@ function Expand-ZipArchive {
         [Switch]
         $Removal
     )
+    $DestinationPath = [string] $DestinationPath.TrimEnd('\')
     if ($ExtractDir) {
-        $OriDestinationPath = $DestinationPath
-        $DestinationPath = "$DestinationPath\_tmp"
+        $OriDestinationPath = [string] $DestinationPath
+        $DestinationPath = [string] [System.IO.Path]::Combine($env:TEMP, [guid]::NewGuid().'Guid')
     }
     # Disable progress bar to gain performance
     $oldProgressPreference = $ProgressPreference

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -298,12 +298,12 @@ function Expand-ZipArchive {
 
     $global:ProgressPreference = $oldProgressPreference
     if ($ExtractDir) {
-        movedir "$DestinationPath\$ExtractDir" $OriDestinationPath | Out-Null
-        Remove-Item $DestinationPath -Recurse -Force
+        $null = movedir "$DestinationPath\$ExtractDir" $OriDestinationPath
+        Remove-Item -Path $DestinationPath -Recurse -Force
     }
     if ($Removal) {
         # Remove original archive file
-        Remove-Item $Path -Force
+        Remove-Item -Path $Path -Force
     }
 }
 

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -84,19 +84,25 @@ function Expand-7zipArchive {
     )
     if ((get_config USE_EXTERNAL_7ZIP)) {
         try {
-            $7zPath = (Get-Command '7z' -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+            $7zPath = (Get-Command -Name '7z' -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
         } catch [System.Management.Automation.CommandNotFoundException] {
             abort "`nCannot find external 7-Zip (7z.exe) while 'use_external_7zip' is 'true'!`nRun 'scoop config use_external_7zip false' or install 7-Zip manually and try again."
         }
     } else {
         $7zPath = Get-HelperPath -Helper 7zip
     }
-    $LogPath = "$(Split-Path $Path)\7zip.log"
+    $LogPath = "$(Split-Path -Path $Path)\7zip.log"
+    $IsTar = ((strip_ext -fname $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
     $DestinationPath = $DestinationPath.TrimEnd('\')
-    $ArgList = @('x', $Path, "-o$DestinationPath", '-xr!*.nsis', '-y')
-    $IsTar = ((strip_ext $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
-    if (!$IsTar -and $ExtractDir) {
-        $ArgList += "-ir!$ExtractDir\*"
+    if ($ExtractDir) {
+        $DestinationPathTemp = [System.IO.Path]::Combine($DestinationPath, [guid]::NewGuid().'Guid')
+        $ArgList = @('x', $Path, "-o$DestinationPathTemp", '-xr!*.nsis', '-y')
+        if (-not $IsTar) {
+            $ArgList += "-ir!$ExtractDir\*"
+        }
+    }
+    else {
+        $ArgList = @('x', $Path, "-o$DestinationPath", '-xr!*.nsis', '-y')
     }
     if ($Switches) {
         $ArgList += (-split $Switches)
@@ -106,28 +112,25 @@ function Expand-7zipArchive {
         'Skip' { $ArgList += '-aos' }
         'Rename' { $ArgList += '-aou' }
     }
-    $Status = Invoke-ExternalCommand $7zPath $ArgList -LogPath $LogPath
-    if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+    $Status = Invoke-ExternalCommand -FilePath $7zPath -ArgumentList $ArgList -LogPath $LogPath
+    if (-not $Status) {
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path -path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
     if ($IsTar) {
         # Check for tar
-        $Status = Invoke-ExternalCommand $7zPath @('l', $Path) -LogPath $LogPath
+        $Status = Invoke-ExternalCommand -FilePath $7zPath  -ArgumentList @('l', $Path) -LogPath $LogPath
         if ($Status) {
-            # get inner tar file name
+            # Get inner tar file name
             $TarFile = (Select-String -Path $LogPath -Pattern '[^ ]*tar$').Matches.Value
             Expand-7zipArchive -Path "$DestinationPath\$TarFile" -DestinationPath $DestinationPath -ExtractDir $ExtractDir -Removal
         } else {
             abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."
         }
     }
-    if (!$IsTar -and $ExtractDir) {
-        movedir "$DestinationPath\$ExtractDir" $DestinationPath | Out-Null
+    if ($ExtractDir -and -not $IsTar) {
+        $null = movedir -from "$DestinationPathTemp\$ExtractDir" -to $DestinationPath
         # Remove temporary directory if it is empty
-        $ExtractDirTopPath = [string] "$DestinationPath\$($ExtractDir -replace '[\\/].*')"
-        if ((Get-ChildItem -Path $ExtractDirTopPath -Force -ErrorAction Ignore).Count -eq 0) {
-            Remove-Item -Path $ExtractDirTopPath -Recurse -Force -ErrorAction Ignore
-        }
+        Remove-Item -Path $DestinationPathTemp -Recurse -Force -ErrorAction Ignore
     }
     if (Test-Path $LogPath) {
         Remove-Item $LogPath -Force
@@ -135,13 +138,13 @@ function Expand-7zipArchive {
     if ($Removal) {
         if (($Path -replace '.*\.([^\.]*)$', '$1') -eq '001') {
             # Remove splitted 7-zip archive parts
-            Get-ChildItem "$($Path -replace '\.[^\.]*$', '').???" | Remove-Item -Force
+            Get-ChildItem -Path "$($Path -replace '\.[^\.]*$', '').???" | Remove-Item -Force
         } elseif (($Path -replace '.*\.part(\d+)\.rar$', '$1')[-1] -eq '1') {
             # Remove splitted RAR archive parts
             Get-ChildItem "$($Path -replace '\.part(\d+)\.rar$', '').part*.rar" | Remove-Item -Force
         } else {
             # Remove original archive file
-            Remove-Item $Path -Force
+            Remove-Item -Path $Path -Force
         }
     }
 }

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -93,16 +93,14 @@ function Expand-7zipArchive {
     }
     $LogPath = "$(Split-Path -Path $Path)\7zip.log"
     $IsTar = ((strip_ext -fname $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
-    $DestinationPath = $DestinationPath.TrimEnd('\')
+    $DestinationPath = [string] $DestinationPath.TrimEnd('\')
     if ($ExtractDir) {
-        $DestinationPathTemp = [System.IO.Path]::Combine($env:TEMP, [guid]::NewGuid().'Guid')
-        $ArgList = @('x', $Path, "-o$DestinationPathTemp", '-xr!*.nsis', '-y')
-        if (-not $IsTar) {
-            $ArgList += "-ir!$ExtractDir\*"
-        }
+        $OriDestinationPath = [string] $DestinationPath
+        $DestinationPath = [System.IO.Path]::Combine($env:TEMP, [guid]::NewGuid().'Guid')
     }
-    else {
-        $ArgList = @('x', $Path, "-o$DestinationPath", '-xr!*.nsis', '-y')
+    $ArgList = @('x', $Path, "-o$DestinationPath", '-xr!*.nsis', '-y')
+    if ($ExtractDir -and -not $IsTar) {
+        $ArgList += "-ir!$ExtractDir\*"
     }
     if ($Switches) {
         $ArgList += (-split $Switches)
@@ -118,7 +116,7 @@ function Expand-7zipArchive {
     }
     if ($IsTar) {
         # Check for tar
-        $Status = Invoke-ExternalCommand -FilePath $7zPath  -ArgumentList @('l', $Path) -LogPath $LogPath
+        $Status = Invoke-ExternalCommand -FilePath $7zPath -ArgumentList @('l', $Path) -LogPath $LogPath
         if ($Status) {
             # Get inner tar file name
             $TarFile = (Select-String -Path $LogPath -Pattern '[^ ]*tar$').Matches.Value
@@ -128,10 +126,10 @@ function Expand-7zipArchive {
         }
     }
     if ($ExtractDir -and -not $IsTar) {
-        # Move content to destination path
-        $null = movedir -from "$DestinationPathTemp\$ExtractDir" -to $DestinationPath
+        # Move content to original destination path
+        $null = movedir -from "$DestinationPath\$ExtractDir" -to $OriDestinationPath
         # Remove temporary directory
-        Remove-Item -Path $DestinationPathTemp -Recurse -Force -ErrorAction Ignore
+        Remove-Item -Path $DestinationPath -Recurse -Force -ErrorAction Ignore
     }
     if (Test-Path -Path $LogPath -PathType 'Leaf') {
         Remove-Item -Path $LogPath -Force


### PR DESCRIPTION
#### Description

`Expand-7zipArchive` have had problems with apps where:

* A directory inside `$ExtractDir` is named the same as a dir above it (issue #6011, PR #6092)
* The workaround for above problem did not handle `$ExtractDir` that are two levels deep or more (issue #6515).
* To make expansion with `$ExtractDir` more robust I previously suggested to extract to TEMP first, then move content from there (feature request #6093).

This PR tries to fix all that.

#### Motivation and Context

* Closes #6515 and #6093.
* Relates to #6011

Merging this might break some manifests that have workarounds to delete leftovers after `$ExtractDir`. Here are some I know of:

* <https://github.com/ScoopInstaller/Extras/blob/master/bucket/foxit-reader.json>
  * <https://github.com/ScoopInstaller/Extras/blob/95abd03aff7151b84a6a9db74ceb071fcc2dd702/bucket/foxit-reader.json#L30C14-L30C40>
* <https://github.com/ScoopInstaller/Extras/blob/master/bucket/foxit-pdf-reader.json>
  * <https://github.com/ScoopInstaller/Extras/blob/95abd03aff7151b84a6a9db74ceb071fcc2dd702/bucket/foxit-pdf-reader.json#L30>

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved partial-extraction workflow: when extracting a subdirectory, files are unpacked to a temporary location and moved into place to ensure reliable results across archive types.

* **Bug Fixes**
  * More reliable handling of destination paths and removal of temporary files to prevent leftovers and placement errors.
  * Clearer errors and more consistent external tool invocation for decompression.

* **Documentation**
  * Updated changelog documenting decompression and extraction improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->