### PR TITLE
fix(core): check $deprecated_dir exists before accessing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **schema:** Add missing `hash.mode` value `github` ([#6533](https://github.com/ScoopInstaller/Scoop/issues/6533))
 - **core:** Skip NO_JUNCTION logic when $app is 'scoop' in `currentdir` function ([#6541](https://github.com/ScoopInstaller/Scoop/issues/6541))
 - **core:** Fix substitute handling of substring keys ([#6561](https://github.com/ScoopInstaller/Scoop/issues/6561))
+- **core:** Check `$deprecated_dir` exists before accessing it ([#6574](https://github.com/ScoopInstaller/Scoop/issues/6574))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -552,7 +552,9 @@ function app_status($app, $global) {
     $status.hold = ($install_info.hold -eq $true)
 
     $deprecated_dir = (Find-BucketDirectory -Name $install_info.bucket -Root) + "\deprecated"
-    $status.deprecated = (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse -ErrorAction Ignore).FullName
+    if (Test-Path $deprecated_dir) {
+        $status.deprecated = (Get-ChildItem $deprecated_dir -Filter "$(sanitary_path $app).json" -Recurse).FullName
+    }
 
     $manifest = manifest $app $install_info.bucket $install_info.url
     $status.removed = (!$manifest)


### PR DESCRIPTION
Closes #6573 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Tested on my computer.
- Before adding the check, `scoop list` takes 2-3 minutes.
- After adding it, it only takes 10 seconds.


#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when the deprecated components directory is missing by checking for its presence before attempting to read it. Deprecation information is now only accessed when available, avoiding runtime errors and improving stability and reliability when deprecated components are absent. No public APIs or behavior changes beyond improved error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->