### PR TITLE
Fix #6515 "Expand-7zipArchive won't remove top folder if $ExtractDir depth exceeds 2" - Idea 3

### DIFF
--- a/lib/decompress.ps1
+++ b/lib/decompress.ps1
@@ -121,12 +121,36 @@ function Expand-7zipArchive {
             abort "Failed to list files in $Path.`nNot a 7-Zip supported archive file."
         }
     }
-    if (!$IsTar -and $ExtractDir) {
-        movedir "$DestinationPath\$ExtractDir" $DestinationPath | Out-Null
-        # Remove temporary directory if it is empty
-        $ExtractDirTopPath = [string] "$DestinationPath\$($ExtractDir -replace '[\\/].*')"
-        if ((Get-ChildItem -Path $ExtractDirTopPath -Force -ErrorAction Ignore).Count -eq 0) {
-            Remove-Item -Path $ExtractDirTopPath -Recurse -Force -ErrorAction Ignore
+    if (-not $IsTar -and $ExtractDir) {
+        # Assets
+        $ExtractDirPath = [string] [System.IO.Path]::GetFullPath(
+            [System.IO.Path]::Combine($DestinationPath, $ExtractDir)
+        )
+        $ExtractDirTopPath = [string] [System.IO.Path]::GetFullPath(
+            [System.IO.Path]::Combine(
+                $DestinationPath,
+                (
+                    $ExtractDir -split '[\\/]' |
+                        Where-Object -FilterScript {-not [string]::IsNullOrWhiteSpace($_)} |
+                        Select-Object -First 1
+                )
+            )
+        )
+        # Check if $ExtractDirPath contains a directory with the same name as $ExtractDirTopPath
+        $DeleteExtractDirTopPath = [bool](
+            ([System.IO.DirectoryInfo]($ExtractDirTopPath)).'Name' -notin [System.IO.Directory]::GetDirectories(
+                $ExtractDirPath
+            ).ForEach{
+                $_.Split(
+                    [System.IO.Path]::DirectorySeparatorChar
+                )[-1]
+            }
+        )
+        # Move content of $ExtractDir to destination
+        $null = movedir -from $ExtractDirPath -to $DestinationPath
+        # Remove leftovers after movedir
+        if ($DeleteExtractDirTopPath) {
+            Remove-Item -Path $ExtractDirTopPath -Recurse -Force -ErrorAction 'Ignore'
         }
     }
     if (Test-Path $LogPath) {


### PR DESCRIPTION
#### Description

Fix #6515 by simply deleting what's left after $ExtractDir has been moved, unless there is a directory name conflict as in #6011.

This is a third idea to a fix, also see

* Attempt 1 / #6516: The proper fix IMO, but can introduce breaking changes
* Attempt 2 / #6517: An attempt on a non-breaking fix, but it can leave behind unneccessary data.
* Attempt 3 / this PR: Another attempt on a non-breaking fix. I like this more than Attempt 2.

#### Motivation and Context

Closes #6515.

#### How Has This Been Tested?

```pwsh
scoop uninstall amber; scoop install extras/amber
scoop uninstall foxit-reader; scoop install extras/foxit-reader
scoop uninstall tor-browser; scoop install extras/tor-browser
```

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improves reliability when extracting non-tar archives with accurate path handling.
  - Correctly moves extracted content to the destination, reducing unwanted top-level folders.
  - Safer cleanup that only removes temporary directories when appropriate, preventing accidental deletions.
  - Preserves existing behavior for tar archives.

- Refactor
  - Streamlines post-extraction workflow with clearer path-based operations and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->