### PR TITLE
fix(autoupdate): Ensure GitHub API requests use token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - **scoop-uninstall:** Correct `-Global` Switch ([#6454](https://github.com/ScoopInstaller/Scoop/issues/6454))
 - **scoop-update:** Force sync tags w/ remote branch while scoop update ([#6439](https://github.com/ScoopInstaller/Scoop/issues/6439))
 - **autoupdate:** Use origin URL to handle URLs with fragment in GitHub mode ([#6455](https://github.com/ScoopInstaller/Scoop/issues/6455))
+- **autoupdate:** Ensure GitHub API requests use token ([#6535](https://github.com/ScoopInstaller/Scoop/issues/6535))
 - **buckets|scoop-info:** Switch git log date format to ISO 8601 to avoid locale issues ([#6446](https://github.com/ScoopInstaller/Scoop/issues/6446))
 - **scoop-version:** Fix logic error caused by missing brackets ([#6463](https://github.com/ScoopInstaller/Scoop/issues/6463))
 - **getopt:** Teach getopt to respect the `--%` token ([#6477](https://github.com/ScoopInstaller/Scoop/issues/6477))

--- a/lib/autoupdate.ps1
+++ b/lib/autoupdate.ps1
@@ -118,6 +118,12 @@ function find_hash_in_json([String] $url, [Hashtable] $substitutions, [String] $
         $wc = New-Object Net.Webclient
         $wc.Headers.Add('Referer', (strip_filename $url))
         $wc.Headers.Add('User-Agent', (Get-UserAgent))
+
+        if (($url -match '^https?://api\.github\.com/.*') -and (Get-GitHubToken)) {
+            $wc.Headers.Add('Authorization', "Bearer $(Get-GitHubToken)")
+            $wc.Headers.Add('X-GitHub-Api-Version', '2022-11-28')
+        }
+
         $data = $wc.DownloadData($url)
         $ms = New-Object System.IO.MemoryStream
         $ms.Write($data, 0, $data.Length)


### PR DESCRIPTION
#### Motivation and Context
A patch for #6416. When retrieve hash from GitHub API, the token was not included in the request header.

#### Changes
- fix(autoupdate): Ensure GitHub API requests use token.
- ~~refactor(autoupdate): Use a unified function interface to retrieve web content and cache the results.~~
Edit: To keep things moving, I've split this change into another PR. This ensures the core updates stay small and get merged quickly, while the optimizations are handled in separate PR.

#### Related Issues/PRs:
- https://github.com/ScoopInstaller/Scoop/pull/6416
- https://github.com/ScoopInstaller/Scoop/issues/6381#issuecomment-3410135538
- https://github.com/ScoopInstaller/GithubActions/issues/64

#### How Has This Been Tested?
Tested on my own computer.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub API authentication for autoupdates. Requests to GitHub now properly include authorization credentials and API version headers, improving reliability, increasing available rate limits, and ensuring compatibility with current GitHub API standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->