### PR TITLE
chore: make warn `use 'scoop update --- to install a new version.` for `scoo…

### DIFF
--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -80,7 +80,7 @@ if ($apps.length -eq 1) {
     }
     $curVersion = Select-CurrentVersion -AppName $app -Global:$global
     if ($null -eq $version -and $curVersion) {
-        warn "'$app' ($curVersion) is already installed.`nUse 'scoop update $app$(if ($global) { ' --global' })' to install a new version."
+        warn "'$app' ($curVersion) is already installed.`nUse 'scoop update $app$(if ($global) { ' --global' })' to install a new version.`n`tscoop update $app$(if ($global) { ' --global' })"
         exit 0
     }
 }
@@ -101,7 +101,7 @@ if ($specific_versions.Count -gt 0) {
 $specific_versions_paths = $specific_versions | ForEach-Object {
     $app, $bucket, $version = parse_app $_
     if (installed_manifest $app $version) {
-        warn "'$app' ($version) is already installed.`nUse 'scoop update $app$(if ($global) { ' --global' })' to install a new version."
+        warn "'$app' ($curVersion) is already installed.`nUse 'scoop update $app$(if ($global) { ' --global' })' to install a new version.`n`tscoop update $app$(if ($global) { ' --global' })"
         continue
     }
 


### PR DESCRIPTION
make wan for `scoop install` more friendly to users

#### Description
add `scoop update ---` to a new line, make it easy to be copied

#### Motivation and Context
when user have installed an app but still run `scoop install`,  the user will get warn about `scoop udpate`.
it's good to put the command in a dedicated line, which is easy to be copied

example 
```
> scoop install brave-beta
WARN  'brave-beta' (1.86.101) is already installed.
Use 'scoop update brave-beta' to install a new version.
        scoop update brave-beta
```

#### How Has This Been Tested?
test is simple because only warn info changed
tested on my pc


#### Checklist:
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installation warning messages to provide additional command suggestions when packages are already installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->