### PR TITLE
Add file lock to prevent concurrent executions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 .DS_Store
 ._.DS_Store
+.lock
 scoop.sublime-workspace
 test/installer/tmp/*
 test/tmp/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **install:** Add separator at the end of notes, highlight suggestions ([#6418](https://github.com/ScoopInstaller/Scoop/issues/6418))
 - **download|scoop-download:** Add GitHub issue prompt when the default downloader fails ([#6539](https://github.com/ScoopInstaller/Scoop/issues/6539))
 - **download|scoop-config:** Allow disabling automatic fallback to the default downloader when Aria2c download fails ([#6538](https://github.com/ScoopInstaller/Scoop/issues/6538))
+- **core:** Add file lock to prevent concurrent executions ([#6557](https://github.com/ScoopInstaller/Scoop/issues/6557))
 
 ### Bug Fixes
 

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -6,48 +6,74 @@ Set-StrictMode -Off
 . "$PSScriptRoot\..\lib\commands.ps1"
 . "$PSScriptRoot\..\lib\help.ps1"
 
-$subCommand = $Args[0]
+$lock_file_path = "$PSScriptRoot\..\.lock"
+$lock_stream = $null
+$lock_show_waiting_message = $true
 
-# for aliases where there's a local function, re-alias so the function takes precedence
-$aliases = Get-Alias | Where-Object { $_.Options -notmatch 'ReadOnly|AllScope' } | ForEach-Object { $_.Name }
-Get-ChildItem Function: | Where-Object -Property Name -In -Value $aliases | ForEach-Object {
-    Set-Alias -Name $_.Name -Value Local:$($_.Name) -Scope Script
+while (-not $lock_stream) {
+    try {
+        $lock_stream = [System.IO.File]::Open($lock_file_path, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+    } catch [System.IO.IOException] {
+        # Only deal with ERROR_SHARING_VIOLATION or ERROR_LOCK_VIOLATION.
+        $error_code = $_.Exception.HResult -band 0xFFFF
+        if ($error_code -notin 32, 33) {
+            throw
+        }
+
+        if ($lock_show_waiting_message) {
+            Write-Host 'Waiting for exclusive access...'
+            $lock_show_waiting_message = $false
+        }
+        Start-Sleep -Seconds 1
+    }
 }
 
-switch ($subCommand) {
-    ({ $subCommand -in @($null, '-h', '--help', '/?') }) {
-        exec 'help'
-    }
-    ({ $subCommand -in @('-v', '--version') }) {
-        Write-Host 'Current Scoop version:'
-        if ((Test-GitAvailable) -and (Test-Path "$PSScriptRoot\..\.git") -and ((get_config SCOOP_BRANCH 'master') -ne 'master')) {
-            Invoke-Git -Path "$PSScriptRoot\.." -ArgumentList @('--no-pager', 'log', 'HEAD', '-1', '--oneline')
-        } else {
-            $version = Select-String -Pattern '^## \[(v[\d.]+)\].*?([\d-]+)$' -Path "$PSScriptRoot\..\CHANGELOG.md"
-            Write-Host $version.Matches.Groups[1].Value -ForegroundColor Cyan -NoNewline
-            Write-Host " - Released at $($version.Matches.Groups[2].Value)"
-        }
-        Write-Host ''
+try {
+    $subCommand = $Args[0]
 
-        Get-LocalBucket | ForEach-Object {
-            $bucketLoc = Find-BucketDirectory $_ -Root
-            if ((Test-GitAvailable) -and (Test-Path "$bucketLoc\.git")) {
-                Write-Host "'$_' bucket:"
-                Invoke-Git -Path $bucketLoc -ArgumentList @('--no-pager', 'log', 'HEAD', '-1', '--oneline')
-                Write-Host ''
+    # for aliases where there's a local function, re-alias so the function takes precedence
+    $aliases = Get-Alias | Where-Object { $_.Options -notmatch 'ReadOnly|AllScope' } | ForEach-Object { $_.Name }
+    Get-ChildItem Function: | Where-Object -Property Name -In -Value $aliases | ForEach-Object {
+        Set-Alias -Name $_.Name -Value Local:$($_.Name) -Scope Script
+    }
+
+    switch ($subCommand) {
+        ({ $subCommand -in @($null, '-h', '--help', '/?') }) {
+            exec 'help'
+        }
+        ({ $subCommand -in @('-v', '--version') }) {
+            Write-Host 'Current Scoop version:'
+            if ((Test-GitAvailable) -and (Test-Path "$PSScriptRoot\..\.git") -and ((get_config SCOOP_BRANCH 'master') -ne 'master')) {
+                Invoke-Git -Path "$PSScriptRoot\.." -ArgumentList @('--no-pager', 'log', 'HEAD', '-1', '--oneline')
+            } else {
+                $version = Select-String -Pattern '^## \[(v[\d.]+)\].*?([\d-]+)$' -Path "$PSScriptRoot\..\CHANGELOG.md"
+                Write-Host $version.Matches.Groups[1].Value -ForegroundColor Cyan -NoNewline
+                Write-Host " - Released at $($version.Matches.Groups[2].Value)"
+            }
+            Write-Host ''
+
+            Get-LocalBucket | ForEach-Object {
+                $bucketLoc = Find-BucketDirectory $_ -Root
+                if ((Test-GitAvailable) -and (Test-Path "$bucketLoc\.git")) {
+                    Write-Host "'$_' bucket:"
+                    Invoke-Git -Path $bucketLoc -ArgumentList @('--no-pager', 'log', 'HEAD', '-1', '--oneline')
+                    Write-Host ''
+                }
             }
         }
-    }
-    ({ $subCommand -in (commands) }) {
-        [string[]]$arguments = $Args | Select-Object -Skip 1
-        if ($null -ne $arguments -and $arguments[0] -in @('-h', '--help', '/?')) {
-            exec 'help' @($subCommand)
-        } else {
-            exec $subCommand $arguments
+        ({ $subCommand -in (commands) }) {
+            [string[]]$arguments = $Args | Select-Object -Skip 1
+            if ($null -ne $arguments -and $arguments[0] -in @('-h', '--help', '/?')) {
+                exec 'help' @($subCommand)
+            } else {
+                exec $subCommand $arguments
+            }
+        }
+        default {
+            warn "scoop: '$subCommand' isn't a scoop command. See 'scoop help'."
+            exit 1
         }
     }
-    default {
-        warn "scoop: '$subCommand' isn't a scoop command. See 'scoop help'."
-        exit 1
-    }
+} finally {
+    $lock_stream.Dispose()
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description

This patch adds a file lock to ensure only one process uses Scoop. Extra processes wait 1 second and retry, so dequeuing is not handled in order.

The diff shows a lot of modified lines, but it's actually just an indent increase due to the try-finally block.

#### Motivation and Context

I've created a scheduled task to automate `scoop update *` every morning or at every startup. Whether it's good or bad is another topic :) But I've noticed some conflicts. For instance, `scoop list` shows `install failed` while the app is being installed. I suspect that I got corrupted git-buckets due to parallel updates too.

This is also in line with my expectations of a service. IMHO Scoop acts like a session-wide service that several processes can access, so it must ensure it's safe to do so. The fact that Scoop exclusively works with PS1 scripts is an implementation detail.

Note that global installs made by different process owners could still conflicts. A better version would be to pinpoint which commands are subjects to lock, and in these cases whether the lock should be global. This would also have the benefit not to lock for things like displaying help. I'd love to have that, but there's more effort to put, so please tell me what you think first.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Locally with multiple shells.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [X] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a file locking mechanism to prevent concurrent executions; callers see a one-time waiting message if a run is already active.

* **Bug Fixes**
  * Ensures the lock is always released after execution.
  * Unknown or unsupported commands now emit a clear warning and exit with a non-zero status.

* **Chores**
  * Updated ignore rules to exclude lock files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->