### PR TITLE
fix(checkup): Catch Get-MpPreference exception

### DIFF
--- a/lib/diagnostic.ps1
+++ b/lib/diagnostic.ps1
@@ -6,21 +6,26 @@ Use 'warn' to highlight the issue, and follow up with the recommended actions to
 function check_windows_defender($global) {
     $defender = Get-Service -Name WinDefend -ErrorAction SilentlyContinue
     if (Test-CommandAvailable Get-MpPreference) {
-        if ((Get-MpPreference).DisableRealtimeMonitoring) { return $true }
-        if ($defender -and $defender.Status) {
-            if ($defender.Status -eq [System.ServiceProcess.ServiceControllerStatus]::Running) {
-                $installPath = $scoopdir;
-                if ($global) { $installPath = $globaldir; }
+        try {
+            if ((Get-MpPreference -Erroraction Stop).DisableRealtimeMonitoring) { return $true }
+            if ($defender -and $defender.Status) {
+                if ($defender.Status -eq [System.ServiceProcess.ServiceControllerStatus]::Running) {
+                    $installPath = $scoopdir;
+                    if ($global) { $installPath = $globaldir; }
 
-                $exclusionPath = (Get-MpPreference).ExclusionPath
-                if (!($exclusionPath -contains $installPath)) {
-                    info "Windows Defender may slow down or disrupt installs with realtime scanning."
-                    Write-Host "  Consider running:"
-                    Write-Host "    sudo Add-MpPreference -ExclusionPath '$installPath'"
-                    Write-Host "  (Requires 'sudo' command. Run 'scoop install sudo' if you don't have it.)"
-                    return $false
+                    $exclusionPath = (Get-MpPreference -Erroraction Stop).ExclusionPath
+                    if (!($exclusionPath -contains $installPath)) {
+                        info "Windows Defender may slow down or disrupt installs with realtime scanning."
+                        Write-Host "  Consider running:"
+                        Write-Host "    sudo Add-MpPreference -ExclusionPath '$installPath'"
+                        Write-Host "  (Requires 'sudo' command. Run 'scoop install sudo' if you don't have it.)"
+                        return $false
+                    }
                 }
             }
+        } catch [Microsoft.Management.Infrastructure.CimException] {
+            debug "Get-MpPreference failed: $($_.Exception.Message)"
+            return $true
         }
     }
     return $true


### PR DESCRIPTION

#### Description
Catches `Get-MpPreference` error and returns gracefully

#### Motivation and Context
Closes: #6583

#### How Has This Been Tested?
Tested by running `scoop checkup` on my machine.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in Windows Defender diagnostic checks to improve reliability when retrieving security preferences and exclusion settings. The diagnostic tool now gracefully handles retrieval failures and provides enhanced debug information for troubleshooting, preventing false negatives due to temporary retrieval errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->