### PR TITLE
Fix #6515 "Expand-7zipArchive won't remove top folder if $ExtractDir depth exceeds 2" - Idea 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
+- **decompress:** Fix `Expand-7zipArchive` won't remove top folder if $ExtractDir depth exceeds 2 ([#6515](https://github.com/ScoopInstaller/Scoop/issues/6515))
 
 ### Code Refactoring
 

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -122,12 +122,26 @@ function Expand-7zipArchive {
         }
     }
     if (-not $IsTar -and $ExtractDir) {
-        $null = movedir "$DestinationPath\$ExtractDir" $DestinationPath
-        # Remove temporary directory if it is empty
-        $ExtractDirTopPath = [string] "$DestinationPath\$($ExtractDir -replace '[\\/].*')"
-        if ((Get-ChildItem -Path $ExtractDirTopPath -Force -ErrorAction Ignore).Count -eq 0) {
-            Remove-Item -Path $ExtractDirTopPath -Recurse -Force -ErrorAction Ignore
+        # Move content from $ExtractDir to destination
+        $null = movedir -from "$DestinationPath\$ExtractDir" -to $DestinationPath
+        # Remove temporary directories if not empty
+        $ExtractDirs = [string[]]($ExtractDir -split '[\\/]' | Where-Object -FilterScript {-not [string]::IsNullOrWhiteSpace($_)})
+        $Depth = [byte]($ExtractDirs.'Count')
+        do {
+            $CurrentDir = [string] [System.IO.Path]::Combine(
+                $DestinationPath, (
+                    ($ExtractDirs | Select-Object -First $Depth) -join [System.IO.Path]::DirectorySeparatorChar
+                )
+            )
+            if ((Get-ChildItem -Path $CurrentDir -Force -ErrorAction 'Ignore').'Count' -gt 0) {
+                $Depth = 0
+            }
+            else {
+                Remove-Item -Path $CurrentDir -Recurse -Force -ErrorAction 'Ignore'
+            }
+            $Depth--
         }
+        while ($Depth -gt 0)
     }
     if (Test-Path -Path $LogPath -PathType 'Leaf') {
         Remove-Item -Path $LogPath -Force

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -91,7 +91,7 @@ function Expand-7zipArchive {
     } else {
         $7zPath = Get-HelperPath -Helper 7zip
     }
-    $LogPath = "$(Split-Path $Path)\7zip.log"
+    $LogPath = "$(Split-Path -Path $Path)\7zip.log"
     $DestinationPath = $DestinationPath.TrimEnd('\')
     $ArgList = @('x', $Path, "-o$DestinationPath", '-xr!*.nsis', '-y')
     $IsTar = ((strip_ext $Path) -match '\.tar$') -or ($Path -match '\.t[abgpx]z2?$')
@@ -106,13 +106,13 @@ function Expand-7zipArchive {
         'Skip' { $ArgList += '-aos' }
         'Rename' { $ArgList += '-aou' }
     }
-    $Status = Invoke-ExternalCommand $7zPath $ArgList -LogPath $LogPath
+    $Status = Invoke-ExternalCommand -FilePath $7zPath -ArgumentList $ArgList -LogPath $LogPath
     if (!$Status) {
-        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
+        abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path -path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
     if ($IsTar) {
         # Check for tar
-        $Status = Invoke-ExternalCommand $7zPath @('l', $Path) -LogPath $LogPath
+        $Status = Invoke-ExternalCommand -FilePath $7zPath -ArgumentList @('l', $Path) -LogPath $LogPath
         if ($Status) {
             # get inner tar file name
             $TarFile = (Select-String -Path $LogPath -Pattern '[^ ]*tar$').Matches.Value
@@ -121,27 +121,27 @@ function Expand-7zipArchive {
             abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."
         }
     }
-    if (!$IsTar -and $ExtractDir) {
-        movedir "$DestinationPath\$ExtractDir" $DestinationPath | Out-Null
+    if (-not $IsTar -and $ExtractDir) {
+        $null = movedir "$DestinationPath\$ExtractDir" $DestinationPath
         # Remove temporary directory if it is empty
         $ExtractDirTopPath = [string] "$DestinationPath\$($ExtractDir -replace '[\\/].*')"
         if ((Get-ChildItem -Path $ExtractDirTopPath -Force -ErrorAction Ignore).Count -eq 0) {
             Remove-Item -Path $ExtractDirTopPath -Recurse -Force -ErrorAction Ignore
         }
     }
-    if (Test-Path $LogPath) {
-        Remove-Item $LogPath -Force
+    if (Test-Path -Path $LogPath -PathType 'Leaf') {
+        Remove-Item -Path $LogPath -Force
     }
     if ($Removal) {
         if (($Path -replace '.*\.([^\.]*)$', '$1') -eq '001') {
             # Remove splitted 7-zip archive parts
-            Get-ChildItem "$($Path -replace '\.[^\.]*$', '').???" | Remove-Item -Force
+            Get-ChildItem -Path "$($Path -replace '\.[^\.]*$', '').???" | Remove-Item -Force
         } elseif (($Path -replace '.*\.part(\d+)\.rar$', '$1')[-1] -eq '1') {
             # Remove splitted RAR archive parts
-            Get-ChildItem "$($Path -replace '\.part(\d+)\.rar$', '').part*.rar" | Remove-Item -Force
+            Get-ChildItem -Path "$($Path -replace '\.part(\d+)\.rar$', '').part*.rar" | Remove-Item -Force
         } else {
             # Remove original archive file
-            Remove-Item $Path -Force
+            Remove-Item -Path $Path -Force
         }
     }
 }

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -125,7 +125,7 @@ function Expand-7zipArchive {
         # Move content from $ExtractDir to destination
         $null = movedir -from "$DestinationPath\$ExtractDir" -to $DestinationPath
         # Remove temporary directories if not empty
-        $ExtractDirs = [string[]]($ExtractDir -split '[\\/]' | Where-Object -FilterScript {-not [string]::IsNullOrWhiteSpace($_)})
+        $ExtractDirs = [string[]]($ExtractDir -split '[\\/]' | Where-Object -FilterScript { -not [string]::IsNullOrWhiteSpace($_) })
         $Depth = [byte] $ExtractDirs.'Count'
         do {
             $CurrentDir = [string] [System.IO.Path]::Combine(
@@ -135,8 +135,7 @@ function Expand-7zipArchive {
             )
             if ((Get-ChildItem -Path $CurrentDir -Force -ErrorAction 'Ignore').'Count' -gt 0) {
                 $Depth = 0
-            }
-            else {
+            } else {
                 Remove-Item -Path $CurrentDir -Recurse -Force -ErrorAction 'Ignore'
             }
             $Depth--
@@ -262,7 +261,7 @@ function Expand-InnoArchive {
     switch -Regex ($ExtractDir) {
         '^[^{].*' { $ArgList += "-c{app}\$ExtractDir" }
         '^{.*' { $ArgList += "-c$ExtractDir" }
-        Default { $ArgList += '-c{app}' }
+        default { $ArgList += '-c{app}' }
     }
     if ($Switches) {
         $ArgList += (-split $Switches)

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -107,7 +107,7 @@ function Expand-7zipArchive {
         'Rename' { $ArgList += '-aou' }
     }
     $Status = Invoke-ExternalCommand -FilePath $7zPath -ArgumentList $ArgList -LogPath $LogPath
-    if (!$Status) {
+    if (-not $Status) {
         abort "Failed to extract files from $Path.`nLog file:`n  $(friendly_path -path $LogPath)`n$(new_issue_msg $app $bucket 'decompress error')"
     }
     if ($IsTar) {

--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -126,7 +126,7 @@ function Expand-7zipArchive {
         $null = movedir -from "$DestinationPath\$ExtractDir" -to $DestinationPath
         # Remove temporary directories if not empty
         $ExtractDirs = [string[]]($ExtractDir -split '[\\/]' | Where-Object -FilterScript {-not [string]::IsNullOrWhiteSpace($_)})
-        $Depth = [byte]($ExtractDirs.'Count')
+        $Depth = [byte] $ExtractDirs.'Count'
         do {
             $CurrentDir = [string] [System.IO.Path]::Combine(
                 $DestinationPath, (


### PR DESCRIPTION
#### Description

Make `Expand-7zipArchive -ExtractDir` handle `$ExtractDir` depth of two or more.

This PR tries to fix it in a non-breaking way, unlike #6516.

#### Motivation and Context

Closes #6515

#### How Has This Been Tested?

```pwsh
PS > scoop install extras/amber
PS > scoop install extras/tor-browser
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 7‑Zip extraction now correctly removes the top-level folder when extracting into deeply nested directories, ensuring the expected folder structure.
  * More reliable cleanup of temporary extraction directories and related log files to avoid leftover artifacts.

* **Refactor**
  * Improved reliability and error handling for archive extraction operations.

* **Documentation**
  * Updated changelog under Unreleased > Bug Fixes to reflect the extraction fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->