### PR TITLE
fix(buckets): Skip Git invocation if unavailable in `new_issue_msg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - **core:** Fix the grep parameter in the `Invoke-GitLog` function ([#6407](https://github.com/ScoopInstaller/Scoop/issues/6407))
+- **buckets:** Skip Git invocation if unavailable in `new_issue_msg` ([#6591](https://github.com/ScoopInstaller/Scoop/issues/6591))
 - **buckets:** Fix the filtering condition when retrieving the number of manifests ([#6509](https://github.com/ScoopInstaller/Scoop/issues/6509))
 - **scoop-download:** Fix function `nightly_version` not defined error ([#6386](https://github.com/ScoopInstaller/Scoop/issues/6386))
 - **scoop-download:** Fix incorrect download success state ([#6473](https://github.com/ScoopInstaller/Scoop/issues/6473))

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -190,7 +190,7 @@ function new_issue_msg($app, $bucket, $title, $body) {
     $url = known_bucket_repo $bucket
     $bucket_path = "$bucketsdir\$bucket"
 
-    if (Test-Path $bucket_path) {
+    if ((Test-Path $bucket_path) -and (Test-GitAvailable)) {
         $remote = Invoke-Git -Path $bucket_path -ArgumentList @('config', '--get', 'remote.origin.url')
         # Support ssh and http syntax
         # git@PROVIDER:USER/REPO.git


### PR DESCRIPTION
#### Motivation and Context
  Fix issues that occur when Git is not installed:
  - `new_issue_msg` throws a error when trying to invoke Git commands, leading to confusing error messages and incorrect issue links.
    e.g. https://github.com/ScoopInstaller/Scoop/issues/6588
    https://github.com/ScoopInstaller/Scoop/issues/4735
    https://github.com/ScoopInstaller/Scoop/issues/6562

    > Please try again or create a new issue by using the following link and paste your console output:
    > https:////
  - Before:<img width="1101" height="517" alt="image" src="https://github.com/user-attachments/assets/a999b091-a221-42a8-b9d8-4d730e585b94" />
  - After: <img width="1100" height="237" alt="image" src="https://github.com/user-attachments/assets/9b54fbfb-b791-45cb-89c9-8b1dc532d296" />

#### Changes:
  - `lib/buckets.ps1`: Check `Test-GitAvailable` before invoking Git in `new_issue_msg`.

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness by gracefully handling scenarios where Git is unavailable when creating issue reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->