### PR TITLE
fix(config): correct scoop_repo help URL

### DIFF
--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -33,7 +33,7 @@
 # no_junction: $true|$false
 #       The 'current' version alias will not be used. Shims and shortcuts will point to specific version instead.
 #
-# scoop_repo: http://github.com/ScoopInstaller/Scoop
+# scoop_repo: https://github.com/ScoopInstaller/Scoop
 #       Git repository containining scoop source code.
 #       This configuration is useful for custom forks.
 #


### PR DESCRIPTION
## Summary
- update the documented `scoop_repo` default URL in `scoop config --help`
- make the help text match the actual default config value

Closes #6633.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration help text to reflect HTTPS repository URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->