### PR TITLE
fix(checkver): Remove redundant always-true condition in GitHub checkver logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **uninstall:** Import `url_filename` from `download.ps1` ([#6530](https://github.com/ScoopInstaller/Scoop/issues/6530))
 - **schema:** Add missing `hash.mode` value `github` ([#6533](https://github.com/ScoopInstaller/Scoop/issues/6533))
 - **core:** Skip NO_JUNCTION logic when $app is 'scoop' in `currentdir` function ([#6541](https://github.com/ScoopInstaller/Scoop/issues/6541))
+- **checkver:** Remove redundant always-true condition in GitHub checkver logic ([#6571](https://github.com/ScoopInstaller/Scoop/issues/6571))
 
 ### Code Refactoring
 

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -159,7 +159,7 @@ $Queue | ForEach-Object {
     if ($json.checkver.github) {
         $url = $json.checkver.github.TrimEnd('/') + '/releases/latest'
         $regex = $githubRegex
-        if ($json.checkver.PSObject.Properties.Count -eq 1) { $useGithubAPI = $true }
+        $useGithubAPI = $true
     }
 
     # SourceForge


### PR DESCRIPTION
#### Motivation and Context
- Relates to #4557
- Relates to https://github.com/ScoopInstaller/Scoop/issues/6559#issuecomment-3567109138

#### Description
https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/bin/checkver.ps1#L159-L163
The previous property count check was always true and had no effect. The always-true condition was misleading and confusing.
This change removes the redundant condition and explicitly enables the GitHub API for GitHub-based checkver.

```powershell
$content = '{"checkver":{"github":"https://github.com/ScoopInstaller/Scoop","regex":"[\\d.]+"}}'
$json = ConvertFrom-Json $content
if ($json.checkver.PSObject.Properties.Count -eq 1) {Write-Host 'Condition passed'}
$json.checkver.PSObject.Properties.Count
$json.checkver | Get-Member -MemberType NoteProperty | Measure-Object | Select-Object -ExpandProperty Count
```
<img width="1098" height="178" alt="image" src="https://github.com/user-attachments/assets/c076b715-1bb3-422e-8689-4c35aa1555d5" />

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub-based version checks now consistently use the GitHub API, removing redundant conditional behavior for more reliable lookups.

* **Documentation**
  * Added an unreleased changelog entry noting the redundant-condition removal in the GitHub checkver flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->