### PR TITLE
test(static-analysis): Add dot-sourcing dependency check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Bug Fixes
 
-- **scoop-download:** Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))
+- **dependency:** Fix missing dot-sourcing dependency ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386), [#6540](https://github.com/ScoopInstaller/Scoop/issues/6540))
 - **scoop-uninstall:** Correct `-Global` Switch ([#6454](https://github.com/ScoopInstaller/Scoop/issues/6454))
 - **scoop-update:** Force sync tags w/ remote branch while scoop update ([#6439](https://github.com/ScoopInstaller/Scoop/issues/6439))
 - **autoupdate:** Use origin URL to handle URLs with fragment in GitHub mode ([#6455](https://github.com/ScoopInstaller/Scoop/issues/6455))
@@ -21,6 +21,10 @@
 ### Code Refactoring
 
 - **output:** Replace raw prints with functions for standardized output ([#6449](https://github.com/ScoopInstaller/Scoop/issues/6449))
+
+### Tests
+
+- **static-analysis:** Add dot-sourcing dependency check ([#6540](https://github.com/ScoopInstaller/Scoop/issues/6540))
 
 ## [v0.5.3](https://github.com/ScoopInstaller/Scoop/compare/v0.5.2...v0.5.3) - 2025-08-11
 

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -64,6 +64,7 @@ param(
     [Switch] $ThrowError
 )
 
+. "$PSScriptRoot\..\lib\core.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
 . "$PSScriptRoot\..\lib\json.ps1"
 

--- a/bin/refresh.ps1
+++ b/bin/refresh.ps1
@@ -1,5 +1,6 @@
 # for development, update the installed scripts to match local source
 . "$PSScriptRoot\..\lib\core.ps1"
+. "$PSScriptRoot\..\lib\system.ps1"
 
 $src = "$PSScriptRoot\.."
 $dest = ensure (versiondir 'scoop' 'current')

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -5,6 +5,10 @@ Set-StrictMode -Off
 . "$PSScriptRoot\..\lib\buckets.ps1"
 . "$PSScriptRoot\..\lib\commands.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
+. "$PSScriptRoot\..\lib\versions.ps1"
+. "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\system.ps1"
+. "$PSScriptRoot\..\lib\database.ps1"
 
 $subCommand = $Args[0]
 

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -17,6 +17,7 @@ param(
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1"
 . "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\download.ps1"
 
 if ($global -and !(is_admin)) {
     error 'You need admin rights to uninstall globally.'

--- a/libexec/scoop-import.ps1
+++ b/libexec/scoop-import.ps1
@@ -10,6 +10,7 @@ param(
 )
 
 . "$PSScriptRoot\..\lib\manifest.ps1"
+. "$PSScriptRoot\..\lib\download.ps1"
 
 $import = $null
 $bucket_names = @()

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -13,6 +13,7 @@
 . "$PSScriptRoot\..\lib\shortcuts.ps1"
 . "$PSScriptRoot\..\lib\psmodules.ps1"
 . "$PSScriptRoot\..\lib\versions.ps1" # 'Select-CurrentVersion'
+. "$PSScriptRoot\..\lib\download.ps1"
 
 # options
 $opt, $apps, $err = getopt $args 'gp' 'global', 'purge'

--- a/test/Scoop-00StaticAnalysis.Tests.ps1
+++ b/test/Scoop-00StaticAnalysis.Tests.ps1
@@ -1,0 +1,55 @@
+Describe 'Static Code Analysis' {
+    BeforeAll {
+        . "$PSScriptRoot\Scoop-StaticAnalysisLib.ps1"
+    }
+
+    Context 'Dot-sourcing dependency check' {
+        BeforeDiscovery {
+            $TestCases = @(
+                @{
+                    LibFolder    = "$PSScriptRoot\..\lib"
+                    ScriptFolder = "$PSScriptRoot\..\libexec"
+                    Entry        = "$PSScriptRoot\..\bin\scoop.ps1"
+                }
+                @{
+                    LibFolder    = "$PSScriptRoot\..\lib"
+                    ScriptFolder = "$PSScriptRoot\..\bin"
+                    Entry        = ''
+                }
+            )
+        }
+
+        It 'For <_.ScriptFolder> Should pass' -TestCases $TestCases {
+            $FlagMissingDep = $false
+
+            $Libs = Get-ChildItem -Path $LibFolder | Select-Object -ExpandProperty FullName
+            $Scripts = Get-ChildItem -Path $ScriptFolder | Select-Object -ExpandProperty FullName
+
+            $AllDeps = $Scripts | Get-DotsourcingDependency -Libs $Libs
+            $PreImportedDeps = if ([string]::IsNullOrWhiteSpace($Entry)) { @() } else { Get-ImportedDependency -Path $Entry }
+
+            $Scripts | ForEach-Object {
+                $Path = $_
+
+                $Deps = $AllDeps[$Path]
+                if (-not $Deps) {
+                    $FlagMissingDep = $true
+                    Write-Host "Error parsing dot-sourcing dependency for $Path."
+                }
+
+                $ImportedDeps = Get-ImportedDependency -Path $Path
+
+                $Deps.Keys | Where-Object { ($_ -notin $ImportedDeps) -and ($_ -notin $PreImportedDeps) } | ForEach-Object {
+                    $FlagMissingDep = $true
+
+                    Write-Host "Missing dot-sourcing dependency in $Path : $_"
+                    $Deps[$_] | ForEach-Object {
+                        Write-Host "`tFunction $($_.Name) called at $($_.File):$($_.Line)"
+                    }
+                }
+            }
+
+            $FlagMissingDep | Should -BeFalse
+        }
+    }
+}

--- a/test/Scoop-StaticAnalysisLib.ps1
+++ b/test/Scoop-StaticAnalysisLib.ps1
@@ -1,0 +1,300 @@
+function Get-ScriptAst {
+    param (
+        [string]$Path
+    )
+
+    if (-not (Test-Path -Path $Path -PathType Leaf)) {
+        Write-Warning "Script file not found: $Path"
+        return $null
+    }
+
+    if ((-not $script:ScriptAst)) {
+        $script:ScriptAst = @{}
+    }
+
+    if (-not $script:ScriptAst[$Path]) {
+        try {
+            $script:ScriptAst[$Path] = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$null, [ref]$null)
+        } catch {
+            Write-Warning "Failed to parse script $Path : $($_.Exception.Message)"
+            return $null
+        }
+    }
+
+    return $script:ScriptAst[$Path]
+}
+
+function Get-ScriptFunction {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [string]$Path
+    )
+
+    begin {
+        $DefinedFuncs = @{}
+    }
+
+    process {
+        Write-Debug "Parsing $Path..."
+
+        $ScriptAst = Get-ScriptAst -Path $Path
+
+        if (-not $ScriptAst) {
+            Write-Warning "Skipping $Path due to AST parsing failure..."
+            return
+        }
+
+        $FuncDefAst = $ScriptAst.FindAll({ param($Node) $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
+
+        $FuncDefAst | ForEach-Object {
+            if ($DefinedFuncs.ContainsKey($_.Name)) {
+                Write-Debug "`tDuplicate function: $($_.Name) defined in $Path`:$($_.Extent.StartLineNumber)"
+                return
+            }
+
+            Write-Debug "`tFound function: $($_.Name) defined in $Path`:$($_.Extent.StartLineNumber)"
+
+            $DefinedFuncs[$_.Name] = @{
+                File = $Path
+                Line = $_.Extent.StartLineNumber
+            }
+        }
+    }
+
+    end {
+        return $DefinedFuncs
+    }
+}
+
+function Get-ImportedDependency {
+    param (
+        [string]$Path
+    )
+
+    $ScriptAst = Get-ScriptAst -Path $Path
+
+    if (-not $ScriptAst) {
+        Write-Warning "Skipping $Path due to AST parsing failure..."
+        return
+    }
+
+    $CommandAst = $ScriptAst.FindAll({ param($Node) $Node -is [System.Management.Automation.Language.CommandAst] }, $true)
+
+    $ImportedDeps = [System.Collections.ArrayList]::new()
+
+    $CommandAst | ForEach-Object {
+        if ($_.InvocationOperator -ne [System.Management.Automation.Language.TokenKind]::Dot) {
+            return
+        }
+
+        if ($_.CommandElements.Count -eq 0) {
+            Write-Warning "Dot-sourcing command with no elements at $Path"
+            return
+        }
+
+        $Dependency = $_.CommandElements[0].Value
+
+        # Workaround for using: prefix in module import. Will be removed in the future.
+        $Dependency = $Dependency -replace 'using:', ''
+
+        try {
+            $ResolvedPath = $Dependency.Replace('$PSScriptRoot', (Split-Path -Parent $Path))
+            $ResolvedDependency = [System.IO.Path]::GetFullPath($ResolvedPath)
+
+            if ($ResolvedDependency -notin $ImportedDeps) {
+                $ImportedDeps.Add($ResolvedDependency) | Out-Null
+            }
+        } catch {
+            Write-Warning "`tFailed to resolve dependency path: $Dependency - $($_.Exception.Message)"
+        }
+    }
+
+    return @($ImportedDeps)
+}
+
+function Get-ScriptFunctionCallMap {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param (
+        [Parameter(ValueFromPipeline)]
+        [string]$Path
+    )
+
+    begin {
+        $CallMap = @{}
+    }
+
+    process {
+        Write-Debug "Parsing $Path..."
+
+        $ScriptAst = Get-ScriptAst -Path $Path
+
+        if (-not $ScriptAst) {
+            Write-Warning "Skipping $Path due to AST parsing failure..."
+            return
+        }
+
+        $FuncDefAst = $ScriptAst.FindAll({ param($Node) $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
+
+        $FuncDefAst | ForEach-Object {
+            $CommandAst = $_.Body.FindAll({ param($Node) $Node -is [System.Management.Automation.Language.CommandAst] }, $true)
+
+            $Visited = @{}
+            $Invocations = [System.Collections.ArrayList]::new()
+
+            $Caller = $_.Name
+
+            $CommandAst | ForEach-Object {
+                $Func = $_.GetCommandName()
+
+                # Workaround for script:url prefix in function calls. Will be removed in the future.
+                $Func = $Func -replace 'script:', ''
+
+                if ((-not $Func) -or $Visited[$Func]) {
+                    return
+                }
+
+                $Visited[$Func] = $true
+
+                $Invocations.Add(@{
+                        Name = $Func
+                        File = $Path
+                        Line = $_.Extent.StartLineNumber
+                    }) | Out-Null
+
+                Write-Debug "`tFound invocation in function $Caller`: $Func."
+            }
+            $CallMap[$Caller] = @($Invocations)
+        }
+    }
+
+    end {
+        return $CallMap
+    }
+}
+
+function Get-ScriptFunctionCall {
+    param (
+        [string]$Path
+    )
+
+    $ScriptAst = Get-ScriptAst -Path $Path
+
+    if (-not $ScriptAst) {
+        Write-Warning "Skipping $Path due to AST parsing failure..."
+        return
+    }
+
+    $CommandAst = $ScriptAst.FindAll({ param($Node) $Node -is [System.Management.Automation.Language.CommandAst] }, $true)
+
+    $Invocation = [System.Collections.ArrayList]::new()
+    $Visited = @{}
+
+    $CommandAst | ForEach-Object {
+        $Func = $_.GetCommandName()
+
+        # Workaround for script:url prefix in function calls. Will be removed in the future.
+        $Func = $Func -replace 'script:', ''
+
+        if ((-not $Func) -or ($Visited[$Func])) {
+            return
+        }
+
+        $Visited[$Func] = $true
+
+        $Invocation.Add(@{
+                Name = $Func
+                File = $Path
+                Line = $_.Extent.StartLineNumber
+            }) | Out-Null
+    }
+
+    return @($Invocation)
+}
+
+function Get-DotsourcingDependency {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param (
+        [string[]] $Libs,
+        [Parameter(ValueFromPipeline)]
+        [string] $Path
+    )
+
+    begin {
+        $Deps = @{}
+        $LibDefinedFuncs = $Libs | Get-ScriptFunction
+        $LibCallMap = $Libs | Get-ScriptFunctionCallMap
+    }
+
+    process {
+        Write-Debug "Analyzing dot-sourcing dependency for $Path ..."
+
+        $Dependency = @{}
+
+        $DefinedFuncs = Get-ScriptFunction -Path $Path
+        $CallMap = Get-ScriptFunctionCallMap -Path $Path
+
+        $Searched = @{}
+        $Queue = [System.Collections.Queue]::new()
+
+        # BFS
+        Get-ScriptFunctionCall -Path $Path | ForEach-Object {
+            $Queue.Enqueue(@{
+                    Name      = $_.Name
+                    CallStack = [System.Collections.ArrayList]::new(@($_))
+                })
+            $Searched[$_.Name] = $true
+        }
+
+        while ($Queue.Count -gt 0) {
+            $Invocation = $Queue.Dequeue()
+            $Name = $Invocation.Name
+
+            Write-Debug "`tFound invocation: $($Invocation.Name)"
+
+            $FuncDefination = $DefinedFuncs[$Name]
+            $FuncCallMap = $CallMap[$Name]
+
+            if (-not $FuncDefination) {
+                $FuncDefination = $LibDefinedFuncs[$Name]
+                $FuncCallMap = $LibCallMap[$Name]
+            }
+
+            if (-not $FuncDefination) {
+                Write-Debug "`tFunction $Name not found, maybe it's a system command or from other script"
+                continue
+            }
+
+            if (($FuncDefination.File -ne $Path) -and (-not $Dependency.ContainsKey($FuncDefination.File))) {
+                $Dependency[$FuncDefination.File] = @($Invocation.CallStack)
+
+                Write-Debug "`t`tFound new dependency: $($FuncDefination.File)"
+                $Invocation.CallStack | ForEach-Object {
+                    Write-Debug "`t`tFunction $($_.Name) called at $($_.File) : $($_.Line)"
+                }
+            }
+
+            $FuncCallMap | Where-Object { $_ -and (-not $Searched[$_.Name]) } | ForEach-Object {
+                $Func = $_.Name
+
+                $CallStack = $Invocation.CallStack.Clone()
+                $CallStack.Add($_) | Out-Null
+
+                $Searched[$Func] = $true
+                $Queue.Enqueue(@{
+                        Name      = $Func
+                        CallStack = $CallStack
+                    })
+            }
+        }
+
+        $Deps[$Path] = $Dependency
+    }
+
+    end {
+        return $Deps
+    }
+}


### PR DESCRIPTION
## Description
This PR makes the following changes:
- test(static-analysis): Add dot-sourcing dependency check.
- fix(dependency): Fix missing dot-sourcing dependency.

### Static Analysis -- Dot-sourcing dependency check
A Function-Level Dot-Sourced Dependency Check is a static analysis mechanism that scans PowerShell scripts to determine which external scripts (modules or libraries) are dot-sourced (i.e., loaded via the . operator) and which functions depend on them.
#### How It Works
A typical implementation proceeds as follows:
1. Parse the script into an AST (Abstract Syntax Tree)
    - `Get-ScriptAst`: The script is parsed into an AST structure, enabling static inspection of function definitions and calls.

2. Extract function definitions and invocations
    - `Get-ScriptFunction`: Collect all functions defined in the current script.
    - `Get-ScriptFunctionCall`: Collect all functions called in the current script.
    - `Get-ScriptFunctionCallMap`: Collect all function calls inside each function body.
    - ~~Skip system-level cmdlets and built-in commands (retrieved via $cmdlet, $function, $alias, or Get-Command -CommandType Cmdlet).~~ This step was **removed** because executing `Get-Command` in a GitHub workflow takes too long.
3. Resolve dot-sourced dependencies
    - `Get-ImportedDependency`: Detect all . <path> expressions (dot-sourcing operators).
    Resolve these file paths (handling $PSScriptRoot, using: prefixes, etc.).
    Record each dot-sourced file as a potential provider of external functions.
4. Cross-link function calls to definitions, Traverse dependencies (BFS)
    - `Get-DotsourcingDependency`: For each function call, determine whether it refers to a local function or one defined in a dot-sourced file. Use breadth-first traversal to resolve transitive dependencies between functions and scripts. Recursively check the function calls within each external function call. Build a dependency map that associates each script with the files and functions it depends on.
    - Check for dot-sourcing dependencies that are used but not imported.
#### Advantage
Helps to detect missing dot-sourced dependencies automatically.

#### Limitations
- Static limitations
  - Since the check is purely static, it may miss dynamically constructed imports (e.g., if a path is computed at runtime) or conditional dot-sourcing based on environment state.
  - This check may produce false positives. For instance, if the caller only executes one branch (e.g., if-else branch) of the callee, the dependencies used in other branches will still be marked as dependencies. (Personally, I think this is an acceptable limitation.)

## Motivation and Context
- Relates to #6385
- Closes #6514
- Closes #6527
- Closes https://github.com/ScoopInstaller/GithubActions/issues/37

## How Has This Been Tested?
Tested in GitHub workflow CI.

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a static code analysis test suite that checks script dependencies and verifies imports and dot-sourced files are resolved.

* **Chores**
  * Added a reusable static-analysis utility library to parse scripts, map function calls, and determine inter-file dependencies for automated validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->