### PR TITLE
fix(checkver): Fix incorrect version returned when script fails without output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **path:** Trim ending slash when initializing paths ([#6501](https://github.com/ScoopInstaller/Scoop/issues/6501))
 - **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
+- **checkver:** Fix incorrect version returned when script fails without output ([#6547](https://github.com/ScoopInstaller/Scoop/issues/6547))
 - **uninstall:** Import `url_filename` from `download.ps1` ([#6530](https://github.com/ScoopInstaller/Scoop/issues/6530))
 - **schema:** Add missing `hash.mode` value `github` ([#6533](https://github.com/ScoopInstaller/Scoop/issues/6533))
 - **core:** Skip NO_JUNCTION logic when $app is 'scoop' in `currentdir` function ([#6541](https://github.com/ScoopInstaller/Scoop/issues/6541))

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -274,6 +274,8 @@ while ($in_progress -gt 0) {
     $expected_ver = $json.version
     $ver = $Version
 
+    $matchesHashtable = @{}
+
     if (!$ver) {
         if (!$regexp -and $replace) {
             next "'replace' requires 're' or 'regex'"
@@ -303,6 +305,11 @@ while ($in_progress -gt 0) {
         if ($script) {
             $page = Invoke-Command ([scriptblock]::Create($script -join "`r`n"))
             $source = 'the output of script'
+        }
+
+        if ($null -eq $page) {
+            next "couldn't retrieve content from $source"
+            continue
         }
 
         if ($jsonpath) {
@@ -363,7 +370,6 @@ while ($in_progress -gt 0) {
             }
 
             if ($match -and $match.Success) {
-                $matchesHashtable = @{}
                 $re.GetGroupNames() | ForEach-Object { $matchesHashtable.Add($_, $match.Groups[$_].Value) }
                 $ver = $matchesHashtable['1']
                 if ($replace) {


### PR DESCRIPTION
## Description
Migrate from #6489.

#### Motivation and Context
Closes:
- #6425
- https://github.com/ScoopInstaller/GithubActions/issues/36

Relats to:
- #4941
- #6489

#### Changes
This PR makes the following changes:
- `fix(checkver)`: Fix incorrect version returned when checkver.script fails without output.

#### Tests
- Before: https://github.com/z-Fng/Test-Scoop-checkver/actions/runs/19346533804/job/55348214134
> other-pkg: 18.0.0 (scoop version is 1.0.0) autoupdate available
- After: https://github.com/z-Fng/Test-Scoop-checkver/actions/runs/19365821642/job/55408575924
> other-pkg: couldn't retrieve content from the output of script

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where version detection could return an incorrect value when a probe or script failed without producing output.
  * Improved isolation between individual checks so results from prior attempts no longer affect subsequent version detection, reducing false positives after errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->