### PR TITLE
fix(uninstall): import url_filename from download.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **path:** Trim ending slash when initializing paths ([#6501](https://github.com/ScoopInstaller/Scoop/issues/6501))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
+- **uninstall:** Import `url_filename` from `download.ps1` ([#6530](https://github.com/ScoopInstaller/Scoop/issues/6530))
 
 ### Code Refactoring
 

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -10,6 +10,7 @@
 . "$PSScriptRoot\..\lib\manifest.ps1" # 'Get-Manifest' 'Select-CurrentVersion' (indirectly)
 . "$PSScriptRoot\..\lib\system.ps1"
 . "$PSScriptRoot\..\lib\install.ps1"
+. "$PSScriptRoot\..\lib\download.ps1" # url_filename
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
<!-- Describe your changes in detail -->

Resolved missing import issue by importing the `url_filename` function from `download.ps1`.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #6514
<!-- or -->
Relates to #6095
Relates to #6527

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

At this moment, this only happens on the develop branch.

In my usage, the error occurs during the `Invoke-Installer` calls  in `libexec\scoop-uninstall.ps1`, which depend on the `url_filename` function.

You can replicate by uninstall an app which uses the uninstaller.file and uninstaller.args. For example:

```powershell
scoop config scoop_repo https://github.com/ScoopInstaller/Scoop
scoop config scoop_branch develop
scoop update
scoop install extras/hack-font
scoop uninstall hack-font
```

```powershell
PS C:\Users\Admin> scoop uninstall hack-font
Uninstalling 'hack-font' (1.6.0).
url_filename : 无法将“url_filename”项识别为 cmdlet、函数、脚本文件或可运行程序的名称。请检查名称的拼写 ，如果包括路径，请确保路径正确，然后再试一次。
所在位置 C:\Users\Admin\scoop\apps\scoop\current\lib\install.ps1:113 字符: 21
+             $Name = url_filename @(url $manifest $architecture)
+                     ~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (url_filename:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException

无法对 Null 数组进行索引。
所在位置 C:\Users\Admin\scoop\apps\scoop\current\lib\install.ps1:115 字符: 30
+         $progName = "$Path\$(coalesce $installer.file $Name[0])"
+                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) []，RuntimeException
    + FullyQualifiedErrorId : NullArray

Running uninstaller ... error.
ERROR 使用“0”个参数调用“Start”时发生异常:“Access is denied”
Uninstallation aborted.
```

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Uninstall process now has access to the download helper; no user-facing behavior changes.
  * Changelog updated to document the linkage between uninstall and the download helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->