### PR TITLE
fix(install): Don't add to `$Error` when checking for service `cexecsvc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
-- **install:** `function New-DirectoryJunction`: Don't add to `$Error` when checking for service `cexecsvc` ([#6519](https://github.com/ScoopInstaller/Scoop/issues/6519))
+- **install:** Function `New-DirectoryJunction`: Don't add to `$Error` when checking for service `cexecsvc` ([#6519](https://github.com/ScoopInstaller/Scoop/issues/6519))
 
 ### Code Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
+- **install:** `function New-DirectoryJunction`: Don't add to `$Error` when checking for service `cexecsvc` ([#6519](https://github.com/ScoopInstaller/Scoop/issues/6519))
 
 ### Code Refactoring
 

--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -555,7 +555,7 @@ function test_running_process($app, $global) {
 # Required to handle docker/for-win#12240
 function New-DirectoryJunction($source, $target) {
     # test if this script is being executed inside a docker container
-    if (Get-Service -Name cexecsvc -ErrorAction SilentlyContinue) {
+    if (Get-Service -Name cexecsvc -ErrorAction Ignore) {
         cmd.exe /d /c "mklink /j `"$source`" `"$target`""
     } else {
         New-Item -Path $source -ItemType Junction -Value $target


### PR DESCRIPTION
#### Description

This check should not add error to $Error if it fails.

#### Motivation and Context

Closes #6519

#### How Has This Been Tested?

This shows no error after the changes in this PR are applied.

```pwsh
PS > scoop install extras/amber
PS > $Error
```

#### Checklist:

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined installer error handling to avoid producing spurious error entries during service checks; junction creation behavior remains unchanged.

* **Documentation**
  * Updated changelog to note the refined error handling during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->