### PR TITLE
add: register pdfzus bucket

### DIFF
--- a/buckets.json
+++ b/buckets.json
@@ -5,6 +5,7 @@
     "nirsoft": "https://github.com/ScoopInstaller/Nirsoft",
     "sysinternals": "https://github.com/niheaven/scoop-sysinternals",
     "php": "https://github.com/ScoopInstaller/PHP",
+    "pdfzus": "https://github.com/wsgtcyx/PDF-zusammenfuegen-scoop",
     "nerd-fonts": "https://github.com/matthewjberger/scoop-nerd-fonts",
     "nonportable": "https://github.com/ScoopInstaller/Nonportable",
     "java": "https://github.com/ScoopInstaller/Java",


### PR DESCRIPTION
## Summary

- add the pdfzus bucket to buckets.json
- point it to https://github.com/wsgtcyx/PDF-zusammenfuegen-scoop

## Notes

- the bucket repository is public
- it already uses the scoop-bucket topic for Scoop Directory discovery
- release assets and manifest are published and installable via Scoop
