### PR TITLE
fix(core): Fix substitute handling of substring keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **uninstall:** Import `url_filename` from `download.ps1` ([#6530](https://github.com/ScoopInstaller/Scoop/issues/6530))
 - **schema:** Add missing `hash.mode` value `github` ([#6533](https://github.com/ScoopInstaller/Scoop/issues/6533))
 - **core:** Skip NO_JUNCTION logic when $app is 'scoop' in `currentdir` function ([#6541](https://github.com/ScoopInstaller/Scoop/issues/6541))
+- **core:** Fix substitute handling of substring keys ([#6561](https://github.com/ScoopInstaller/Scoop/issues/6561))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1209,11 +1209,12 @@ function substitute($entity, [Hashtable] $params, [Bool]$regexEscape = $false) {
         $newentity = $entity.PSObject.Copy()
         switch ($entity.GetType().Name) {
             'String' {
-                $params.GetEnumerator() | ForEach-Object {
-                    if ($regexEscape -eq $false -or $null -eq $_.Value) {
-                        $newentity = $newentity.Replace($_.Name, $_.Value)
+                $params.Keys | Sort-Object Length -Descending | ForEach-Object {
+                    $value = $params[$_]
+                    if ($regexEscape -eq $false -or $null -eq $value) {
+                        $newentity = $newentity.Replace($_, $value)
                     } else {
-                        $newentity = $newentity.Replace($_.Name, [Regex]::Escape($_.Value))
+                        $newentity = $newentity.Replace($_, [Regex]::Escape($value))
                     }
                 }
             }

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -393,3 +393,17 @@ Describe 'Format Architecture String' -Tag 'Scoop' {
         { Format-ArchitectureString 'PPC' } | Should -Throw "Invalid architecture: 'ppc'"
     }
 }
+
+Describe 'substitute' -Tag 'Scoop' {
+    It 'should properly handle keys that are substrings of other keys' {
+        $params = @{}
+
+        # Run repeatedly (10 times) to reduce the likelihood of accidental correct ordering.
+        1 .. 10 | ForEach-Object {
+            $params["`$name$($_)"] = "$($_).exe"
+            $params["`$name$($_)NoExt"] = "$_"
+
+            substitute ("`$name$($_)NoExt") $params $false | Should -Be "$_"
+        }
+    }
+}


### PR DESCRIPTION
#### Description
This PR serves as a patch for #3742.
- fix(core): Fix substitute handling of substring keys.

#### Motivation and Context
- Closes #5466
- Relates to #3742
- Relates to https://github.com/ScoopInstaller/Extras/pull/16663

Replacing `$urlNoExt`/`$basenameNoExt` gives the wrong result, since they can't be guaranteed to be substituted before `$url`/`$basename`. e.g., https://github.com/ScoopInstaller/Extras/actions/runs/19738928350/job/56557648027
> Searching hash for EverythingToolbar-2.1.1-x64.exe in https://github.com/srwi/EverythingToolbar/releases/download/2.1.1/EverythingToolbar-2.1.1-x64.exeNoExt.sha256
The remote server returned an error: (404) Not Found.


#### How Has This Been Tested?
Unit tests have been added.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved parameter substitution to avoid substring collisions by applying longer keys before shorter ones, ensuring proper escaping when required and per-key replacements.
* **Tests**
  * Added unit tests verifying substitution behavior for keys that are substrings of others, including repeated runs to reduce ordering flakiness and null-safety checks.
* **Chore**
  * Added an unreleased changelog entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->