### PR TITLE
move default config file from userprofile\.config to scoop\persist - Update core.ps1

### DIFF
--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -1260,7 +1260,8 @@ function Out-UTF8File {
 Optimize-SecurityProtocol
 
 # Load Scoop config
-$configHome = $env:XDG_CONFIG_HOME, "$env:USERPROFILE\.config" | Select-Object -First 1
+$legacyConfig = if (Test-Path "$env:USERPROFILE\.config") { "$env:USERPROFILE\.config" }
+$configHome = $env:XDG_CONFIG_HOME, $legacyConfig, "$PSScriptRoot\..\..\..\..\persist" | Select-Object -First 1
 $configFile = "$configHome\scoop\config.json"
 # Check if it's the expected install path for scoop: <root>/apps/scoop/current
 $coreRoot = Split-Path $PSScriptRoot


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description
dumping a .config folder in the root user profile is annoying, so I propose moving it to be in scoop\persist\scoop to be consistent with other scoop apps

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Annoyance
<!-- or -->
Companion to https://github.com/ScoopInstaller/Install/pull/126

#### How Has This Been Tested?
tested on my PC works fine
tested to still accept .config as priority if it already exists

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.

Sorry am noob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced configuration loading to intelligently search multiple paths including legacy and portable configurations. System now checks multiple standard locations in priority order while maintaining full backward compatibility with existing setups, ensuring configurations are correctly located regardless of user environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->