### PR TITLE
feat(download|scoop-config): Allow disabling automatic fallback to the default downloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **scoop-uninstall:** Allow access to `$bucket` in uninstall scripts ([#6380](https://github.com/ScoopInstaller/Scoop/issues/6380))
 - **install:** Add separator at the end of notes, highlight suggestions ([#6418](https://github.com/ScoopInstaller/Scoop/issues/6418))
+- **download|scoop-config:** Allow disabling automatic fallback to the default downloader when Aria2c download fails ([#6538](https://github.com/ScoopInstaller/Scoop/issues/6538))
 
 ### Bug Fixes
 

--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -454,6 +454,13 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
         Write-Host ''
 
         if ($lastexitcode -gt 0) {
+            if (get_config ARIA2-FALLBACK-DISABLED) {
+                error "Download failed! (Error $lastexitcode) $(aria_exit_code $lastexitcode)"
+                error $urlstxt_content
+                error $aria2
+                abort $(new_issue_msg $app $bucket 'download via aria2 failed')
+            }
+
             warn "Download failed! (Error $lastexitcode) $(aria_exit_code $lastexitcode)"
             warn $urlstxt_content
             warn $aria2

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -132,6 +132,9 @@
 # aria2-warning-enabled: $true|$false
 #       Disable Aria2c warning which is shown while downloading.
 #
+# aria2-fallback-disabled: $true|$false
+#       Disable automatic fallback to the default downloader when Aria2c download fails.
+#
 # aria2-retry-wait: 2
 #       Number of seconds to wait between retries.
 #       See: 'https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-retry-wait'


### PR DESCRIPTION
#### Description
This PR makes the following changes:
- feat(download|scoop-config): Introduce option `aria2-fallback-disabled` to allow disabling automatic fallback to the default downloader when Aria2c download fails.

#### Related PRs/Issues
- Relates to #4292
- Relates to #6497

#### How Has This Been Tested?
  <img width="1101" height="576" alt="image" src="https://github.com/user-attachments/assets/a370716e-d5af-480e-af46-bca44e9aff95" />



#### Checklist
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an aria2-fallback-disabled setting to let users disable automatic fallback to the default downloader when aria2 fails; when enabled, failures emit an error and abort the download.

* **Bug Fixes**
  * Skip the GitHub issue prompt when the downloader falls back to the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->