### PR TITLE
fix(core): Skip NO_JUNCTION logic when $app is 'scoop' in `currentdir` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **path:** Trim ending slash when initializing paths ([#6501](https://github.com/ScoopInstaller/Scoop/issues/6501))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
 - **schema:** Add missing `hash.mode` value `github` ([#6533](https://github.com/ScoopInstaller/Scoop/issues/6533))
+- **core:** Skip NO_JUNCTION logic when $app is 'scoop' in `currentdir` function ([#6541](https://github.com/ScoopInstaller/Scoop/issues/6541))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -353,7 +353,7 @@ function appdir($app, $global) { "$(appsdir $global)\$app" }
 function versiondir($app, $version, $global) { "$(appdir $app $global)\$version" }
 
 function currentdir($app, $global) {
-    if (get_config NO_JUNCTION) {
+    if ((get_config NO_JUNCTION) -and ($app -ne 'scoop')) {
         $version = Select-CurrentVersion -App $app -Global:$global
     } else {
         $version = 'current'


### PR DESCRIPTION
#### Description
This PR makes the following changes:
- fix(core): Skip NO_JUNCTION logic when $app is 'scoop' in `currentdir` function.

#### Motivation and Context
When I set `NO_JUNCTION` to true, I noticed that `scoop prefix scoop` returns an incorrect path.

This causes scripts under bucket\bin\, such as checkver.ps1, to stop working.

```powershell
if(!$env:SCOOP_HOME) { $env:SCOOP_HOME = Resolve-Path (scoop prefix scoop) }
$checkver = "$env:SCOOP_HOME/bin/checkver.ps1"
$dir = "$PSScriptRoot/../bucket" # checks the parent dir
Invoke-Expression -command "& '$checkver' -dir '$dir' $($args | ForEach-Object { "$_ " })"
```

<img width="1221" height="124" alt="image" src="https://github.com/user-attachments/assets/2fd0505c-3fc7-490f-9958-e028731c65a9" />

<img width="1222" height="121" alt="image" src="https://github.com/user-attachments/assets/a87a1b97-6300-4e71-a4a3-3873f58e6a4e" />

#### Related PRs/Issues
- Relates to #4722

#### How Has This Been Tested?
<img width="1219" height="440" alt="image" src="https://github.com/user-attachments/assets/c20b8781-7314-4c00-9e1b-61efd47aad47" />

#### Checklist
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted version selection so the 'scoop' application no longer uses the non-junction "current" handling, ensuring consistent current-version behavior for scoop-managed packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->