### PR TITLE
fix(core): Give `dark` higher priority when use `Extract-DarkArchive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - **core:** Fix substitute handling of substring keys ([#6561](https://github.com/ScoopInstaller/Scoop/issues/6561))
 - **core:** Check `$deprecated_dir` exists before accessing it ([#6574](https://github.com/ScoopInstaller/Scoop/issues/6574))
 - **checkver:** Remove redundant always-true condition in GitHub checkver logic ([#6571](https://github.com/ScoopInstaller/Scoop/issues/6571))
+- **core:** Give `dark` higher priority when use `Extract-DarkArchive` ([#6637](https://github.com/ScoopInstaller/Scoop/issues/6637))
 
 ### Code Refactoring
 

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -80,7 +80,7 @@ function Show-DeprecatedWarning {
 }
 
 function load_cfg($file) {
-    if(!(Test-Path $file)) {
+    if (!(Test-Path $file)) {
         return $null
     }
 
@@ -96,14 +96,14 @@ function load_cfg($file) {
 
 function get_config($name, $default) {
     $name = $name.ToLowerInvariant()
-    if($null -eq $scoopConfig.$name -and $null -ne $default) {
+    if ($null -eq $scoopConfig.$name -and $null -ne $default) {
         return $default
     }
     return $scoopConfig.$name
 }
 
 function set_config {
-    Param (
+    param (
         [ValidateNotNullOrEmpty()]
         $name,
         $value
@@ -235,11 +235,11 @@ function Invoke-Git {
         $ArgumentList = @('-C', $WorkingDirectory) + $ArgumentList
     }
 
-    if([String]::IsNullOrEmpty($proxy) -or $proxy -eq 'none')  {
+    if ([String]::IsNullOrEmpty($proxy) -or $proxy -eq 'none') {
         return & $git @ArgumentList
     }
 
-    if($ArgumentList -Match '\b(clone|checkout|pull|fetch|ls-remote)\b') {
+    if ($ArgumentList -match '\b(clone|checkout|pull|fetch|ls-remote)\b') {
         $j = Start-Job -ScriptBlock {
             # convert proxy setting for git
             $proxy = $using:proxy
@@ -259,14 +259,14 @@ function Invoke-Git {
 
 function Invoke-GitLog {
     [CmdletBinding()]
-    Param (
+    param (
         [Parameter(Mandatory, ValueFromPipeline)]
         [String]$Path,
         [Parameter(Mandatory, ValueFromPipeline)]
         [String]$CommitHash,
         [String]$Name = ''
     )
-    Process {
+    process {
         if ($Name) {
             if ($Name.Length -gt 12) {
                 $Name = "$($Name.Substring(0, 10)).."
@@ -278,7 +278,7 @@ function Invoke-GitLog {
 }
 
 # helper functions
-function coalesce($a, $b) { if($a) { return $a } $b }
+function coalesce($a, $b) { if ($a) { return $a } $b }
 
 function is_admin {
     $admin = [security.principal.windowsbuiltinrole]::administrator
@@ -287,10 +287,10 @@ function is_admin {
 }
 
 # messages
-function abort($msg, [int] $exit_code=1) { write-host $msg -f red; exit $exit_code }
-function error($msg) { write-host "ERROR $msg" -f darkred }
-function warn($msg) {  write-host "WARN  $msg" -f darkyellow }
-function info($msg) {  write-host "INFO  $msg" -f darkgray }
+function abort($msg, [int] $exit_code = 1) { Write-Host $msg -f red; exit $exit_code }
+function error($msg) { Write-Host "ERROR $msg" -f darkred }
+function warn($msg) { Write-Host "WARN  $msg" -f darkyellow }
+function info($msg) { Write-Host "INFO  $msg" -f darkgray }
 function debug($obj) {
     if ((get_config DEBUG $false) -ine 'true' -and $env:SCOOP_DEBUG -ine 'true') {
         return
@@ -300,14 +300,14 @@ function debug($obj) {
     $param = $MyInvocation.Line.Replace($MyInvocation.InvocationName, '').Trim()
     $msg = $obj | Out-String -Stream
 
-    if($null -eq $obj -or $null -eq $msg) {
+    if ($null -eq $obj -or $null -eq $msg) {
         Write-Host "$prefix $param = " -f DarkCyan -NoNewline
         Write-Host '$null' -f DarkYellow -NoNewline
         Write-Host " -> $($MyInvocation.PSCommandPath):$($MyInvocation.ScriptLineNumber):$($MyInvocation.OffsetInLine)" -f DarkGray
         return
     }
 
-    if($msg.GetType() -eq [System.Object[]]) {
+    if ($msg.GetType() -eq [System.Object[]]) {
         Write-Host "$prefix $param ($($obj.GetType()))" -f DarkCyan -NoNewline
         Write-Host " -> $($MyInvocation.PSCommandPath):$($MyInvocation.ScriptLineNumber):$($MyInvocation.OffsetInLine)" -f DarkGray
         $msg | Where-Object { ![String]::IsNullOrWhiteSpace($_) } |
@@ -320,18 +320,18 @@ function debug($obj) {
         Write-Host " -> $($MyInvocation.PSCommandPath):$($MyInvocation.ScriptLineNumber):$($MyInvocation.OffsetInLine)" -f DarkGray
     }
 }
-function success($msg) { write-host $msg -f darkgreen }
+function success($msg) { Write-Host $msg -f darkgreen }
 
 function filesize($length) {
     $gb = [math]::pow(2, 30)
     $mb = [math]::pow(2, 20)
     $kb = [math]::pow(2, 10)
 
-    if($length -gt $gb) {
+    if ($length -gt $gb) {
         "{0:n1} GB" -f ($length / $gb)
-    } elseif($length -gt $mb) {
+    } elseif ($length -gt $mb) {
         "{0:n1} MB" -f ($length / $mb)
-    } elseif($length -gt $kb) {
+    } elseif ($length -gt $kb) {
         "{0:n1} KB" -f ($length / $kb)
     } else {
         if ($null -eq $length) {
@@ -342,7 +342,7 @@ function filesize($length) {
 }
 
 # dirs
-function basedir($global) { if($global) { return $globaldir } $scoopdir }
+function basedir($global) { if ($global) { return $globaldir } $scoopdir }
 function appsdir($global) { "$(basedir $global)\apps" }
 function shimdir($global) { "$(basedir $global)\shims" }
 function modulesdir($global) { "$(basedir $global)\modules" }
@@ -438,14 +438,14 @@ function Get-AppFilePath {
     return $null
 }
 
-Function Test-CommandAvailable {
+function Test-CommandAvailable {
     param (
         [String]$Name
     )
-    Return [Boolean](Get-Command $Name -ErrorAction Ignore)
+    return [Boolean](Get-Command $Name -ErrorAction Ignore)
 }
 
-Function Test-GitAvailable {
+function Test-GitAvailable {
     return [Boolean](Get-HelperPath -Helper Git)
 }
 
@@ -480,9 +480,9 @@ function Get-HelperPath {
                 }
             }
             'Dark' {
-                $HelperPath = Get-AppFilePath 'wixtoolset' 'wix.exe'
+                $HelperPath = Get-AppFilePath 'dark' 'dark.exe'
                 if ([String]::IsNullOrEmpty($HelperPath)) {
-                    $HelperPath = Get-AppFilePath 'dark' 'dark.exe'
+                    $HelperPath = Get-AppFilePath 'wixtoolset' 'wix.exe'
                 }
             }
             'Aria2' { $HelperPath = Get-AppFilePath 'aria2' 'aria2c.exe' }
@@ -587,14 +587,14 @@ function app_status($app, $global) {
 }
 
 function appname_from_url($url) {
-    (split-path $url -leaf) -replace '.json$', ''
+    (Split-Path $url -Leaf) -replace '.json$', ''
 }
 
 # paths
-function fname($path) { split-path $path -leaf }
+function fname($path) { Split-Path $path -Leaf }
 function strip_ext($fname) { $fname -replace '\.[^\.]*$', '' }
 function strip_filename($path) { $path -replace [regex]::escape((fname $path)) }
-function strip_fragment($url) { $url -replace (new-object uri $url).fragment }
+function strip_fragment($url) { $url -replace (New-Object uri $url).fragment }
 function ensure($dir) {
     if (!(Test-Path -Path $dir)) {
         New-Item -Path $dir -ItemType Directory | Out-Null
@@ -724,7 +724,7 @@ function Invoke-ExternalCommand {
         # ref-1: https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.4#psnativecommandargumentpassing
         # ref-2: https://nsis.sourceforge.io/Docs/Chapter3.html
         $LegacyCommand = $FilePath -match '^((cmd|cscript|find|sqlcmd|wscript|msiexec)(\.exe)?|.*\.(bat|cmd|js|vbs|wsf))$' -or
-            ($ArgumentList -match '^/S$|^/D=[A-Z]:[\\/].*$').Length -eq 2
+        ($ArgumentList -match '^/S$|^/D=[A-Z]:[\\/].*$').Length -eq 2
         $SupportArgumentList = $Process.StartInfo.PSObject.Properties.Name -contains 'ArgumentList'
         if ((-not $LegacyCommand) -and $SupportArgumentList) {
             # ArgumentList is supported in PowerShell 6.1 and later (built on .NET Core 2.1+)
@@ -799,8 +799,7 @@ function isFileLocked([string]$path) {
             $stream.Close()
         }
         return $false
-    }
-    catch {
+    } catch {
         # file is locked by a process.
         return $true
     }
@@ -825,7 +824,7 @@ function movedir($from, $to) {
     $stdoutTask = $proc.StandardOutput.ReadToEndAsync()
     $proc.WaitForExit()
 
-    if($proc.ExitCode -ge 8) {
+    if ($proc.ExitCode -ge 8) {
         debug $stdoutTask.Result
         throw "Could not find '$(fname $from)'! (error $($proc.ExitCode))"
     }
@@ -914,7 +913,8 @@ function shim($path, $global, $name, $arg) {
         }
 
         $target_subsystem = Get-PESubsystem $resolved_path
-        if ($target_subsystem -eq 2) { # we only want to make shims GUI
+        if ($target_subsystem -eq 2) {
+            # we only want to make shims GUI
             Write-Output "Making $shim.exe a GUI binary."
             Set-PESubsystem "$shim.exe" $target_subsystem | Out-Null
         }
@@ -1127,30 +1127,30 @@ function Confirm-InstallationStatus {
 }
 
 function wraptext($text, $width) {
-    if(!$width) { $width = $host.ui.rawui.buffersize.width };
+    if (!$width) { $width = $host.ui.rawui.buffersize.width }
     $width -= 1 # be conservative: doesn't seem to print the last char
 
     $text -split '\r?\n' | ForEach-Object {
         $line = ''
         $_ -split ' ' | ForEach-Object {
-            if($line.length -eq 0) { $line = $_ }
-            elseif($line.length + $_.length + 1 -le $width) { $line += " $_" }
-            else { $lines += ,$line; $line = $_ }
+            if ($line.length -eq 0) { $line = $_ }
+            elseif ($line.length + $_.length + 1 -le $width) { $line += " $_" }
+            else { $lines += , $line; $line = $_ }
         }
-        $lines += ,$line
+        $lines += , $line
     }
 
     $lines -join "`n"
 }
 
 function pluralize($count, $singular, $plural) {
-    if($count -eq 1) { $singular } else { $plural }
+    if ($count -eq 1) { $singular } else { $plural }
 }
 
 # convert list of apps to list of ($app, $global) tuples
 function applist($apps, $global) {
-    if(!$apps) { return @() }
-    return ,@($apps | ForEach-Object { ,@($_, $global) })
+    if (!$apps) { return @() }
+    return , @($apps | ForEach-Object { , @($_, $global) })
 }
 
 function parse_app([string]$app) {
@@ -1162,10 +1162,10 @@ function parse_app([string]$app) {
 }
 
 function show_app($app, $bucket, $version) {
-    if($bucket) {
+    if ($bucket) {
         $app = "$bucket/$app"
     }
-    if($version) {
+    if ($version) {
         $app = "$app@$version"
     }
     return $app
@@ -1271,7 +1271,7 @@ $configHome = $env:XDG_CONFIG_HOME, "$env:USERPROFILE\.config" | Select-Object -
 $configFile = "$configHome\scoop\config.json"
 # Check if it's the expected install path for scoop: <root>/apps/scoop/current
 $coreRoot = Split-Path $PSScriptRoot
-$pathExpected = ($coreRoot -replace '\\','/') -like '*apps/scoop/current*'
+$pathExpected = ($coreRoot -replace '\\', '/') -like '*apps/scoop/current*'
 if ($pathExpected) {
     # Portable config is located in root directory:
     #    .\current\scoop\apps\<root>\config.json  <- a reversed path


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!-- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue for discussion with the maintainers,
  before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

#### Description

When user has both `dark` and `wixtoolset` installed, use `dark` to extract WiX executes.

Other changes are code styling.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Relates to https://github.com/ScoopInstaller/Main/issues/7841#issuecomment-4229723750

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I have ensured that I am targeting the `develop` branch.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have added an entry in the CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prioritized the application-specific Dark helper so the preferred extractor is tried before falling back to alternatives.

* **Style**
  * Normalized PowerShell syntax casing, spacing, and formatting across the codebase for consistency.

* **Documentation**
  * Added an Unreleased changelog entry noting the Dark helper priority change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->