### PR TITLE
fix(checkver): Prevent $page from carrying over between iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - **getopt:** Teach getopt to respect the `--%` token ([#6477](https://github.com/ScoopInstaller/Scoop/issues/6477))
 - **core|manifest:** Avoid error messages when searching non-existent 'deprecated' directory ([#6471](https://github.com/ScoopInstaller/Scoop/issues/6471))
 - **path:** Trim ending slash when initializing paths ([#6501](https://github.com/ScoopInstaller/Scoop/issues/6501))
-- **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490))
+- **checkver:** Allow script to run when URL fetch fails but script exists ([#6490](https://github.com/ScoopInstaller/Scoop/issues/6490), [#6556](https://github.com/ScoopInstaller/Scoop/issues/6556))
 - **install:** Don't add to `$Error` when checking for service `cexecsvc` ([#6520](https://github.com/ScoopInstaller/Scoop/issues/6520))
 - **checkver:** Fix incorrect version returned when script fails without output ([#6547](https://github.com/ScoopInstaller/Scoop/issues/6547))
 - **uninstall:** Import `url_filename` from `download.ps1` ([#6530](https://github.com/ScoopInstaller/Scoop/issues/6530))

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -292,6 +292,9 @@ while ($in_progress -gt 0) {
             }
         }
 
+        $page = $null
+        $source = $url
+
         if ($url -and !$err) {
             $ms = New-Object System.IO.MemoryStream
             $ms.Write($result, 0, $result.Length)
@@ -301,7 +304,7 @@ while ($in_progress -gt 0) {
             }
             $page = (New-Object System.IO.StreamReader($ms, (Get-Encoding $wc))).ReadToEnd()
         }
-        $source = $url
+
         if ($script) {
             $page = Invoke-Command ([scriptblock]::Create($script -join "`r`n"))
             $source = 'the output of script'


### PR DESCRIPTION
#### Description
This PR makes the following changes:
- fix(checkver): Prevent $page from carrying over between iterations.

#### Motivation and Context
This PR serves as a patch for PR #6490.

If `$url` fails to fetch, the `$page` value may persist across iterations and be used by `checkver.script`.

- Relates to: #5080
- Relates to: #6547
- Relates to: #6490

#### How Has This Been Tested?
I've tested this locally. I'm not sure if adding a test case is necessary.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download vs. script fallback flow for more reliable content retrieval
  * Clarified source and error messages to better reflect whether content came from a URL or script
  * Enhanced error-checking to reduce false failures during retrieval

* **Chores**
  * Updated changelog entry with an additional cross-reference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->