### PR TITLE
fix(sqlite): select latest search result semantically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - **checkver:** Remove redundant always-true condition in GitHub checkver logic ([#6571](https://github.com/ScoopInstaller/Scoop/issues/6571))
 - **core:** Give `dark` higher priority when use `Extract-DarkArchive` ([#6637](https://github.com/ScoopInstaller/Scoop/issues/6637))
 - **checkver:** Harden github checkver ([#6641](https://github.com/ScoopInstaller/Scoop/issues/6641))
+- **scoop-search:** Select latest search result semantically ([#6643](https://github.com/ScoopInstaller/Scoop/issues/6643))
 
 ### Code Refactoring
 

--- a/lib/database.ps1
+++ b/lib/database.ps1
@@ -21,7 +21,7 @@ function Get-LatestScoopDBRow {
     return $latest
 }
 
-function Select-LatestScoopDBRows {
+function Select-LatestScoopDBRow {
     param(
         [Parameter(Mandatory)]
         [System.Data.DataTable]
@@ -337,7 +337,7 @@ function Find-ScoopDBItem {
         $dbCommand.Dispose()
         $dbAdapter.Dispose()
         $db.Dispose()
-        return Select-LatestScoopDBRows -Table $result -GroupBy @('name', 'bucket')
+        return Select-LatestScoopDBRow -Table $result -GroupBy @('name', 'bucket')
     }
 }
 
@@ -404,7 +404,7 @@ function Get-ScoopDBItem {
             return $result
         }
 
-        return Select-LatestScoopDBRows -Table $result
+        return Select-LatestScoopDBRow -Table $result
     }
 }
 

--- a/lib/database.ps1
+++ b/lib/database.ps1
@@ -4,12 +4,23 @@ if (-not (Get-Command Compare-Version -ErrorAction Ignore)) {
     . "$PSScriptRoot\versions.ps1"
 }
 
+<#
+.SYNOPSIS
+    Get the latest row from a set of Scoop database rows.
+.DESCRIPTION
+    Compares the `version` property of each row semantically and returns the
+    latest row. Returns `$null` when no rows are provided.
+#>
 function Get-LatestScoopDBRow {
     param(
         [Parameter(Mandatory)]
         [object[]]
         $Rows
     )
+
+    if (-not $Rows -or $Rows.Count -eq 0) {
+        return $null
+    }
 
     $latest = $Rows[0]
     foreach ($row in ($Rows | Select-Object -Skip 1)) {

--- a/lib/database.ps1
+++ b/lib/database.ps1
@@ -1,5 +1,52 @@
 # Description: Functions for interacting with the Scoop database cache
 
+if (-not (Get-Command Compare-Version -ErrorAction Ignore)) {
+    . "$PSScriptRoot\versions.ps1"
+}
+
+function Get-LatestScoopDBRow {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]
+        $Rows
+    )
+
+    $latest = $Rows[0]
+    foreach ($row in ($Rows | Select-Object -Skip 1)) {
+        if ((Compare-Version -ReferenceVersion $latest.version -DifferenceVersion $row.version) -gt 0) {
+            $latest = $row
+        }
+    }
+
+    return $latest
+}
+
+function Select-LatestScoopDBRows {
+    param(
+        [Parameter(Mandatory)]
+        [System.Data.DataTable]
+        $Table,
+        [string[]]
+        $GroupBy
+    )
+
+    $latestRows = $Table.Clone()
+    $rows = @($Table.Rows)
+    if ($rows.Count -eq 0) {
+        return $latestRows
+    }
+
+    if ($GroupBy -and $GroupBy.Count -gt 0) {
+        foreach ($group in ($rows | Group-Object -Property $GroupBy)) {
+            $latestRows.ImportRow((Get-LatestScoopDBRow -Rows @($group.Group)))
+        }
+    } else {
+        $latestRows.ImportRow((Get-LatestScoopDBRow -Rows $rows))
+    }
+
+    return $latestRows
+}
+
 <#
 .SYNOPSIS
     Get SQLite .NET driver
@@ -277,7 +324,6 @@ function Find-ScoopDBItem {
         $dbAdapter = New-Object -TypeName System.Data.SQLite.SQLiteDataAdapter
         $result = New-Object System.Data.DataTable
         $dbQuery = "SELECT * FROM app WHERE $(($From -join ' LIKE @Pattern OR ') + ' LIKE @Pattern')"
-        $dbQuery = "SELECT * FROM ($($dbQuery + ' ORDER BY version DESC')) GROUP BY name, bucket"
         $dbCommand = $db.CreateCommand()
         $dbCommand.CommandText = $dbQuery
         $dbCommand.CommandType = [System.Data.CommandType]::Text
@@ -291,7 +337,7 @@ function Find-ScoopDBItem {
         $dbCommand.Dispose()
         $dbAdapter.Dispose()
         $db.Dispose()
-        return $result
+        return Select-LatestScoopDBRows -Table $result -GroupBy @('name', 'bucket')
     }
 }
 
@@ -336,8 +382,6 @@ function Get-ScoopDBItem {
         $dbQuery = 'SELECT * FROM app WHERE name = @Name AND bucket = @Bucket'
         if ($Version) {
             $dbQuery += ' AND version = @Version'
-        } else {
-            $dbQuery += ' ORDER BY version DESC LIMIT 1'
         }
         $dbCommand = $db.CreateCommand()
         $dbCommand.CommandText = $dbQuery
@@ -356,7 +400,11 @@ function Get-ScoopDBItem {
         $dbCommand.Dispose()
         $dbAdapter.Dispose()
         $db.Dispose()
-        return $result
+        if ($Version) {
+            return $result
+        }
+
+        return Select-LatestScoopDBRows -Table $result
     }
 }
 

--- a/lib/database.ps1
+++ b/lib/database.ps1
@@ -1,80 +1,5 @@
 # Description: Functions for interacting with the Scoop database cache
 
-if (-not (Get-Command Compare-Version -ErrorAction Ignore)) {
-    . "$PSScriptRoot\versions.ps1"
-}
-
-<#
-.SYNOPSIS
-    Get the latest row from a set of Scoop database rows.
-.DESCRIPTION
-    Compares the `version` property of each row semantically and returns the
-    latest row. Returns `$null` when no rows are provided.
-#>
-function Get-LatestScoopDBRow {
-    param(
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [object[]]
-        $Rows
-    )
-
-    if (-not $Rows -or $Rows.Count -eq 0) {
-        return $null
-    }
-
-    $latest = $Rows[0]
-    for ($i = 1; $i -lt $Rows.Count; $i++) {
-        $row = $Rows[$i]
-        if ((Compare-Version -ReferenceVersion $latest.version -DifferenceVersion $row.version) -gt 0) {
-            $latest = $row
-        }
-    }
-
-    return $latest
-}
-
-<#
-.SYNOPSIS
-    Return the semantically latest row or rows from a Scoop database result set.
-.DESCRIPTION
-    Clones the schema of `Table` and imports the latest row per group when
-    `GroupBy` is supplied, or the single latest row across the whole table when
-    it is omitted. Returns an empty cloned table when the source table has no rows.
-.PARAMETER Table
-    The source `System.Data.DataTable` returned from a Scoop database query.
-.PARAMETER GroupBy
-    Optional column names used to group rows before semantic latest-row selection.
-.OUTPUTS
-    System.Data.DataTable
-    A cloned table containing the latest matching row for each requested scope.
-#>
-function Select-LatestScoopDBRow {
-    param(
-        [Parameter(Mandatory)]
-        [System.Data.DataTable]
-        $Table,
-        [string[]]
-        $GroupBy
-    )
-
-    $latestRows = $Table.Clone()
-    $rows = @($Table.Rows)
-    if ($rows.Count -eq 0) {
-        return $latestRows
-    }
-
-    if ($GroupBy -and $GroupBy.Count -gt 0) {
-        foreach ($group in ($rows | Group-Object -Property $GroupBy)) {
-            $latestRows.ImportRow((Get-LatestScoopDBRow -Rows @($group.Group)))
-        }
-    } else {
-        $latestRows.ImportRow((Get-LatestScoopDBRow -Rows $rows))
-    }
-
-    return $latestRows
-}
-
 <#
 .SYNOPSIS
     Get SQLite .NET driver
@@ -436,6 +361,91 @@ function Get-ScoopDBItem {
 
         return Select-LatestScoopDBRow -Table $result
     }
+}
+
+<#
+.SYNOPSIS
+    Get the latest row from a set of Scoop database rows.
+.DESCRIPTION
+    Compares the `version` property of each row semantically and returns the
+    latest row. Returns `$null` when no rows are provided.
+.PARAMETER Rows
+    System.Object[]
+    The rows to evaluate for the latest version. Each row must have a `version` property.
+.INPUTS
+    System.Object[]
+.OUTPUTS
+    System.Object
+    The latest row based on semantic versioning, or `$null` if no rows are provided.
+#>
+function Get-LatestScoopDBRow {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]
+        $Rows
+    )
+
+    if (-not $Rows -or $Rows.Count -eq 0) {
+        return $null
+    }
+
+    if (-not (Get-Command Compare-Version -ErrorAction Ignore)) {
+        . "$PSScriptRoot\versions.ps1"
+    }
+
+    $latest = $Rows[0]
+    for ($i = 1; $i -lt $Rows.Count; $i++) {
+        $row = $Rows[$i]
+        if ((Compare-Version -ReferenceVersion $latest.version -DifferenceVersion $row.version) -gt 0) {
+            $latest = $row
+        }
+    }
+
+    return $latest
+}
+
+<#
+.SYNOPSIS
+    Return the semantically latest row or rows from a Scoop database result set.
+.DESCRIPTION
+    Clones the schema of `Table` and imports the latest row per group when
+    `GroupBy` is supplied, or the single latest row across the whole table when
+    it is omitted. Returns an empty cloned table when the source table has no rows.
+.PARAMETER Table
+    System.Data.DataTable
+    The source table returned from a Scoop database query.
+.PARAMETER GroupBy
+    System.String[]
+    Optional column names used to group rows before semantic latest-row selection.
+.OUTPUTS
+    System.Data.DataTable
+    A cloned table containing the latest matching row for each requested scope.
+#>
+function Select-LatestScoopDBRow {
+    param(
+        [Parameter(Mandatory)]
+        [System.Data.DataTable]
+        $Table,
+        [string[]]
+        $GroupBy
+    )
+
+    $latestRows = $Table.Clone()
+    $rows = @($Table.Rows)
+    if ($rows.Count -eq 0) {
+        return $latestRows
+    }
+
+    if ($GroupBy -and $GroupBy.Count -gt 0) {
+        foreach ($group in ($rows | Group-Object -Property $GroupBy)) {
+            $latestRows.ImportRow((Get-LatestScoopDBRow -Rows @($group.Group)))
+        }
+    } else {
+        $latestRows.ImportRow((Get-LatestScoopDBRow -Rows $rows))
+    }
+
+    return $latestRows
 }
 
 <#

--- a/lib/database.ps1
+++ b/lib/database.ps1
@@ -14,6 +14,7 @@ if (-not (Get-Command Compare-Version -ErrorAction Ignore)) {
 function Get-LatestScoopDBRow {
     param(
         [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
         [object[]]
         $Rows
     )
@@ -23,7 +24,8 @@ function Get-LatestScoopDBRow {
     }
 
     $latest = $Rows[0]
-    foreach ($row in ($Rows | Select-Object -Skip 1)) {
+    for ($i = 1; $i -lt $Rows.Count; $i++) {
+        $row = $Rows[$i]
         if ((Compare-Version -ReferenceVersion $latest.version -DifferenceVersion $row.version) -gt 0) {
             $latest = $row
         }
@@ -32,6 +34,21 @@ function Get-LatestScoopDBRow {
     return $latest
 }
 
+<#
+.SYNOPSIS
+    Return the semantically latest row or rows from a Scoop database result set.
+.DESCRIPTION
+    Clones the schema of `Table` and imports the latest row per group when
+    `GroupBy` is supplied, or the single latest row across the whole table when
+    it is omitted. Returns an empty cloned table when the source table has no rows.
+.PARAMETER Table
+    The source `System.Data.DataTable` returned from a Scoop database query.
+.PARAMETER GroupBy
+    Optional column names used to group rows before semantic latest-row selection.
+.OUTPUTS
+    System.Data.DataTable
+    A cloned table containing the latest matching row for each requested scope.
+#>
 function Select-LatestScoopDBRow {
     param(
         [Parameter(Mandatory)]
@@ -411,6 +428,8 @@ function Get-ScoopDBItem {
         $dbCommand.Dispose()
         $dbAdapter.Dispose()
         $db.Dispose()
+        # With $Version, the PRIMARY KEY guarantees at most one row; without it, the
+        # query is already limited to one name+bucket pair, so selecting latest needs no -GroupBy.
         if ($Version) {
             return $result
         }

--- a/test/Scoop-Database.Tests.ps1
+++ b/test/Scoop-Database.Tests.ps1
@@ -28,7 +28,7 @@ Describe 'database version selection' -Tag 'Scoop' {
         [void]$result.Rows.Add('zotero', '7.0.9', 'he0119', 'zotero')
         [void]$result.Rows.Add('zotero', '7.0.20', 'he0119', 'zotero')
 
-        $latest = @(Select-LatestScoopDBRows -Table $result -GroupBy @('name', 'bucket'))
+        $latest = @(Select-LatestScoopDBRow -Table $result -GroupBy @('name', 'bucket'))
 
         $latest.Count | Should -Be 3
         (@($latest | Where-Object { $_.name -eq 'copilot-cli' -and $_.bucket -eq 'main' })[0]).version | Should -Be '1.0.31'
@@ -45,7 +45,7 @@ Describe 'database version selection' -Tag 'Scoop' {
         [void]$result.Rows.Add('zotero', '7.0.9', 'extras', 'zotero')
         [void]$result.Rows.Add('zotero', '7.0.20', 'extras', 'zotero')
 
-        $latest = @(Select-LatestScoopDBRows -Table $result)
+        $latest = @(Select-LatestScoopDBRow -Table $result)
 
         $latest.Count | Should -Be 1
         $latest[0].version | Should -Be '7.0.20'

--- a/test/Scoop-Database.Tests.ps1
+++ b/test/Scoop-Database.Tests.ps1
@@ -1,0 +1,53 @@
+Describe 'database version selection' -Tag 'Scoop' {
+    BeforeAll {
+        . "$PSScriptRoot\Scoop-TestLib.ps1"
+        . "$PSScriptRoot\..\lib\core.ps1"
+        . "$PSScriptRoot\..\lib\versions.ps1"
+        . "$PSScriptRoot\..\lib\database.ps1"
+    }
+
+    It 'chooses the semantically latest row within one result set' {
+        $rows = @(
+            [pscustomobject]@{ version = '1.0.7' }
+            [pscustomobject]@{ version = '1.0.31' }
+        )
+
+        (Get-LatestScoopDBRow -Rows $rows).version | Should -Be '1.0.31'
+    }
+
+    It 'returns the latest semantic version per name and bucket' {
+        $result = New-Object System.Data.DataTable
+        [void]$result.Columns.Add('name', [string])
+        [void]$result.Columns.Add('version', [string])
+        [void]$result.Columns.Add('bucket', [string])
+        [void]$result.Columns.Add('binary', [string])
+        [void]$result.Rows.Add('copilot-cli', '1.0.7', 'main', 'copilot')
+        [void]$result.Rows.Add('copilot-cli', '1.0.31', 'main', 'copilot')
+        [void]$result.Rows.Add('zotero', '7.0.9', 'extras', 'zotero')
+        [void]$result.Rows.Add('zotero', '7.0.20', 'extras', 'zotero')
+        [void]$result.Rows.Add('zotero', '7.0.9', 'he0119', 'zotero')
+        [void]$result.Rows.Add('zotero', '7.0.20', 'he0119', 'zotero')
+
+        $latest = @(Select-LatestScoopDBRows -Table $result -GroupBy @('name', 'bucket'))
+
+        $latest.Count | Should -Be 3
+        (@($latest | Where-Object { $_.name -eq 'copilot-cli' -and $_.bucket -eq 'main' })[0]).version | Should -Be '1.0.31'
+        (@($latest | Where-Object { $_.name -eq 'zotero' -and $_.bucket -eq 'extras' })[0]).version | Should -Be '7.0.20'
+        (@($latest | Where-Object { $_.name -eq 'zotero' -and $_.bucket -eq 'he0119' })[0]).version | Should -Be '7.0.20'
+    }
+
+    It 'returns the latest semantic version when no grouping is requested' {
+        $result = New-Object System.Data.DataTable
+        [void]$result.Columns.Add('name', [string])
+        [void]$result.Columns.Add('version', [string])
+        [void]$result.Columns.Add('bucket', [string])
+        [void]$result.Columns.Add('binary', [string])
+        [void]$result.Rows.Add('zotero', '7.0.9', 'extras', 'zotero')
+        [void]$result.Rows.Add('zotero', '7.0.20', 'extras', 'zotero')
+
+        $latest = @(Select-LatestScoopDBRows -Table $result)
+
+        $latest.Count | Should -Be 1
+        $latest[0].version | Should -Be '7.0.20'
+    }
+}

--- a/test/Scoop-Database.Tests.ps1
+++ b/test/Scoop-Database.Tests.ps1
@@ -15,6 +15,10 @@ Describe 'database version selection' -Tag 'Scoop' {
         (Get-LatestScoopDBRow -Rows $rows).version | Should -Be '1.0.31'
     }
 
+    It 'returns null when no rows are provided' {
+        Get-LatestScoopDBRow -Rows @() | Should -Be $null
+    }
+
     It 'returns the latest semantic version per name and bucket' {
         $result = New-Object System.Data.DataTable
         [void]$result.Columns.Add('name', [string])


### PR DESCRIPTION
## Summary
- keep SQLite as the fast search filter, but stop using lexicographic SQL ordering for version selection
- pick the latest matching version in PowerShell with `Compare-Version`
- add regression coverage for semantic version selection in cached search results

## Why
SQLite stores cached manifest versions as plain text, so `ORDER BY version DESC` can prefer `1.0.7` over `1.0.31` and `7.0.9` over `7.0.20` when `use_sqlite_cache` is enabled.

This keeps the cache fast for filtering, while moving the final "which version is latest" decision back to Scoop's existing semantic version logic.

Closes #6419.
Addresses #6639.

## Verification
- manually verified `Select-LatestScoopDBRows` returns `1.0.31` over `1.0.7`
- manually verified it returns `7.0.20` over `7.0.9`
- added focused regression tests in `test/Scoop-Database.Tests.ps1`
- local CI-style Pester run was not fully available here because the repo test script requires modules missing in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic latest-version selection so package queries consistently return the correct newest semantic version per package and per package+source, increasing package resolution accuracy.

* **Tests**
  * Added automated tests that validate semantic-version selection in grouped (per package+source) and global scenarios to ensure a single correct latest version is chosen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->