### PR TITLE
feat(download|scoop-download): Add GitHub issue prompt when the default downloader fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **scoop-uninstall:** Allow access to `$bucket` in uninstall scripts ([#6380](https://github.com/ScoopInstaller/Scoop/issues/6380))
 - **install:** Add separator at the end of notes, highlight suggestions ([#6418](https://github.com/ScoopInstaller/Scoop/issues/6418))
+- **download|scoop-download:** Add GitHub issue prompt when the default downloader fails ([#6539](https://github.com/ScoopInstaller/Scoop/issues/6539))
 
 ### Bug Fixes
 

--- a/lib/download.ps1
+++ b/lib/download.ps1
@@ -23,7 +23,8 @@ function Invoke-ScoopDownload ($app, $version, $manifest, $bucket, $architecture
                 Invoke-CachedDownload $app $version $url "$dir\$fname" $cookies $use_cache
             } catch {
                 Write-Host -ForegroundColor DarkRed $_
-                abort "URL $url is not valid"
+                error "URL $url is not valid"
+                abort $(new_issue_msg $app $bucket 'download failed')
             }
 
             if ($check_hash) {
@@ -457,9 +458,8 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
             warn "Download failed! (Error $lastexitcode) $(aria_exit_code $lastexitcode)"
             warn $urlstxt_content
             warn $aria2
-            warn $(new_issue_msg $app $bucket "download via aria2 failed")
 
-            Write-Host "Fallback to default downloader ..."
+            Write-Host 'Fallback to default downloader ...'
 
             try {
                 foreach ($url in $urls) {
@@ -467,7 +467,8 @@ function Invoke-CachedAria2Download ($app, $version, $manifest, $architecture, $
                 }
             } catch {
                 Write-Host $_ -ForegroundColor DarkRed
-                abort "URL $url is not valid"
+                error "URL $url is not valid"
+                abort $(new_issue_msg $app $bucket 'download failed')
             }
         }
 

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -109,6 +109,7 @@ foreach ($curr_app in $apps) {
             } catch {
                 write-host -f darkred $_
                 error "URL $url is not valid"
+                error $(new_issue_msg $app $bucket 'download failed')
                 $dl_failure = $true
                 continue
             }


### PR DESCRIPTION
#### Motivation and Context
When Aria2c download fails, it prompts the user to create a GitHub issue, but the default downloader doesn't show any prompt.

#### Description
This PR makes the following changes:
- feat(download|scoop-download): Add GitHub issue prompt when the default downloader fails
- fix(download): Skip GitHub issue prompt when falling back to the default downloader

#### How Has This Been Tested?
```
scoop install games/openxcom
scoop download games/openxcom
```
- Before:
  <img width="1104" height="158" alt="image" src="https://github.com/user-attachments/assets/c285d6c9-8fa3-4293-a238-b41bdb7d7e89" />
- After
  <img width="1097" height="266" alt="image" src="https://github.com/user-attachments/assets/6b04f199-4678-411b-acb0-f0d2230a760e" />

#### Checklist
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download failure messages now include a GitHub issue prompt to help users report problems when a download fails.

* **Bug Fixes**
  * Improved invalid-download handling: explicit error output shown for invalid URLs and the issue prompt is surfaced when the primary or fallback downloader fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->